### PR TITLE
Address K8s Deprecation of Kubelet security controls. Remove Whitespaces.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,12 @@
 
 Features:
 
-* Added `authDelegator` Cluster Role Binding to Vault service account for 
+* Added `authDelegator` Cluster Role Binding to Vault service account for
   bootstrapping Kube auth method
 
 Improvements:
 
-* Added `server.service.clusterIP` to `values.yml` so users can toggle 
+* Added `server.service.clusterIP` to `values.yml` so users can toggle
   the Vault service to headless by using the value `None`.
 * Upgraded Vault to 1.2.1
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,7 @@ disclose by contacting us at security@hashicorp.com.
 issue or pull request anyways. You won't be yelled at for giving it your best
 effort. The worst that can happen is that you'll be politely asked to change
 something. We appreciate any sort of contributions, and don't want a wall of
-rules to get in the way of that. 
+rules to get in the way of that.
 
 That said, if you want to ensure that a pull request is likely to be merged,
 talk to us! You can find out our thoughts and ensure that your contribution
@@ -29,7 +29,7 @@ quickly merge or address your contributions.
   against `master`, as bugs are fixed regularly but new versions are only
   released every few months.
 
-* Provide steps to reproduce the issue, and if possible include the expected 
+* Provide steps to reproduce the issue, and if possible include the expected
   results as well as the actual results. Please provide text, not screen shots!
 
 * Respond as promptly as possible to any questions made by the Vault

--- a/templates/NOTES.txt
+++ b/templates/NOTES.txt
@@ -1,8 +1,8 @@
 
 Thank you for installing HashiCorp Vault!
 
-Now that you have deployed Vault, you should look over the docs on using 
-Vault with Kubernetes available here: 
+Now that you have deployed Vault, you should look over the docs on using
+Vault with Kubernetes available here:
 
 https://www.vaultproject.io/docs/
 

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -47,7 +47,7 @@ Add a special case for replicas=1, where it should default to 0 as well.
 {{- end -}}
 
 {{/*
-Set the variable 'mode' to the server mode requested by the user to simplify 
+Set the variable 'mode' to the server mode requested by the user to simplify
 template logic.
 */}}
 {{- define "vault.mode" -}}
@@ -76,8 +76,8 @@ Set's the replica count based on the different modes configured by user
 {{- end -}}
 
 {{/*
-Set's fsGroup based on different modes.  Standalone is the only mode 
-that requires fsGroup at this time because it uses PVC for the file 
+Set's fsGroup based on different modes.  Standalone is the only mode
+that requires fsGroup at this time because it uses PVC for the file
 storage backend.
 */}}
 {{- define "vault.fsgroup" -}}
@@ -87,8 +87,8 @@ storage backend.
 {{- end -}}
 
 {{/*
-Set's up configmap mounts if this isn't a dev deployment and the user 
-defined a custom configuration.  Additionally iterates over any 
+Set's up configmap mounts if this isn't a dev deployment and the user
+defined a custom configuration.  Additionally iterates over any
 extra volumes the user may have specified (such as a secret with TLS).
 */}}
 {{- define "vault.volumes" -}}
@@ -109,8 +109,8 @@ extra volumes the user may have specified (such as a secret with TLS).
 {{- end -}}
 
 {{/*
-Set's a command to override the entrypoint defined in the image 
-so we can make the user experience nicer.  This works in with 
+Set's a command to override the entrypoint defined in the image
+so we can make the user experience nicer.  This works in with
 "vault.args" to specify what commands /bin/sh should run.
 */}}
 {{- define "vault.command" -}}
@@ -121,14 +121,14 @@ so we can make the user experience nicer.  This works in with
 {{- end -}}
 
 {{/*
-Set's the args for custom command to render the Vault configuration 
-file with IP addresses to make the out of box experience easier 
+Set's the args for custom command to render the Vault configuration
+file with IP addresses to make the out of box experience easier
 for users looking to use this chart with Consul Helm.
 */}}
 {{- define "vault.args" -}}
   {{ if or (eq .mode "standalone") (eq .mode "ha") }}
           - |
