### PR TITLE
remove field only valid for pod from container securityContext

### DIFF
--- a/templates/server-statefulset.yaml
+++ b/templates/server-statefulset.yaml
@@ -45,7 +45,6 @@ spec:
         - name: vault
           {{ template "vault.resources" . }}
           securityContext:
-            fsGroup: {{ template "vault.fsgroup" . }}
             privileged: true
           image: "{{ .Values.global.image }}"
           command: {{ template "vault.command" . }}


### PR DESCRIPTION
Addresses:

```bash
error:
 error validating "STDIN":
  error validating data:
   ValidationError(StatefulSet.spec.template.spec.containers[0].securityContext):
    unknown field "fsGroup" in io.k8s.api.core.v1.SecurityContext;
    if you choose to ignore these errors, turn validation off with --validate=false
```