### PR TITLE
Add AWS credential environment variable

### DIFF
--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -143,6 +143,13 @@ Set's additional environment variables based on the mode.
             - name: VAULT_DEV_ROOT_TOKEN_ID
               value: "root"
   {{ end }}
+  {{ if .Values.server.aws.secretName }}
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.server.aws.secretName }}
+                  key: {{ .Values.server.aws.secretKey }}
+  {{ end }}
 {{- end -}}
 
 {{/*

--- a/test/unit/server-ha-statefulset.bats
+++ b/test/unit/server-ha-statefulset.bats
@@ -258,6 +258,28 @@ load _helpers
 }
 
 #--------------------------------------------------------------------
+# aws
+
+@test "server/ha-StatefulSet: set aws" {
+  cd `chart_dir`
+  local object=$(helm template \
+      -x templates/server-statefulset.yaml  \
+      --set 'server.aws.secretName=foo-name' \
+      --set 'server.aws.secretKey=bar-key' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.containers[0].env' | tee /dev/stderr)
+
+
+  local actual=$(echo $object |
+      yq -r '.[4].valueFrom.secretKeyRef.name' | tee /dev/stderr)
+  [ "${actual}" = "foo-name" ]
+
+  local actual=$(echo $object |
+      yq -r '.[4].valueFrom.secretKeyRef.key' | tee /dev/stderr)
+  [ "${actual}" = "bar-key" ]
+}
+
+#--------------------------------------------------------------------
 # storage class
 
 @test "server/ha-StatefulSet: no storage by default" {

--- a/values.yaml
+++ b/values.yaml
@@ -28,6 +28,12 @@ server:
     # GOOGLE_PROJECT: myproject,
     # GOOGLE_CREDENTIALS: /vault/userconfig/myproject/myproject-creds.json
 
+  # AWS credentials. Provide the name and key of a Kubernetes secret that contains
+  # AWS_SECRET_ACCESS_KEY. Provide `AWS_ACCESS_KEY_ID` and `AWS_REGION` in `extraEnvironmentVars`.
+  aws:
+    secretName: null
+    secretKey: null
+
   # extraVolumes is a list of extra volumes to mount. These will be exposed
   # to Vault in the path `/vault/userconfig/<name>/`. The value below is
   # an array of objects, examples are shown below.


### PR DESCRIPTION
This PR allows user to add AWS credential via environment variable with a Kubernetes Secret object:

```yaml
# values
server:
  aws:
    secretName: vault
    secretKey: AWS_SECRET_ACCESS_KEY
  extraEnvironmentVars:
    AWS_REGION: eu-west-1
    AWS_ACCESS_KEY_ID: xxx
```

Secret object:
```yaml
apiVersion: v1
kind: Secret
metadata:
  name: vault
type: Opaque
stringData:
  AWS_SECRET_ACCESS_KEY: xxx
```
