### PR TITLE
Remove privileged, add mlock configurable

### DIFF
--- a/templates/server-config-configmap.yaml
+++ b/templates/server-config-configmap.yaml
@@ -13,6 +13,9 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
 data:
   extraconfig-from-values.hcl: |-
+  {{- if eq (.Values.server.mlock.enabled | toString) "false" }}
+    disable_mlock = true
+  {{- end }}
   {{- if eq .mode "standalone" }}
     {{ tpl .Values.server.standalone.config . | nindent 4 | trim }}
   {{- else if eq .mode "ha" }}

--- a/templates/server-statefulset.yaml
+++ b/templates/server-statefulset.yaml
@@ -44,8 +44,11 @@ spec:
       containers:
         - name: vault
           {{ template "vault.resources" . }}
+          {{- if eq (.Values.server.mlock.enabled | toString) "true" }}
           securityContext:
-            privileged: true
+            capabilities:
+              add: ["IPC_LOCK"]
+          {{- end }}
           image: "{{ .Values.global.image }}"
           command: {{ template "vault.command" . }}
           args: {{ template "vault.args" . }}
@@ -64,6 +67,10 @@ spec:
               value: "{{ include "vault.scheme" . }}://$(POD_IP):8200"
             - name: SKIP_CHOWN
               value: "true"
+            {{- if eq (.Values.server.mlock.enabled | toString) "false" }}
+            - name: SKIP_SETCAP
+              value: "true"
+            {{- end }}
             {{ template "vault.envs" . }}
             {{- include "vault.extraEnvironmentVars" .Values.server | nindent 12 }}
             {{- include "vault.extraSecretEnvironmentVars" .Values.server | nindent 12 }}

--- a/test/acceptance/_helpers.bash
+++ b/test/acceptance/_helpers.bash
@@ -87,7 +87,7 @@ wait_for_running() {
     for i in $(seq 60); do
         if [ -n "$(check ${POD_NAME})" ]; then
             echo "${POD_NAME} is ready."
-            sleep 2
+            sleep 10
             return
         fi
 
@@ -117,7 +117,7 @@ wait_for_ready() {
     for i in $(seq 60); do
         if [ -n "$(check ${POD_NAME})" ]; then
             echo "${POD_NAME} is ready."
-            sleep 2
+            sleep 10
             return
         fi
 

--- a/test/acceptance/server-ha.bats
+++ b/test/acceptance/server-ha.bats
@@ -18,6 +18,11 @@ load _helpers
     jq -r '.initialized')
   [ "${init_status}" == "false" ]
 
+  # Security
+  local ipc=$(kubectl get statefulset "$(name_prefix)" --output json |
+    jq -r '.spec.template.spec.containers[0].securityContext.capabilities.add[0]')
+  [ "${ipc}" == "IPC_LOCK" ]
+
   # Replicas
   local replicas=$(kubectl get statefulset "$(name_prefix)" --output json |
     jq -r '.spec.replicas')
@@ -36,10 +41,6 @@ load _helpers
   local volume=$(kubectl get statefulset "$(name_prefix)" --output json |
     jq -r '.spec.template.spec.volumes[0].configMap.name')
   [ "${volume}" == "$(name_prefix)-config" ]
-
-  local privileged=$(kubectl get statefulset "$(name_prefix)" --output json |
-    jq -r '.spec.template.spec.containers[0].securityContext.privileged')
-  [ "${privileged}" == "true" ]
 
   # Service
   local service=$(kubectl get service "$(name_prefix)" --output json |

--- a/test/acceptance/server.bats
+++ b/test/acceptance/server.bats
@@ -16,6 +16,11 @@ load _helpers
     jq -r '.initialized')
   [ "${init_status}" == "false" ]
 
+  # Security
+  local ipc=$(kubectl get statefulset "$(name_prefix)" --output json |
+    jq -r '.spec.template.spec.containers[0].securityContext.capabilities.add[0]')
+  [ "${ipc}" == "IPC_LOCK" ]
+
   # Replicas
   local replicas=$(kubectl get statefulset "$(name_prefix)" --output json |
     jq -r '.spec.replicas')
@@ -52,10 +57,6 @@ load _helpers
   local fsGroup=$(kubectl get statefulset "$(name_prefix)" --output json |
     jq -r '.spec.template.spec.securityContext.fsGroup')
   [ "${fsGroup}" == "1000" ]
-
-  local privileged=$(kubectl get statefulset "$(name_prefix)" --output json |
-    jq -r '.spec.template.spec.containers[0].securityContext.privileged')
-  [ "${privileged}" == "true" ]
 
   # Service
   local service=$(kubectl get service "$(name_prefix)" --output json |

--- a/test/unit/server-configmap.bats
+++ b/test/unit/server-configmap.bats
@@ -82,3 +82,52 @@ load _helpers
       yq '.data["extraconfig-from-values.hcl"] | match("bar") | length' | tee /dev/stderr)
   [ ! -z "${actual}" ]
 }
