### PR TITLE
Add TLS support 

### DIFF
--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -103,7 +103,7 @@ extra volumes the user may have specified (such as a secret with TLS).
          {{- if (eq .type "configMap") }}
            name: {{ .name }}
          {{- else if (eq .type "secret") }}
-          secretName: {{ .name }}
+           secretName: {{ .name }}
          {{- end }}
   {{- end }}
 {{- end -}}
@@ -167,7 +167,7 @@ based on the mode configured.
   {{- range .Values.server.extraVolumes }}
             - name: userconfig-{{ .name }}
               readOnly: true
-              mountPath: /vault/userconfig/{{ .name }}
+              mountPath: {{ .path | default "/vault/userconfig" }}/{{ .name }}
   {{- end }}
 {{- end -}}
 

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -270,3 +270,18 @@ Inject extra environment vars in the format key:value, if populated
 {{- end -}}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Inject extra environment populated by secrets, if populated
+*/}}
+{{- define "vault.extraSecretEnvironmentVars" -}}
+{{- if .extraSecretEnvironmentVars -}}
+{{- range .extraSecretEnvironmentVars }}
+- name: {{ .envName }}
+  valueFrom:
+   secretKeyRef:
+     name: {{ .secretName }}
+     key: {{ .secretKey }}
+{{- end -}}
+{{- end -}}
+{{- end -}}

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -285,3 +285,12 @@ Inject extra environment populated by secrets, if populated
 {{- end -}}
 {{- end -}}
 {{- end -}}
+
+{{/* Scheme for health check and local endpoint */}}
+{{- define "vault.scheme" -}}
+{{- if .Values.global.tls_disable -}}
+{{ "http" }}
+{{- else -}}
+{{ "https" }}
+{{- end -}}
+{{- end -}}

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -299,7 +299,7 @@ Inject extra environment populated by secrets, if populated
 
 {{/* Scheme for health check and local endpoint */}}
 {{- define "vault.scheme" -}}
-{{- if .Values.global.tls_disable -}}
+{{- if .Values.global.tlsDisable -}}
 {{ "http" }}
 {{- else -}}
 {{ "https" }}

--- a/templates/server-statefulset.yaml
+++ b/templates/server-statefulset.yaml
@@ -59,7 +59,7 @@ spec:
                 fieldRef:
                   fieldPath: status.podIP
             - name: VAULT_ADDR
-              value: "http://localhost:8200"
+              value: "{{ include "vault.scheme" . }}://127.0.0.1:8200"
             - name: SKIP_CHOWN
               value: "true"
             {{ template "vault.envs" . }}
@@ -85,7 +85,7 @@ spec:
             #   1 - error
             #   2 - sealed
             exec:
-              command: ["/bin/sh", "-ec", "vault status"]
+              command: ["/bin/sh", "-ec", "vault status -tls-skip-verify"]
             failureThreshold: 2
             initialDelaySeconds: 5
             periodSeconds: 3

--- a/templates/server-statefulset.yaml
+++ b/templates/server-statefulset.yaml
@@ -64,6 +64,7 @@ spec:
               value: "true"
             {{ template "vault.envs" . }}
             {{- include "vault.extraEnvironmentVars" .Values.server | nindent 12 }}
+            {{- include "vault.extraSecretEnvironmentVars" .Values.server | nindent 12 }}
           volumeMounts:
           {{ template "vault.mounts" . }}
           lifecycle:

--- a/templates/ui-service.yaml
+++ b/templates/ui-service.yaml
@@ -26,14 +26,8 @@ spec:
     - name: http
       port: 8200
       targetPort: 8200
-      {{- if .Values.ui.serviceNodePortHttp }}
-      nodePort: {{ .Values.ui.serviceNodePortHttp }}
-      {{- end }}
-    - name: https
-      port: 443
-      targetPort: 8200
-      {{- if .Values.ui.serviceNodePortHttps }}
-      nodePort: {{ .Values.ui.serviceNodePortHttps }}
+      {{- if .Values.ui.serviceNodePort }}
+      nodePort: {{ .Values.ui.serviceNodePort }}
       {{- end }}
   type: {{ .Values.ui.serviceType | default "ClusterIP" }}
 {{- end -}}

--- a/templates/ui-service.yaml
+++ b/templates/ui-service.yaml
@@ -23,5 +23,14 @@ spec:
     - name: http
       port: 80
       targetPort: 8200
+      {{- if .Values.ui.serviceNodePortHttp }}
+      nodePort: {{ .Values.ui.serviceNodePortHttp }}
+      {{- end }}
+    - name: https
+      port: 443
+      targetPort: 8200
+      {{- if .Values.ui.serviceNodePortHttps }}
+      nodePort: {{ .Values.ui.serviceNodePortHttps }}
+      {{- end }}
   type: {{ .Values.ui.serviceType | default "ClusterIP" }}
 {{- end -}}

