### PR TITLE
Add VAULT_API_ADDR as environment var

### DIFF
--- a/templates/server-statefulset.yaml
+++ b/templates/server-statefulset.yaml
@@ -60,6 +60,8 @@ spec:
                   fieldPath: status.podIP
             - name: VAULT_ADDR
               value: "{{ include "vault.scheme" . }}://127.0.0.1:8200"
+            - name: VAULT_API_ADDR
+              value: "{{ include "vault.scheme" . }}://$(POD_IP):8200"
             - name: SKIP_CHOWN
               value: "true"
             {{ template "vault.envs" . }}

--- a/test/unit/server-dev-statefulset.bats
+++ b/test/unit/server-dev-statefulset.bats
@@ -224,19 +224,19 @@ load _helpers
       yq -r '.spec.template.spec.containers[0].env' | tee /dev/stderr)
 
   local actual=$(echo $object |
-     yq -r '.[5].name' | tee /dev/stderr)
+     yq -r '.[6].name' | tee /dev/stderr)
   [ "${actual}" = "FOO" ]
 
   local actual=$(echo $object |
-      yq -r '.[5].value' | tee /dev/stderr)
+      yq -r '.[6].value' | tee /dev/stderr)
   [ "${actual}" = "bar" ]
 
   local actual=$(echo $object |
-      yq -r '.[6].name' | tee /dev/stderr)
+      yq -r '.[7].name' | tee /dev/stderr)
   [ "${actual}" = "FOOBAR" ]
 
   local actual=$(echo $object |
-      yq -r '.[6].value' | tee /dev/stderr)
+      yq -r '.[7].value' | tee /dev/stderr)
   [ "${actual}" = "foobar" ]
 }
 
@@ -257,23 +257,23 @@ load _helpers
       yq -r '.spec.template.spec.containers[0].env' | tee /dev/stderr)
 
   local actual=$(echo $object |
-      yq -r '.[4].name' | tee /dev/stderr)
+      yq -r '.[5].name' | tee /dev/stderr)
   [ "${actual}" = "ENV_FOO_0" ]
   local actual=$(echo $object |
-      yq -r '.[4].valueFrom.secretKeyRef.name' | tee /dev/stderr)
+      yq -r '.[5].valueFrom.secretKeyRef.name' | tee /dev/stderr)
   [ "${actual}" = "secret_name_0" ]
   local actual=$(echo $object |
-      yq -r '.[4].valueFrom.secretKeyRef.key' | tee /dev/stderr)
+      yq -r '.[5].valueFrom.secretKeyRef.key' | tee /dev/stderr)
   [ "${actual}" = "secret_key_0" ]
 
   local actual=$(echo $object |
-      yq -r '.[5].name' | tee /dev/stderr)
+      yq -r '.[6].name' | tee /dev/stderr)
   [ "${actual}" = "ENV_FOO_1" ]
   local actual=$(echo $object |
-      yq -r '.[5].valueFrom.secretKeyRef.name' | tee /dev/stderr)
+      yq -r '.[6].valueFrom.secretKeyRef.name' | tee /dev/stderr)
   [ "${actual}" = "secret_name_1" ]
   local actual=$(echo $object |
-      yq -r '.[5].valueFrom.secretKeyRef.key' | tee /dev/stderr)
+      yq -r '.[6].valueFrom.secretKeyRef.key' | tee /dev/stderr)
   [ "${actual}" = "secret_key_1" ]
 }
 

--- a/test/unit/server-ha-statefulset.bats
+++ b/test/unit/server-ha-statefulset.bats
@@ -320,19 +320,19 @@ load _helpers
       yq -r '.spec.template.spec.containers[0].env' | tee /dev/stderr)
 
   local actual=$(echo $object |
-     yq -r '.[4].name' | tee /dev/stderr)
+     yq -r '.[5].name' | tee /dev/stderr)
   [ "${actual}" = "FOO" ]
 
   local actual=$(echo $object |
-      yq -r '.[4].value' | tee /dev/stderr)
+      yq -r '.[5].value' | tee /dev/stderr)
   [ "${actual}" = "bar" ]
 
   local actual=$(echo $object |
-      yq -r '.[5].name' | tee /dev/stderr)
+      yq -r '.[6].name' | tee /dev/stderr)
   [ "${actual}" = "FOOBAR" ]
 
   local actual=$(echo $object |
-      yq -r '.[5].value' | tee /dev/stderr)
+      yq -r '.[6].value' | tee /dev/stderr)
   [ "${actual}" = "foobar" ]
 }
 
