### PR TITLE
Remove step-down preStop

### DIFF
--- a/templates/server-statefulset.yaml
+++ b/templates/server-statefulset.yaml
@@ -68,10 +68,6 @@ spec:
             {{- include "vault.extraSecretEnvironmentVars" .Values.server | nindent 12 }}
           volumeMounts:
           {{ template "vault.mounts" . }}
-          lifecycle:
-            preStop:
-              exec:
-                command: ["vault", "step-down"]
           ports:
             - containerPort: 8200
               name: http


### PR DESCRIPTION
The step-down command was failing because it requires client authentication.  We currently cannot automatically authenticate locally in the Vault container.  The error was not noticeable due to how fast Kube cleaned up the pod.

Since Vault already does active duty step-down as part of shutdown, we get the same functionality from Kube shutdown signals.  Thus this is unneeded at this time.