### PR TITLE
feat: allow setting loadBalancerIP and externalPort for service-ui

### DIFF
--- a/templates/ui-service.yaml
+++ b/templates/ui-service.yaml
@@ -24,12 +24,15 @@ spec:
     component: server
   ports:
     - name: http
-      port: 8200
+      port: {{ .Values.ui.externalPort }}
       targetPort: 8200
       {{- if .Values.ui.serviceNodePort }}
       nodePort: {{ .Values.ui.serviceNodePort }}
       {{- end }}
-  type: {{ .Values.ui.serviceType | default "ClusterIP" }}
+  type: {{ .Values.ui.serviceType }}
+  {{- if and (eq (.Values.ui.serviceType | toString) "LoadBalancer") (.Values.ui.loadBalancerIP) }}
+  loadBalancerIP: {{ .Values.ui.loadBalancerIP }}
+  {{- end }}
 {{- end -}}
 
 {{ end }}

--- a/test/unit/ui-service.bats
+++ b/test/unit/ui-service.bats
@@ -110,6 +110,29 @@ load _helpers
   [ "${actual}" = "LoadBalancer" ]
 }
 
+@test "ui/Service: LoadBalancerIP set if specified and serviceType == LoadBalancer" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/ui-service.yaml  \
+      --set 'server.dev.enabled=true' \
+      --set 'ui.serviceType=LoadBalancer' \
+      --set 'ui.enabled=true' \
+      --set 'ui.loadBalancerIP=123.123.123.123' \
+      . | tee /dev/stderr |
+      yq -r '.spec.loadBalancerIP' | tee /dev/stderr)
+  [ "${actual}" = "123.123.123.123" ]
+
+  local actual=$(helm template \
+      -x templates/ui-service.yaml  \
+      --set 'server.dev.enabled=true' \
+      --set 'ui.serviceType=ClusterIP' \
+      --set 'ui.enabled=true' \
+      --set 'ui.loadBalancerIP=123.123.123.123' \
+      . | tee /dev/stderr |
+      yq -r '.spec.loadBalancerIP' | tee /dev/stderr)
+  [ "${actual}" = "null" ]
+}
+
 @test "ui/Service: specify annotations" {
   cd `chart_dir`
   local actual=$(helm template \

--- a/test/unit/ui-service.bats
+++ b/test/unit/ui-service.bats
@@ -53,33 +53,6 @@ load _helpers
   [ "${actual}" = "false" ]
 }
 
-@test "ui/Service: disable with ui.service.enabled" {
-  cd `chart_dir`
-  local actual=$(helm template \
-      -x templates/ui-service.yaml  \
-      --set 'server.dev.enabled=true' \
-      --set 'ui.service.enabled=false' \
-      . | tee /dev/stderr |
-      yq 'length > 0' | tee /dev/stderr)
-  [ "${actual}" = "false" ]
-
-  local actual=$(helm template \
-      -x templates/ui-service.yaml  \
-      --set 'server.ha.enabled=true' \
-      --set 'ui.service.enabled=false' \
-      . | tee /dev/stderr |
-      yq 'length > 0' | tee /dev/stderr)
-  [ "${actual}" = "false" ]
-
-  local actual=$(helm template \
-      -x templates/ui-service.yaml  \
-      --set 'server.standalone.enabled=true' \
-      --set 'ui.service.enabled=false' \
-      . | tee /dev/stderr |
-      yq 'length > 0' | tee /dev/stderr)
-  [ "${actual}" = "false" ]
-}
-
 @test "ui/Service: ClusterIP type by default" {
   cd `chart_dir`
   local actual=$(helm template \

--- a/values.yaml
+++ b/values.yaml
@@ -216,6 +216,8 @@ ui:
   enabled: false
   serviceType: "ClusterIP"
   serviceNodePort: null
+  externalPort: 8200
+  # loadBalancerIP:
 
   # Extra annotations to attach to the ui service
   # This should be a multi-line string mapping directly to the a map of


### PR DESCRIPTION
One way to allow external access to the vault cluster is via a LoadBalancer service (another would be an ingress).
With this PR it is possible to set the external port of the ui service and if wanted to specify a pre-registered ip for the service.