### PR TITLE
annotation configuration on service account

### DIFF
--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -259,6 +259,15 @@ Sets extra ui service annotations
   {{- end }}
 {{- end -}}
 
+{{/*
+Sets extra service account annotations
+*/}}
+{{- define "vault.serviceaccount.annotations" -}}
+  {{- if and (ne .mode "dev") .Values.server.serviceaccount.annotations }}
+  annotations:
+    {{- toYaml .Values.server.serviceaccount.annotations | nindent 4 }}
+  {{- end }}
+{{- end -}}
 
 {{/*
 Set's the container resources if the user has set any.

--- a/templates/server-serviceaccount.yaml
+++ b/templates/server-serviceaccount.yaml
@@ -10,4 +10,5 @@ metadata:
     app.kubernetes.io/name: {{ include "vault.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
+  {{ template "vault.serviceaccount.annotations" . }}
 {{ end }}

--- a/test/unit/server-serviceaccount.bats
+++ b/test/unit/server-serviceaccount.bats
@@ -1,0 +1,29 @@
+#!/usr/bin/env bats
+
+load _helpers
+
+@test "server/ServiceAccount: specify annotations" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/server-serviceaccount.yaml  \
+      --set 'server.dev.enabled=true' \
+      --set 'server.serviceaccount.annotations.foo=bar' \
+      . | tee /dev/stderr |
+      yq -r '.metadata.annotations["foo"]' | tee /dev/stderr)
+  [ "${actual}" = "null" ]
+
+  local actual=$(helm template \
+      -x templates/server-serviceaccount.yaml  \
+      --set 'server.ha.enabled=true' \
+      --set 'server.serviceaccount.annotations.foo=bar' \
+      . | tee /dev/stderr |
+      yq -r '.metadata.annotations["foo"]' | tee /dev/stderr)
+  [ "${actual}" = "bar" ]
+
+  local actual=$(helm template \
+      -x templates/server-serviceaccount.yaml  \
+      --set 'server.ha.enabled=true' \
+      . | tee /dev/stderr |
+      yq -r '.metadata.annotations["foo"]' | tee /dev/stderr)
+  [ "${actual}" = "null" ]
+}

--- a/values.yaml
+++ b/values.yaml
@@ -206,6 +206,10 @@ server:
     # replicas. If you'd like a custom value, you can specify an override here.
       maxUnavailable: null
 
+  # Definition of the serviceaccount used to run Vault.
+  serviceaccount:
+    annotations: {}
+
 # Vault UI
 ui:
   # True if you want to create a Service entry for the Vault UI.


### PR DESCRIPTION
We need this to be able to use the new Workload Identity feature from Google Cloud. That feature needs an annotation on the service account.