### PR TITLE
Use correct name label for UI Service object

### DIFF
--- a/templates/ui-service.yaml
+++ b/templates/ui-service.yaml
@@ -12,7 +12,7 @@ metadata:
   name: {{ template "vault.fullname" . }}-ui
   labels:
     helm.sh/chart: {{ include "vault.chart" . }}
-    app.kubernetes.io/name: {{ include "vault.name" . }}
+    app.kubernetes.io/name: {{ include "vault.name" . }}-ui
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     app.kubernetes.io/version: {{ .Chart.Version | quote }}


### PR DESCRIPTION
Currently `app.kubernetes.io/name` label for both headless and UI Service services are the same: `{{ include "vault.name" . }}`.
This causes problem for tools that use labels for service discovery.
The correct name for ui Service should be the same in `.metadata.name`:
```yaml
   name: {{ template "vault.fullname" . }}-ui
   labels:
     helm.sh/chart: {{ include "vault.chart" . }}
     app.kubernetes.io/name: {{ include "vault.name" . }}-ui
```