### PR TITLE
Add secret env vars and custom mounting path

### DIFF
--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -103,7 +103,7 @@ extra volumes the user may have specified (such as a secret with TLS).
          {{- if (eq .type "configMap") }}
            name: {{ .name }}
          {{- else if (eq .type "secret") }}
-          secretName: {{ .name }}
+           secretName: {{ .name }}
          {{- end }}
   {{- end }}
 {{- end -}}
@@ -167,7 +167,7 @@ based on the mode configured.
   {{- range .Values.server.extraVolumes }}
             - name: userconfig-{{ .name }}
               readOnly: true
-              mountPath: /vault/userconfig/{{ .name }}
+              mountPath: {{ .path | default "/vault/userconfig" }}/{{ .name }}
   {{- end }}
 {{- end -}}
 

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -270,3 +270,18 @@ Inject extra environment vars in the format key:value, if populated
 {{- end -}}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Inject extra environment populated by secrets, if populated
+*/}}
+{{- define "vault.extraSecretEnvironmentVars" -}}
+{{- if .extraSecretEnvironmentVars -}}
+{{- range .extraSecretEnvironmentVars }}
+- name: {{ .envName }}
+  valueFrom:
+   secretKeyRef:
+     name: {{ .secretName }}
+     key: {{ .secretKey }}
+{{- end -}}
+{{- end -}}
+{{- end -}}

--- a/templates/server-statefulset.yaml
+++ b/templates/server-statefulset.yaml
@@ -64,6 +64,7 @@ spec:
               value: "true"
             {{ template "vault.envs" . }}
             {{- include "vault.extraEnvironmentVars" .Values.server | nindent 12 }}
+            {{- include "vault.extraSecretEnvironmentVars" .Values.server | nindent 12 }}
           volumeMounts:
           {{ template "vault.mounts" . }}
           lifecycle:

--- a/test/unit/server-dev-statefulset.bats
+++ b/test/unit/server-dev-statefulset.bats
@@ -241,6 +241,43 @@ load _helpers
 }
 
 #--------------------------------------------------------------------