-            sed -E "s/HOST_IP/${HOST_IP?}/g" /vault/config/extraconfig-from-values.hcl > /tmp/storageconfig.hcl; 
+            sed -E "s/HOST_IP/${HOST_IP?}/g" /vault/config/extraconfig-from-values.hcl > /tmp/storageconfig.hcl;
             sed -Ei "s/POD_IP/${POD_IP?}/g" /tmp/storageconfig.hcl;
             chown vault:vault /tmp/storageconfig.hcl;
             /usr/local/bin/docker-entrypoint.sh vault server -config=/tmp/storageconfig.hcl
@@ -146,7 +146,7 @@ Set's additional environment variables based on the mode.
 {{- end -}}
 
 {{/*
-Set's which additional volumes should be mounted to the container 
+Set's which additional volumes should be mounted to the container
 based on the mode configured.
 */}}
 {{- define "vault.mounts" -}}
@@ -172,8 +172,8 @@ based on the mode configured.
 {{- end -}}
 
 {{/*
-Set's up the volumeClaimTemplates when data or audit storage is required.  HA 
-might not use data storage since Consul is likely it's backend, however, audit 
+Set's up the volumeClaimTemplates when data or audit storage is required.  HA
+might not use data storage since Consul is likely it's backend, however, audit
 storage might be desired by the user.
 */}}
 {{- define "vault.volumeclaims" -}}

--- a/templates/server-statefulset.yaml
+++ b/templates/server-statefulset.yaml
@@ -45,7 +45,7 @@ spec:
         - name: vault
           {{ template "vault.resources" . }}
           securityContext:
-            privileged: true
+            allowPrivilegeEscalation: true
           image: "{{ .Values.global.image }}"
           command: {{ template "vault.command" . }}
           args: {{ template "vault.args" . }}

--- a/test/acceptance/server-dev.bats
+++ b/test/acceptance/server-dev.bats
@@ -52,5 +52,5 @@ load _helpers
 teardown() {
   echo "helm/pvc teardown"
   helm delete --purge vault
-  kubectl delete --all pvc 
+  kubectl delete --all pvc
 }

