### PR TITLE
Update ui-service.yaml

### DIFF
--- a/templates/ui-service.yaml
+++ b/templates/ui-service.yaml
@@ -21,7 +21,7 @@ spec:
     component: server
   ports:
     - name: http
-      port: 80
+      port: 8200
       targetPort: 8200
   type: {{ .Values.ui.serviceType | default "ClusterIP" }}
 {{- end -}}


### PR DESCRIPTION
port 80 doesn't work in case of https. So the default behavior in all of our docs is to use <vault-ip>:8200