@@ -354,23 +354,23 @@ load _helpers
       yq -r '.spec.template.spec.containers[0].env' | tee /dev/stderr)
 
   local actual=$(echo $object |
-      yq -r '.[4].name' | tee /dev/stderr)
+      yq -r '.[5].name' | tee /dev/stderr)
   [ "${actual}" = "ENV_FOO_0" ]
   local actual=$(echo $object |
-      yq -r '.[4].valueFrom.secretKeyRef.name' | tee /dev/stderr)
+      yq -r '.[5].valueFrom.secretKeyRef.name' | tee /dev/stderr)
   [ "${actual}" = "secret_name_0" ]
   local actual=$(echo $object |
-      yq -r '.[4].valueFrom.secretKeyRef.key' | tee /dev/stderr)
+      yq -r '.[5].valueFrom.secretKeyRef.key' | tee /dev/stderr)
   [ "${actual}" = "secret_key_0" ]
 
   local actual=$(echo $object |
-      yq -r '.[5].name' | tee /dev/stderr)
+      yq -r '.[6].name' | tee /dev/stderr)
   [ "${actual}" = "ENV_FOO_1" ]
   local actual=$(echo $object |
-      yq -r '.[5].valueFrom.secretKeyRef.name' | tee /dev/stderr)
+      yq -r '.[6].valueFrom.secretKeyRef.name' | tee /dev/stderr)
   [ "${actual}" = "secret_name_1" ]
   local actual=$(echo $object |
-      yq -r '.[5].valueFrom.secretKeyRef.key' | tee /dev/stderr)
+      yq -r '.[6].valueFrom.secretKeyRef.key' | tee /dev/stderr)
   [ "${actual}" = "secret_key_1" ]
 }
 

--- a/test/unit/server-statefulset.bats
+++ b/test/unit/server-statefulset.bats
@@ -296,19 +296,19 @@ load _helpers
       yq -r '.spec.template.spec.containers[0].env' | tee /dev/stderr)
 
   local actual=$(echo $object |
-     yq -r '.[4].name' | tee /dev/stderr)
+     yq -r '.[5].name' | tee /dev/stderr)
   [ "${actual}" = "FOO" ]
 
   local actual=$(echo $object |
-      yq -r '.[4].value' | tee /dev/stderr)
+      yq -r '.[5].value' | tee /dev/stderr)
   [ "${actual}" = "bar" ]
 
   local actual=$(echo $object |
-      yq -r '.[5].name' | tee /dev/stderr)
+      yq -r '.[6].name' | tee /dev/stderr)
   [ "${actual}" = "FOOBAR" ]
 
   local actual=$(echo $object |
-      yq -r '.[5].value' | tee /dev/stderr)
+      yq -r '.[6].value' | tee /dev/stderr)
   [ "${actual}" = "foobar" ]
 
   local object=$(helm template \
@@ -319,19 +319,19 @@ load _helpers
       yq -r '.spec.template.spec.containers[0].env' | tee /dev/stderr)
 
   local actual=$(echo $object |
-     yq -r '.[4].name' | tee /dev/stderr)
+     yq -r '.[5].name' | tee /dev/stderr)
   [ "${actual}" = "FOO" ]
 
   local actual=$(echo $object |
-      yq -r '.[4].value' | tee /dev/stderr)
+      yq -r '.[5].value' | tee /dev/stderr)
   [ "${actual}" = "bar" ]
 
   local actual=$(echo $object |
-      yq -r '.[5].name' | tee /dev/stderr)
+      yq -r '.[6].name' | tee /dev/stderr)
   [ "${actual}" = "FOOBAR" ]
 
   local actual=$(echo $object |
-      yq -r '.[5].value' | tee /dev/stderr)
+      yq -r '.[6].value' | tee /dev/stderr)
   [ "${actual}" = "foobar" ]
 }
 

--- a/values.yaml
+++ b/values.yaml
@@ -6,7 +6,7 @@ global:
   enabled: true
 
   # Image is the name (and tag) of the Vault Docker image.
-  image: "vault:1.2.1"
+  image: "vault:1.2.2"
   # TLS for end-to-end encrypted transport
   tlsDisable: true
 
@@ -176,6 +176,7 @@ server:
     # This should be HCL.
     config: |
       ui = true
+
       listener "tcp" {
         tls_disable = 1
         address = "[::]:8200"


### PR DESCRIPTION
The default `api_addr` set by the Vault server is not binding to the correct address (Pod IP) which causes issues in HA deployments.  This adds `VAULT_API_ADDR` as an environment variable for two reason:

* Using the new `global.tlsDisable` var allows the helm chart to discover which protocol to use (http/https).  This is helpful when setting the api protocol to use and templating this is not possible in `values.yaml`
* We also need to grab the pod IP during runtime, so we let Kube do the rendering of our variable.