+# extraSecretEnvironmentVars
+
+@test "server/dev-StatefulSet: set extraSecretEnvironmentVars" {
+  cd `chart_dir`
+  local object=$(helm template \
+      -x templates/server-statefulset.yaml  \
+      --set 'server.extraSecretEnvironmentVars[0].envName=ENV_FOO_0' \
+      --set 'server.extraSecretEnvironmentVars[0].secretName=secret_name_0' \
+      --set 'server.extraSecretEnvironmentVars[0].secretKey=secret_key_0' \
+      --set 'server.extraSecretEnvironmentVars[1].envName=ENV_FOO_1' \
+      --set 'server.extraSecretEnvironmentVars[1].secretName=secret_name_1' \
+      --set 'server.extraSecretEnvironmentVars[1].secretKey=secret_key_1' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.containers[0].env' | tee /dev/stderr)
+
+  local actual=$(echo $object |
+      yq -r '.[4].name' | tee /dev/stderr)
+  [ "${actual}" = "ENV_FOO_0" ]
+  local actual=$(echo $object |
+      yq -r '.[4].valueFrom.secretKeyRef.name' | tee /dev/stderr)
+  [ "${actual}" = "secret_name_0" ]
+  local actual=$(echo $object |
+      yq -r '.[4].valueFrom.secretKeyRef.key' | tee /dev/stderr)
+  [ "${actual}" = "secret_key_0" ]
+
+  local actual=$(echo $object |
+      yq -r '.[5].name' | tee /dev/stderr)
+  [ "${actual}" = "ENV_FOO_1" ]
+  local actual=$(echo $object |
+      yq -r '.[5].valueFrom.secretKeyRef.name' | tee /dev/stderr)
+  [ "${actual}" = "secret_name_1" ]
+  local actual=$(echo $object |
+      yq -r '.[5].valueFrom.secretKeyRef.key' | tee /dev/stderr)
+  [ "${actual}" = "secret_key_1" ]
+}
+
+#--------------------------------------------------------------------
 # storage class
 
 @test "server/dev-StatefulSet: can't set storageClass" {

--- a/test/unit/server-ha-statefulset.bats
+++ b/test/unit/server-ha-statefulset.bats
@@ -189,6 +189,49 @@ load _helpers
   [ "${actual}" = "/vault/userconfig/foo" ]
 }
 
+@test "server/ha-StatefulSet: adds extra volume custom mount path" {
+  cd `chart_dir`
+  # Test that it mounts it
+  local object=$(helm template \
+      -x templates/server-statefulset.yaml  \
+      --set 'server.ha.enabled=true' \
+      --set 'server.extraVolumes[0].type=configMap' \
+      --set 'server.extraVolumes[0].name=foo' \
+      --set 'server.extraVolumes[0].path=/custom/path' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.containers[0].volumeMounts[] | select(.name == "userconfig-foo")' | tee /dev/stderr)
+
+  local actual=$(echo $object |
+      yq -r '.readOnly' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+
+  local actual=$(echo $object |
+      yq -r '.mountPath' | tee /dev/stderr)
+  [ "${actual}" = "/custom/path/foo" ]
+}
+
+@test "server/ha-StatefulSet: adds extra secret volume custom mount path" {
+  cd `chart_dir`
+
+  # Test that it mounts it
+  local object=$(helm template \
+      -x templates/server-statefulset.yaml  \
+      --set 'server.ha.enabled=true' \
+      --set 'server.extraVolumes[0].type=configMap' \
+      --set 'server.extraVolumes[0].name=foo' \
+      --set 'server.extraVolumes[0].path=/custom/path' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.containers[0].volumeMounts[] | select(.name == "userconfig-foo")' | tee /dev/stderr)
+
+  local actual=$(echo $object |
+      yq -r '.readOnly' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+
+  local actual=$(echo $object |
+      yq -r '.mountPath' | tee /dev/stderr)
+  [ "${actual}" = "/custom/path/foo" ]
+}
+
 @test "server/ha-StatefulSet: adds extra secret volume" {
   cd `chart_dir`
 

--- a/values.yaml
+++ b/values.yaml
@@ -27,12 +27,19 @@ server:
   authDelegator:
     enabled: false
 
-  # extraEnvVars is a list of extra enviroment variables to set with the stateful set. These could be
+  # extraEnvironmentVars is a list of extra enviroment variables to set with the stateful set. These could be
   # used to include variables required for auto-unseal.
   extraEnvironmentVars: {}
     # GOOGLE_REGION: global,
     # GOOGLE_PROJECT: myproject,
     # GOOGLE_CREDENTIALS: /vault/userconfig/myproject/myproject-creds.json
+
+  # extraSecretEnvironmentVars is a list of extra enviroment variables to set with the stateful set.
+  # These variables take value from existing Secret objects.
+  extraSecretEnvironmentVars: []
+    # - envName: AWS_SECRET_ACCESS_KEY
+    #   secretName: vault
+    #   secretKey: AWS_SECRET_ACCESS_KEY
 
   # extraVolumes is a list of extra volumes to mount. These will be exposed
   # to Vault in the path `/vault/userconfig/<name>/`. The value below is

--- a/values.yaml
+++ b/values.yaml
@@ -48,6 +48,7 @@ server:
     # - type: secret (or "configMap")
     #   name: my-secret
     #   load: false # if true, will add to `-config` to load by Vault
+    #   path: null # default is `/vault/userconfig`
 
   # Affinity Settings
   # Commenting out or setting as empty the affinity variable, will allow


### PR DESCRIPTION
From discussion and @jasonodonnell 's suggestion in https://github.com/hashicorp/vault-helm/pull/11
This PR allows user to:
- Add env vars from existing Secret objects
- Choose a different mounting path for `extraVolumes` 