### PR TITLE
Only include clusterIp on vault service if set in values

### DIFF
--- a/templates/server-service.yaml
+++ b/templates/server-service.yaml
@@ -16,7 +16,9 @@ metadata:
     # https://github.com/kubernetes/kubernetes/issues/58662
     service.alpha.kubernetes.io/tolerate-unready-endpoints: "true"
 spec:
+  {{- if .Values.server.service.clusterIP }}
   clusterIP: {{ .Values.server.service.clusterIP }}
+  {{- end }}
   # We want the servers to become available even if they're not ready
   # since this DNS is also used for join operations.
   publishNotReadyAddresses: true

--- a/values.yaml
+++ b/values.yaml
@@ -81,7 +81,7 @@ server:
     # Kubernetes will create a "headless" service.  Headless services can be 
     # used to communicate with pods directly through DNS instead of a round robin
     # load balancer.
-    clusterIP: ""
+    # clusterIP: None
 
   # This configures the Vault Statefulset to create a PVC for data 
   # storage when using the file backend.


### PR DESCRIPTION
Prevents error if the field is set to empty and then remove on an upgrade.

reference : https://github.com/hashicorp/vault-helm/pull/10