### PR TITLE
Make serviceAccount name a configuration option

### DIFF
--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -263,7 +263,7 @@ Sets extra ui service annotations
 Create the name of the service account to use
 */}}
 {{- define "vault.serviceAccountName" -}}
-{{- if .Values.serviceAccount.create -}}
+{{- if .Values.serviceAccount.enabled -}}
     {{ default (include "vault.fullname" .) .Values.serviceAccount.name }}
 {{- else -}}
     {{ default "default" .Values.serviceAccount.name }}

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -263,20 +263,20 @@ Sets extra ui service annotations
 Create the name of the service account to use
 */}}
 {{- define "vault.serviceAccountName" -}}
-{{- if .Values.serviceAccount.enabled -}}
-    {{ default (include "vault.fullname" .) .Values.serviceAccount.name }}
+{{- if .Values.server.serviceaccount.enabled -}}
+    {{ default (include "vault.fullname" .) .Values.server.serviceaccount.name }}
 {{- else -}}
-    {{ default "default" .Values.serviceAccount.name }}
+    {{ default "default" .Values.server.serviceaccount.name }}
 {{- end -}}
 {{- end -}}
 
 {{/*
 Sets extra service account annotations
 */}}
-{{- define "vault.serviceAccount.annotations" -}}
-  {{- if and (ne .mode "dev") .Values.serviceAccount.annotations }}
+{{- define "vault.serviceaccount.annotations" -}}
+  {{- if and (ne .mode "dev") .Values.server.serviceaccount.annotations }}
   annotations:
-    {{- toYaml .Values.serviceAccount.annotations | nindent 4 }}
+    {{- toYaml .Values.server.serviceaccount.annotations | nindent 4 }}
   {{- end }}
 {{- end -}}
 

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -260,12 +260,23 @@ Sets extra ui service annotations
 {{- end -}}
 
 {{/*
+Create the name of the service account to use
+*/}}
+{{- define "vault.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+    {{ default (include "vault.fullname" .) .Values.serviceAccount.name }}
+{{- else -}}
+    {{ default "default" .Values.serviceAccount.name }}
+{{- end -}}
+{{- end -}}
+
+{{/*
 Sets extra service account annotations
 */}}
-{{- define "vault.serviceaccount.annotations" -}}
-  {{- if and (ne .mode "dev") .Values.server.serviceaccount.annotations }}
+{{- define "vault.serviceAccount.annotations" -}}
+  {{- if and (ne .mode "dev") .Values.serviceAccount.annotations }}
   annotations:
-    {{- toYaml .Values.server.serviceaccount.annotations | nindent 4 }}
+    {{- toYaml .Values.serviceAccount.annotations | nindent 4 }}
   {{- end }}
 {{- end -}}
 

--- a/templates/server-serviceaccount.yaml
+++ b/templates/server-serviceaccount.yaml
@@ -1,5 +1,6 @@
 {{ template "vault.mode" . }}
 {{- if and (ne .mode "") (eq (.Values.global.enabled | toString) "true") }}
+{{- if (eq (.Values.server.serviceaccount.enabled | toString) "true" ) }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -10,5 +11,6 @@ metadata:
     app.kubernetes.io/name: {{ include "vault.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
-  {{ template "vault.serviceAccount.annotations" . }}
+  {{ template "vault.serviceaccount.annotations" . }}
+{{ end }}
 {{ end }}

--- a/templates/server-serviceaccount.yaml
+++ b/templates/server-serviceaccount.yaml
@@ -3,12 +3,12 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ template "vault.fullname" . }}
+  name: {{ template "vault.serviceAccountName" . }}
   namespace: {{ .Release.Namespace }}
   labels:
     helm.sh/chart: {{ include "vault.chart" . }}
     app.kubernetes.io/name: {{ include "vault.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
-  {{ template "vault.serviceaccount.annotations" . }}
+  {{ template "vault.serviceAccount.annotations" . }}
 {{ end }}

--- a/templates/server-statefulset.yaml
+++ b/templates/server-statefulset.yaml
@@ -36,7 +36,7 @@ spec:
       {{ template "vault.tolerations" . }}
       {{ template "vault.nodeselector" . }}
       terminationGracePeriodSeconds: 10
-      serviceAccountName: {{ template "vault.fullname" . }}
+      serviceAccountName: {{ template "vault.serviceAccountName" . }}
       securityContext:
         fsGroup: {{ template "vault.fsgroup" . }}
       volumes:

--- a/test/unit/server-serviceaccount.bats
+++ b/test/unit/server-serviceaccount.bats
@@ -2,6 +2,41 @@
 
 load _helpers
 
+@test "server/ServiceAccount: specify service account name" {
+  cd `chart_dir`
+
+  local actual=$(helm template \
+      -x templates/server-serviceaccount.yaml  \
+      --set 'server.dev.enabled=true' \
+      --set 'server.serviceaccount.enabled=false' \
+      . | tee /dev/stderr |
+      yq 'length == 0' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+
+  local actual=$(helm template \
+      -x templates/server-serviceaccount.yaml  \
+      --set 'server.dev.enabled=true' \
+      --set 'server.serviceaccount.name=user-defined-ksa' \
+      . | tee /dev/stderr |
+      yq -r '.metadata.name' | tee /dev/stderr)
+  [ "${actual}" = "user-defined-ksa" ]
+
+  local actual=$(helm template \
+      -x templates/server-serviceaccount.yaml  \
+      --set 'server.dev.enabled=true' \
+      . | tee /dev/stderr |
+      yq -r '.metadata.name' | tee /dev/stderr)
+  [ "${actual}" = "release-name-vault" ]
+
+  local actual=$(helm template \
+      -x templates/server-serviceaccount.yaml  \
+      --set 'server.ha.enabled=true' \
+      --set 'server.serviceaccount.annotations.iam\.gke\.io/gcp-service-account=user-defined-gsa@my-project.iam.gserviceaccount.com' \
+      . | tee /dev/stderr |
+      yq -r '.metadata.annotations["iam.gke.io/gcp-service-account"]' | tee /dev/stderr)
+  [ "${actual}" = "user-defined-gsa@my-project.iam.gserviceaccount.com" ]
+}
+
 @test "server/ServiceAccount: specify annotations" {
   cd `chart_dir`
   local actual=$(helm template \

--- a/values.yaml
+++ b/values.yaml
@@ -233,6 +233,11 @@ server:
 
   # Definition of the serviceaccount used to run Vault.
   serviceaccount:
+    # Specifies whether a service account should be created
+    enabled: true
+    # The name of the service account to use.
+    # If not set and create is true, a name is generated using the fullname template
+    name:
     annotations: {}
   
   # mlock prevents memory from being swapped to disk.  If swap is enabled this should 

--- a/values.yaml
+++ b/values.yaml
@@ -239,7 +239,7 @@ server:
     # If not set and create is true, a name is generated using the fullname template
     name:
     annotations: {}
-  
+
   # mlock prevents memory from being swapped to disk.  If swap is enabled this should 
   # be true.
   mlock:


### PR DESCRIPTION
Allow user to set the Kubernetes serviceAccount name used by vault.

Currently the serviceAccount name is based on the chart release name
which is non-deterministic and so makes using GCloud Workload Identity
service account mapping very difficult. 

And according to Google, "Workload Identity is the recommended way to access Google Cloud services from within GKE due to its improved security properties and manageability."
https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity

This also follows Helm Best Practices when defining serviceAccount names
https://helm.sh/docs/chart_best_practices/#using-rbac-resources

**Example values.yaml**
```
server:
  serviceaccount:
    name: vault-ksa
    annotations:
      iam.gke.io/gcp-service-account: vault-gsa@my-project.iam.gserviceaccount.com
```
where
- "vault-ksa" is the Kubernetes Service Account
- "vault-gsa" is the GCP Service Account
- "my-project" is the GCP Project name