--- a/test/acceptance/server-ha.bats
+++ b/test/acceptance/server-ha.bats
@@ -4,7 +4,7 @@ load _helpers
 
 @test "server/ha: testing deployment" {
   cd `chart_dir`
-  
+
   helm install --name="$(name_prefix)" \
     --set='server.ha.enabled=true' .
   wait_for_running $(name_prefix)-0
@@ -71,7 +71,7 @@ load _helpers
   # Vault Unseal
   local pods=($(kubectl get pods --selector='app.kubernetes.io/name=vault' -o json | jq -r '.items[].metadata.name'))
   for pod in "${pods[@]}"
-  do  
+  do
       kubectl exec -ti ${pod} -- vault operator unseal ${token}
   done
 
@@ -95,12 +95,12 @@ setup() {
     --name consul \
     --set 'ui.enabled=false' \
 
-  wait_for_running_consul 
+  wait_for_running_consul
 }
 
 #cleanup
 teardown() {
-  helm delete --purge vault 
+  helm delete --purge vault
   helm delete --purge consul
-  kubectl delete --all pvc 
+  kubectl delete --all pvc
 }

--- a/test/acceptance/server.bats
+++ b/test/acceptance/server.bats
@@ -8,11 +8,11 @@ load _helpers
   wait_for_running $(name_prefix)-0
 
   # Sealed, not initialized
-  local sealed_status=$(kubectl exec "$(name_prefix)-0" -- vault status -format=json | 
+  local sealed_status=$(kubectl exec "$(name_prefix)-0" -- vault status -format=json |
     jq -r '.sealed' )
   [ "${sealed_status}" == "true" ]
-  
-  local init_status=$(kubectl exec "$(name_prefix)-0" -- vault status -format=json | 
+
+  local init_status=$(kubectl exec "$(name_prefix)-0" -- vault status -format=json |
     jq -r '.initialized')
   [ "${init_status}" == "false" ]
 
@@ -21,7 +21,7 @@ load _helpers
     jq -r '.spec.replicas')
   [ "${replicas}" == "1" ]
 
-  # Affinity 
+  # Affinity
   local affinity=$(kubectl get statefulset "$(name_prefix)" --output json |
     jq -r '.spec.template.spec.affinity')
   [ "${affinity}" != "null" ]
@@ -34,7 +34,7 @@ load _helpers
   local mountName=$(kubectl get statefulset "$(name_prefix)" --output json |
     jq -r '.spec.template.spec.containers[0].volumeMounts[0].name')
   [ "${mountName}" == "data" ]
-  
+
   local mountPath=$(kubectl get statefulset "$(name_prefix)" --output json |
     jq -r '.spec.template.spec.containers[0].volumeMounts[0].mountPath')
   [ "${mountPath}" == "/vault/data" ]
@@ -107,5 +107,5 @@ load _helpers
 teardown() {
   echo "helm/pvc teardown"
   helm delete --purge vault
-  kubectl delete --all pvc 
+  kubectl delete --all pvc
 }

--- a/test/unit/server-dev-statefulset.bats
+++ b/test/unit/server-dev-statefulset.bats
@@ -211,7 +211,7 @@ load _helpers
 }
 
 #--------------------------------------------------------------------
-# extraEnvironmentVars 
+# extraEnvironmentVars
 
 @test "server/dev-StatefulSet: set extraEnvironmentVars" {
   cd `chart_dir`

--- a/test/unit/server-ha-statefulset.bats
+++ b/test/unit/server-ha-statefulset.bats
@@ -55,7 +55,7 @@ load _helpers
 }
 
 #--------------------------------------------------------------------
-# affinity 
+# affinity
 
 @test "server/ha-StatefulSet: default affinity" {
   cd `chart_dir`
@@ -100,7 +100,7 @@ load _helpers
 }
 
 #--------------------------------------------------------------------
-# resources 
+# resources
 
 @test "server/ha-StatefulSet: default resources" {
   cd `chart_dir`

--- a/test/unit/server-service.bats
+++ b/test/unit/server-service.bats
@@ -121,7 +121,7 @@ load _helpers
   local actual=$(helm template \
       -x templates/server-service.yaml \
       --set 'server.dev.enabled=true' \
-      . | tee /dev/stderr | 
+      . | tee /dev/stderr |
       yq -r '.metadata.annotations["service.alpha.kubernetes.io/tolerate-unready-endpoints"]' | tee /dev/stderr)
   [ "${actual}" = "true" ]
 
@@ -187,7 +187,7 @@ load _helpers
   [ "${actual}" = "null" ]
 }
 
-@test "server/Service: clusterIP can set" { 
+@test "server/Service: clusterIP can set" {
   cd `chart_dir`
   local actual=$(helm template \
       -x templates/server-service.yaml \

--- a/values.yaml
+++ b/values.yaml
@@ -21,8 +21,8 @@ server:
   #     memory: 256Mi
   #     cpu: 250m
 
-  # authDelegator enables a cluster role binding to be attached to the service 
-  # account.  This cluster role binding can be used to setup Kubernetes auth 
+  # authDelegator enables a cluster role binding to be attached to the service
+  # account.  This cluster role binding can be used to setup Kubernetes auth
   # method.  https://www.vaultproject.io/docs/auth/kubernetes.html
   authDelegator:
     enabled: false
@@ -52,7 +52,7 @@ server:
 
   # Affinity Settings
   # Commenting out or setting as empty the affinity variable, will allow
-  # deployment to single node services such as Minikube  
+  # deployment to single node services such as Minikube
   affinity: |
     podAntiAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:
@@ -79,41 +79,41 @@ server:
   # This should be a multi-line string mapping directly to the a map of
   # the annotations to apply to the server pods
   annotations: {}
-  
+
   # Enables a headless service to be used by the Vault Statefulset
   service:
     enabled: true
-    # clusterIP controls whether a Cluster IP address is attached to the 
-    # Vault service within Kubernetes.  By default the Vault service will 
-    # be given a Cluster IP address, set to None to disable.  When disabled 
-    # Kubernetes will create a "headless" service.  Headless services can be 
+    # clusterIP controls whether a Cluster IP address is attached to the
+    # Vault service within Kubernetes.  By default the Vault service will
+    # be given a Cluster IP address, set to None to disable.  When disabled
+    # Kubernetes will create a "headless" service.  Headless services can be
     # used to communicate with pods directly through DNS instead of a round robin
     # load balancer.
     # clusterIP: None
 
-  # This configures the Vault Statefulset to create a PVC for data 
+  # This configures the Vault Statefulset to create a PVC for data
   # storage when using the file backend.
-  # See https://www.vaultproject.io/docs/audit/index.html to know more 
+  # See https://www.vaultproject.io/docs/audit/index.html to know more
   dataStorage:
     enabled: true
     # Size of the PVC created
     size: 10Gi
-    # Name of the storage class to use.  If null it will use the 
+    # Name of the storage class to use.  If null it will use the
     # configured default Storage Class.
     storageClass: null
     # Access Mode of the storage device being used for the PVC
     accessMode: ReadWriteOnce
 
-  # This configures the Vault Statefulset to create a PVC for audit 
-  # logs.  Once Vault is deployed, initialized and unseal, Vault must 
-  # be configured to use this for audit logs.  This will be mounted to 
+  # This configures the Vault Statefulset to create a PVC for audit
+  # logs.  Once Vault is deployed, initialized and unseal, Vault must
+  # be configured to use this for audit logs.  This will be mounted to
   # /vault/audit
-  # See https://www.vaultproject.io/docs/audit/index.html to know more 
+  # See https://www.vaultproject.io/docs/audit/index.html to know more
   auditStorage:
     enabled: false
     # Size of the PVC created
     size: 10Gi
-    # Name of the storage class to use.  If null it will use the 
+    # Name of the storage class to use.  If null it will use the
     # configured default Storage Class.
     storageClass: null
     # Access Mode of the storage device being used for the PVC
@@ -127,9 +127,9 @@ server:
   dev:
     enabled: false
 
-  # Run Vault in "standalone" mode. This is the default mode that will deploy if 
-  # no arguments are given to helm. This requires a PVC for data storage to use 
-  # the "file" backend.  This mode is not highly available and should not be scaled 
+  # Run Vault in "standalone" mode. This is the default mode that will deploy if
+  # no arguments are given to helm. This requires a PVC for data storage to use
+  # the "file" backend.  This mode is not highly available and should not be scaled
   # past a single replica.
   standalone:
     enabled: "-"
@@ -160,10 +160,10 @@ server:
       #   crypto_key  = "vault-helm-unseal-key"
       #}
 
-  # Run Vault in "HA" mode. There are no storage requirements unless audit log 
-  # persistence is required.  In HA mode Vault will configure itself to use Consul 
-  # for its storage backend.  The default configuration provided will work the Consul 
-  # Helm project by default.  It is possible to manually configure Vault to use a 
+  # Run Vault in "HA" mode. There are no storage requirements unless audit log
+  # persistence is required.  In HA mode Vault will configure itself to use Consul
+  # for its storage backend.  The default configuration provided will work the Consul
+  # Helm project by default.  It is possible to manually configure Vault to use a
   # different HA backend.
   ha:
     enabled: false
@@ -194,7 +194,7 @@ server:
       #   crypto_key  = "vault-helm-unseal-key"
       #}
 
-    # A disruption budget limits the number of pods of a replicated application 
+    # A disruption budget limits the number of pods of a replicated application
     # that are down simultaneously from voluntary disruptions
     disruptionBudget:
       enabled: true


### PR DESCRIPTION
Two changes:

1. Address K8s Deprecation of Kubelet security controls - https://github.com/kubernetes/kubernetes/pull/77820
It's done here: https://github.com/hashicorp/vault-helm/pull/24/files#diff-60ca1594dfcfe4f0d22db67a9583d9fe

2. Remove all whitespaces.