### PR TITLE
Remove version label from resources

### DIFF
--- a/templates/server-clusterrolebinding.yaml
+++ b/templates/server-clusterrolebinding.yaml
@@ -10,7 +10,6 @@ metadata:
     app.kubernetes.io/name: {{ include "vault.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
-    app.kubernetes.io/version: {{ .Chart.Version | quote }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/templates/server-config-configmap.yaml
+++ b/templates/server-config-configmap.yaml
@@ -10,7 +10,6 @@ metadata:
     app.kubernetes.io/name: {{ include "vault.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
-    app.kubernetes.io/version: {{ .Chart.Version | quote }}
 data:
   extraconfig-from-values.hcl: |-
   {{- if eq .mode "standalone" }}

--- a/templates/server-disruptionbudget.yaml
+++ b/templates/server-disruptionbudget.yaml
@@ -11,7 +11,6 @@ metadata:
     app.kubernetes.io/name: {{ include "vault.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
-    app.kubernetes.io/version: {{ .Chart.Version | quote }}
 spec:
   maxUnavailable: {{ template "vault.pdb.maxUnavailable" . }}
   selector:

--- a/templates/server-service.yaml
+++ b/templates/server-service.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/name: {{ include "vault.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
-    app.kubernetes.io/version: {{ .Chart.Version | quote }}
   annotations:
     # This must be set in addition to publishNotReadyAddresses due
     # to an open issue where it may not work:

--- a/templates/server-serviceaccount.yaml
+++ b/templates/server-serviceaccount.yaml
@@ -10,5 +10,4 @@ metadata:
     app.kubernetes.io/name: {{ include "vault.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
-    app.kubernetes.io/version: {{ .Chart.Version | quote }}
 {{ end }}

--- a/templates/server-statefulset.yaml
+++ b/templates/server-statefulset.yaml
@@ -10,7 +10,6 @@ metadata:
     app.kubernetes.io/name: {{ include "vault.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
-    app.kubernetes.io/version: {{ .Chart.Version | quote }}
 spec:
   serviceName: {{ template "vault.fullname" . }}
   podManagementPolicy: Parallel

--- a/templates/ui-service.yaml
+++ b/templates/ui-service.yaml
@@ -15,7 +15,6 @@ metadata:
     app.kubernetes.io/name: {{ include "vault.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
-    app.kubernetes.io/version: {{ .Chart.Version | quote }}
   {{- template "vault.ui.annotations" . }}
 spec:
   selector:


### PR DESCRIPTION
This fixes a bug I introduced when applying a fix for #7 by removing `version` from labels.  Some objects in Kubernetes (Statefulset's in particular) can't mutate labels once they've been set.  This leads to an unnecessary upgrade process of purging and recreating objects instead of a direct upgrade.

After upgrading to these new templates there should be no need for purging resources anymore.