+
+@test "server/ConfigMap: mlock by default" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/server-config-configmap.yaml \
+      . | tee /dev/stderr |
+      yq '.data["extraconfig-from-values.hcl"] | contains("disable_mlock") | not)' | tee /dev/stderr)
+  [ -z "${actual}" ]
+
+  local actual=$(helm template \
+      -x templates/server-config-configmap.yaml \
+      --set 'server.standalone.enabled=true' \
+      . | tee /dev/stderr |
+      yq '.data["extraconfig-from-values.hcl"] | contains("disable_mlock") | not)' | tee /dev/stderr)
+  [ -z "${actual}" ]
+
+  local actual=$(helm template \
+      -x templates/server-config-configmap.yaml \
+      --set 'server.ha.enabled=true' \
+      . | tee /dev/stderr |
+      yq '.data["extraconfig-from-values.hcl"] | contains("disable_mlock") | not)' | tee /dev/stderr)
+  [ -z "${actual}" ]
+}
+
+@test "server/ConfigMap: disable mlock" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/server-config-configmap.yaml \
+      --set 'server.mlock.enabled=false' \
+      . | tee /dev/stderr |
+      yq '.data["extraconfig-from-values.hcl"] | contains("disable_mlock")' | tee /dev/stderr)
+  [ ! -z "${actual}" ]
+
+  local actual=$(helm template \
+      -x templates/server-config-configmap.yaml \
+      --set 'server.mlock.enabled=false' \
+      --set 'server.standalone.enabled=true' \
+      . | tee /dev/stderr |
+      yq '.data["extraconfig-from-values.hcl"] | contains("disable_mlock")' | tee /dev/stderr)
+  [ ! -z "${actual}" ]
+
+  local actual=$(helm template \
+      -x templates/server-config-configmap.yaml \
+      --set 'server.mlock.enabled=false' \
+      --set 'server.ha.enabled=true' \
+      . | tee /dev/stderr |
+      yq '.data["extraconfig-from-values.hcl"] | contains("disable_mlock")' | tee /dev/stderr)
+  [ ! -z "${actual}" ]
+}

--- a/values.yaml
+++ b/values.yaml
@@ -214,6 +214,11 @@ server:
   # Definition of the serviceaccount used to run Vault.
   serviceaccount:
     annotations: {}
+  
+  # mlock prevents memory from being swapped to disk.  If swap is enabled this should 
+  # be true.
+  mlock:
+    enabled: true
 
 # Vault UI
 ui:


### PR DESCRIPTION
This addresses #36 and #37 by replacing `privileged` security contexts with `IPC_LOCK`.  Additionally added a toggle for disabling/enabling `mlock` (enabled by default) if you wish to remove `IPC_LOCK` privileges from your deployment (assuming swap is disabled).