### PR TITLE
Add privileged for mlock requirements

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: vault
-version: 0.1.1
+version: 0.1.2
 description: Install and configure Vault on Kubernetes.
 home: https://www.vaultproject.io
 icon: https://github.com/hashicorp/vault/raw/f22d202cde2018f9455dec755118a9b84586e082/Vault_PrimaryLogo_Black.png

--- a/templates/server-statefulset.yaml
+++ b/templates/server-statefulset.yaml
@@ -44,7 +44,7 @@ spec:
         - name: vault
           {{ template "vault.resources" . }}
           securityContext:
-            allowPrivilegeEscalation: true
+            privileged: true
           image: "{{ .Values.global.image }}"
           command: {{ template "vault.command" . }}
           args: {{ template "vault.args" . }}


### PR DESCRIPTION
#24 caused an error in the Vault pod because `mlock` was failing due to reduced privileges.  Reverted for now until we can investigate other security capabilities.