--- a/test/unit/server-dev-statefulset.bats
+++ b/test/unit/server-dev-statefulset.bats
@@ -241,6 +241,43 @@ load _helpers
 }
 
 #--------------------------------------------------------------------
+# extraSecretEnvironmentVars
+
+@test "server/dev-StatefulSet: set extraSecretEnvironmentVars" {
+  cd `chart_dir`
+  local object=$(helm template \
+      -x templates/server-statefulset.yaml  \
+      --set 'server.extraSecretEnvironmentVars[0].envName=ENV_FOO_0' \
+      --set 'server.extraSecretEnvironmentVars[0].secretName=secret_name_0' \
+      --set 'server.extraSecretEnvironmentVars[0].secretKey=secret_key_0' \
+      --set 'server.extraSecretEnvironmentVars[1].envName=ENV_FOO_1' \
+      --set 'server.extraSecretEnvironmentVars[1].secretName=secret_name_1' \
+      --set 'server.extraSecretEnvironmentVars[1].secretKey=secret_key_1' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.containers[0].env' | tee /dev/stderr)
+
+  local actual=$(echo $object |
+      yq -r '.[4].name' | tee /dev/stderr)
+  [ "${actual}" = "ENV_FOO_0" ]
+  local actual=$(echo $object |
+      yq -r '.[4].valueFrom.secretKeyRef.name' | tee /dev/stderr)
+  [ "${actual}" = "secret_name_0" ]
+  local actual=$(echo $object |
+      yq -r '.[4].valueFrom.secretKeyRef.key' | tee /dev/stderr)
+  [ "${actual}" = "secret_key_0" ]
+
+  local actual=$(echo $object |
+      yq -r '.[5].name' | tee /dev/stderr)
+  [ "${actual}" = "ENV_FOO_1" ]
+  local actual=$(echo $object |
+      yq -r '.[5].valueFrom.secretKeyRef.name' | tee /dev/stderr)
+  [ "${actual}" = "secret_name_1" ]
+  local actual=$(echo $object |
+      yq -r '.[5].valueFrom.secretKeyRef.key' | tee /dev/stderr)
+  [ "${actual}" = "secret_key_1" ]
+}
+
+#--------------------------------------------------------------------
 # storage class
 
 @test "server/dev-StatefulSet: can't set storageClass" {

--- a/test/unit/server-ha-statefulset.bats
+++ b/test/unit/server-ha-statefulset.bats
@@ -189,6 +189,49 @@ load _helpers
   [ "${actual}" = "/vault/userconfig/foo" ]
 }
 
+@test "server/ha-StatefulSet: adds extra volume custom mount path" {
+  cd `chart_dir`
+  # Test that it mounts it
+  local object=$(helm template \
+      -x templates/server-statefulset.yaml  \
+      --set 'server.ha.enabled=true' \
+      --set 'server.extraVolumes[0].type=configMap' \
+      --set 'server.extraVolumes[0].name=foo' \
+      --set 'server.extraVolumes[0].path=/custom/path' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.containers[0].volumeMounts[] | select(.name == "userconfig-foo")' | tee /dev/stderr)
+
+  local actual=$(echo $object |
+      yq -r '.readOnly' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+
+  local actual=$(echo $object |
+      yq -r '.mountPath' | tee /dev/stderr)
+  [ "${actual}" = "/custom/path/foo" ]
+}
+
+@test "server/ha-StatefulSet: adds extra secret volume custom mount path" {
+  cd `chart_dir`
+
+  # Test that it mounts it
+  local object=$(helm template \
+      -x templates/server-statefulset.yaml  \
+      --set 'server.ha.enabled=true' \
+      --set 'server.extraVolumes[0].type=configMap' \
+      --set 'server.extraVolumes[0].name=foo' \
+      --set 'server.extraVolumes[0].path=/custom/path' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.containers[0].volumeMounts[] | select(.name == "userconfig-foo")' | tee /dev/stderr)
+
+  local actual=$(echo $object |
+      yq -r '.readOnly' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+
+  local actual=$(echo $object |
+      yq -r '.mountPath' | tee /dev/stderr)
+  [ "${actual}" = "/custom/path/foo" ]
+}
+
 @test "server/ha-StatefulSet: adds extra secret volume" {
   cd `chart_dir`
 

--- a/test/unit/server-ha-statefulset.bats
+++ b/test/unit/server-ha-statefulset.bats
@@ -42,6 +42,42 @@ load _helpers
 }
 
 #--------------------------------------------------------------------
+# TLS
+
+@test "server/ha-StatefulSet: tls disabled" {
+  cd `chart_dir`
+  local object=$(helm template \
+      -x templates/server-statefulset.yaml  \
+      --set 'global.tls_disable=true' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.containers[0].env' | tee /dev/stderr)
+
+  local actual=$(echo $object |
+     yq -r '.[2].name' | tee /dev/stderr)
+  [ "${actual}" = "VAULT_ADDR" ]
+
+  local actual=$(echo $object |
+     yq -r '.[2].value' | tee /dev/stderr)
+  [ "${actual}" = "http://127.0.0.1:8200" ]
+}
+@test "server/ha-StatefulSet: tls enabled" {
+  cd `chart_dir`
+  local object=$(helm template \
+      -x templates/server-statefulset.yaml  \
+      --set 'global.tls_disable=false' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.containers[0].env' | tee /dev/stderr)
+
+  local actual=$(echo $object |
+     yq -r '.[2].name' | tee /dev/stderr)
+  [ "${actual}" = "VAULT_ADDR" ]
+
+  local actual=$(echo $object |
+     yq -r '.[2].value' | tee /dev/stderr)
+  [ "${actual}" = "https://127.0.0.1:8200" ]
+}
+
+#--------------------------------------------------------------------
 # updateStrategy
 
 @test "server/ha-StatefulSet: OnDelete updateStrategy" {

--- a/test/unit/server-ha-statefulset.bats
+++ b/test/unit/server-ha-statefulset.bats
@@ -48,7 +48,7 @@ load _helpers
   cd `chart_dir`
   local object=$(helm template \
       -x templates/server-statefulset.yaml  \
-      --set 'global.tls_disable=true' \
+      --set 'global.tlsDisable=true' \
       . | tee /dev/stderr |
       yq -r '.spec.template.spec.containers[0].env' | tee /dev/stderr)
 
@@ -64,7 +64,7 @@ load _helpers
   cd `chart_dir`
   local object=$(helm template \
       -x templates/server-statefulset.yaml  \
-      --set 'global.tls_disable=false' \
+      --set 'global.tlsDisable=false' \
       . | tee /dev/stderr |
       yq -r '.spec.template.spec.containers[0].env' | tee /dev/stderr)
 

--- a/values.yaml
+++ b/values.yaml
@@ -27,12 +27,19 @@ server:
   authDelegator:
     enabled: false
 
-  # extraEnvVars is a list of extra enviroment variables to set with the stateful set. These could be
+  # extraEnvironmentVars is a list of extra enviroment variables to set with the stateful set. These could be
   # used to include variables required for auto-unseal.
   extraEnvironmentVars: {}
     # GOOGLE_REGION: global,
     # GOOGLE_PROJECT: myproject,
     # GOOGLE_CREDENTIALS: /vault/userconfig/myproject/myproject-creds.json
+
+  # extraSecretEnvironmentVars is a list of extra enviroment variables to set with the stateful set.
+  # These variables take value from existing Secret objects.
+  extraSecretEnvironmentVars: []
+    # - envName: AWS_SECRET_ACCESS_KEY
+    #   secretName: vault
+    #   secretKey: AWS_SECRET_ACCESS_KEY
 
   # extraVolumes is a list of extra volumes to mount. These will be exposed
   # to Vault in the path `/vault/userconfig/<name>/`. The value below is

--- a/values.yaml
+++ b/values.yaml
@@ -8,7 +8,7 @@ global:
   # Image is the name (and tag) of the Vault Docker image.
   image: "vault:1.2.1"
   # TLS for end-to-end encrypted transport
-  tls_disable: false
+  tls_disable: true
 
 server:
   # Resource requests, limits, etc. for the server cluster placement. This

--- a/values.yaml
+++ b/values.yaml
@@ -8,7 +8,7 @@ global:
   # Image is the name (and tag) of the Vault Docker image.
   image: "vault:1.2.1"
   # TLS for end-to-end encrypted transport
-  tls_disable: true
+  tlsDisable: true
 
 server:
   # Resource requests, limits, etc. for the server cluster placement. This

--- a/values.yaml
+++ b/values.yaml
@@ -48,6 +48,7 @@ server:
     # - type: secret (or "configMap")
     #   name: my-secret
     #   load: false # if true, will add to `-config` to load by Vault
+    #   path: null # default is `/vault/userconfig`
 
   # Affinity Settings
   # Commenting out or setting as empty the affinity variable, will allow

--- a/values.yaml
+++ b/values.yaml
@@ -7,6 +7,8 @@ global:
 
   # Image is the name (and tag) of the Vault Docker image.
   image: "vault:1.2.1"
+  # TLS for end-to-end encrypted transport
+  tls_disable: false
 
 server:
   # Resource requests, limits, etc. for the server cluster placement. This
@@ -212,3 +214,5 @@ ui:
   # balancer (for supported K8S installations) to access the UI.
   enabled: false
   serviceType: "ClusterIP"
+  serviceNodePortHttp: null
+  serviceNodePortHttps: null


### PR DESCRIPTION
- Add TLS support for health check: with TLS enabled, health check also need to use `https` scheme
- Add custom NodePort: in the situation of using NodePort type for Service, user should be able to define selected NodePort