### PR TITLE
WIP: Raft support

### DIFF
--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -181,7 +181,7 @@ storage might be desired by the user.
 {{- define "vault.volumeclaims" -}}
   {{- if and (ne .mode "dev") (or .Values.server.dataStorage.enabled .Values.server.auditStorage.enabled) }}
   volumeClaimTemplates:
-      {{- if and (eq (.Values.server.dataStorage.enabled | toString) "true") (or (eq .mode "standalone") (and ((eq .mode "ha") (eq (.Values.server.ha.raft.enabled | toString) "true")))) }}
+      {{- if and (eq (.Values.server.dataStorage.enabled | toString) "true") (or (eq .mode "standalone") (and (eq .mode "ha") (eq (.Values.server.ha.raft.enabled | toString) "true"))) }}
     - metadata:
         name: data
       spec:
@@ -314,5 +314,16 @@ Inject extra environment populated by secrets, if populated
 {{ "http" }}
 {{- else -}}
 {{ "https" }}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create serviceName for statefulsets.
+*/}}
+{{- define "vault.serviceName" -}}
+{{- if eq (.Values.server.service.headless.enabled | toString) "true" -}}
+{{ template "vault.fullname" . }}-headless
+{{- else -}}
+{{ template "vault.fullname" . }}
 {{- end -}}
 {{- end -}}

--- a/templates/server-service-headless.yaml
+++ b/templates/server-service-headless.yaml
@@ -1,9 +1,9 @@
 # Service for Vault cluster
-{{- if and (eq (.Values.server.service.enabled | toString) "true" ) (eq (.Values.global.enabled | toString) "true") }}
+{{- if and (eq (.Values.server.service.headless.enabled | toString) "true" ) (eq (.Values.global.enabled | toString) "true") }}
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ template "vault.fullname" . }}
+  name: {{ template "vault.fullname" . }}-headless
   namespace: {{ .Release.Namespace }}
   labels:
     helm.sh/chart: {{ include "vault.chart" . }}
@@ -16,7 +16,7 @@ metadata:
     # https://github.com/kubernetes/kubernetes/issues/58662
     service.alpha.kubernetes.io/tolerate-unready-endpoints: "true"
 spec:
-  clusterIP: 
+  clusterIP: None
   # We want the servers to become available even if they're not ready
   # since this DNS is also used for join operations.
   publishNotReadyAddresses: true

--- a/templates/server-statefulset.yaml
+++ b/templates/server-statefulset.yaml
@@ -12,7 +12,7 @@ metadata:
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
 spec:
-  serviceName: {{ template "vault.fullname" . }}
+  serviceName: {{ template "vault.serviceName" . }}
   podManagementPolicy: Parallel
   replicas: {{ template "vault.replicas" . }}
   updateStrategy:

--- a/test/acceptance/_helpers.bash
+++ b/test/acceptance/_helpers.bash
@@ -117,7 +117,7 @@ wait_for_ready() {
     for i in $(seq 60); do
         if [ -n "$(check ${POD_NAME})" ]; then
             echo "${POD_NAME} is ready."
-            sleep 2
+            sleep 10
             return
         fi
 

--- a/test/acceptance/server-ha-consul.bats
+++ b/test/acceptance/server-ha-consul.bats
@@ -2,7 +2,7 @@
 
 load _helpers
 
-@test "server/ha: testing deployment" {
+@test "server/ha-consul: testing deployment" {
   cd `chart_dir`
 
   helm install --name="$(name_prefix)" \

--- a/test/acceptance/server-ha-raft.bats
+++ b/test/acceptance/server-ha-raft.bats
@@ -1,0 +1,117 @@
+#!/usr/bin/env bats
+
+load _helpers
+
+@test "server/ha-raft: testing deployment" {
+  cd `chart_dir`
+
+  helm install --name="$(name_prefix)" \
+    -f ./test/acceptance/values-raft.yaml .
+  wait_for_running $(name_prefix)-0
+
+  # Sealed, not initialized
+  local sealed_status=$(kubectl exec "$(name_prefix)-0" -- vault status -format=json |
+    jq -r '.sealed' )
+  [ "${sealed_status}" == "true" ]
+
+  local init_status=$(kubectl exec "$(name_prefix)-0" -- vault status -format=json |
+    jq -r '.initialized')
+  [ "${init_status}" == "false" ]
+
+  # Replicas
+  local replicas=$(kubectl get statefulset "$(name_prefix)" --output json |
+    jq -r '.spec.replicas')
+  [ "${replicas}" == "3" ]
+
+  # Volume Mounts
+  local volumeCount=$(kubectl get statefulset "$(name_prefix)" --output json |
+    jq -r '.spec.template.spec.containers[0].volumeMounts | length')
+  [ "${volumeCount}" == "2" ]
+
+  # Volumes
+  local volumeCount=$(kubectl get statefulset "$(name_prefix)" --output json |
+    jq -r '.spec.template.spec.volumes | length')
+  [ "${volumeCount}" == "1" ]
+
+  local volume=$(kubectl get statefulset "$(name_prefix)" --output json |
+    jq -r '.spec.template.spec.volumes[0].configMap.name')
+  [ "${volume}" == "$(name_prefix)-config" ]
+
+  local privileged=$(kubectl get statefulset "$(name_prefix)" --output json |
+    jq -r '.spec.template.spec.containers[0].securityContext.privileged')
+  [ "${privileged}" == "true" ]
+
+  # Service
+  local service=$(kubectl get service "$(name_prefix)" --output json |
+    jq -r '.spec.clusterIP')
+  [ "${service}" != "None" ]
+
+  local service=$(kubectl get service "$(name_prefix)" --output json |
+    jq -r '.spec.type')
+  [ "${service}" == "ClusterIP" ]
+
+  local ports=$(kubectl get service "$(name_prefix)" --output json |
+    jq -r '.spec.ports | length')
+  [ "${ports}" == "2" ]
+
+  local ports=$(kubectl get service "$(name_prefix)" --output json |
+    jq -r '.spec.ports[0].port')
+  [ "${ports}" == "8200" ]
+
+  local ports=$(kubectl get service "$(name_prefix)" --output json |
+    jq -r '.spec.ports[1].port')
+  [ "${ports}" == "8201" ]
+
+  # Service Headless
+  local service=$(kubectl get service "$(name_prefix)-headless" --output json |
+    jq -r '.spec.clusterIP')
+  [ "${service}" = "None" ]
+
+  local ports=$(kubectl get service "$(name_prefix)-headless" --output json |
+    jq -r '.spec.ports | length')
+  [ "${ports}" == "2" ]
+
+  local ports=$(kubectl get service "$(name_prefix)-headless" --output json |
+    jq -r '.spec.ports[0].port')
+  [ "${ports}" == "8200" ]
+
+  local ports=$(kubectl get service "$(name_prefix)-headless" --output json |
+    jq -r '.spec.ports[1].port')
+  [ "${ports}" == "8201" ]
+
+  # Vault Init
+  local token=$(kubectl exec -ti "$(name_prefix)-0" -- \
+    vault operator init -format=json -n 1 -t 1 | \
+    jq -r '.unseal_keys_b64[0]')
+  [ "${token}" != "" ]
+   
+  kubectl exec -ti "$(name_prefix)-0" -- vault operator unseal ${token}
+  wait_for_ready "$(name_prefix)-0"
+
+  # Vault Raft Join
+  local pods=($(kubectl get pods --selector='app.kubernetes.io/name=vault' -o json | jq -r '.items[].metadata.name'))
+  for pod in "${pods[@]}"
+  do
+      if [[ ${pod?} != "$(name_prefix)-0" ]]
+      then
+          kubectl exec -ti ${pod} -- vault operator raft join http://$(name_prefix)-0.$(name_prefix)-headless:8200
+          sleep 5
+          kubectl exec -ti ${pod} -- vault operator unseal ${token}
+      fi
+  done
+
+  # Sealed, not initialized
+  local sealed_status=$(kubectl exec "$(name_prefix)-0" -- vault status -format=json |
+    jq -r '.sealed' )
+  [ "${sealed_status}" == "false" ]
+
+  local init_status=$(kubectl exec "$(name_prefix)-0" -- vault status -format=json |
+    jq -r '.initialized')
+  [ "${init_status}" == "true" ]
+}
+
+#cleanup
+teardown() {
+  helm delete --purge vault
+  kubectl delete --all pvc
+}

--- a/test/acceptance/values-raft.yaml
+++ b/test/acceptance/values-raft.yaml
@@ -1,0 +1,20 @@
+server:
+  ha:
+    enabled: true
+
+    raft:
+      enabled: true
+
+    config: |
+      ui = true
+      cluster_addr = "https://POD_IP:8201"
+
+      listener "tcp" {
+        tls_disable = 1
+        address = "[::]:8200"
+        cluster_address = "[::]:8201"
+      }
+
+      storage "raft" {
+        path = "/vault/data"
+      }

--- a/test/terraform/.gitignore
+++ b/test/terraform/.gitignore
@@ -1,0 +1,1 @@
+vault-helm-dev-creds.json

--- a/test/terraform/outputs.tf
+++ b/test/terraform/outputs.tf
@@ -1,7 +1,0 @@
-output "cluster_id" {
-  value = "${google_container_cluster.cluster.id}"
-}
-
-output "cluster_name" {
-  value = "${google_container_cluster.cluster.name}"
-}

--- a/test/unit/server-ha-statefulset.bats
+++ b/test/unit/server-ha-statefulset.bats
@@ -400,6 +400,19 @@ load _helpers
   [ "${actual}" = "null" ]
 }
 
+@test "server/ha-StatefulSet: can set data storage for raft" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/server-statefulset.yaml  \
+      --set 'server.ha.enabled=true' \
+      --set 'server.ha.raft.enabled=true' \
+      --set 'server.dataStorage.enabled=true' \
+      --set 'server.dataStorage.storageClass=foo' \
+      . | tee /dev/stderr |
+      yq -r '.spec.volumeClaimTemplates' | tee /dev/stderr)
+  [ "${actual}" != "null" ]
+}
+
 @test "server/ha-StatefulSet: can set storageClass" {
   cd `chart_dir`
   local actual=$(helm template \

--- a/test/unit/server-service-headless.bats
+++ b/test/unit/server-service-headless.bats
@@ -1,0 +1,169 @@
+#!/usr/bin/env bats
+
+load _helpers
+
+@test "server/Service-Headless: headless service enabled by default" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/server-service-headless.yaml \
+      --set 'server.dev.enabled=true' \
+      . | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+
+  local actual=$(helm template \
+      -x templates/server-service-headless.yaml \
+      --set 'server.ha.enabled=true' \
+      . | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+
+  local actual=$(helm template \
+      -x templates/server-service-headless.yaml \
+      --set 'server.standalone.enabled=true' \
+      . | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}
+
+@test "server/Service-Headless: disable with global.enabled false" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/server-service-headless.yaml  \
+      --set 'server.dev.enabled=true' \
+      --set 'global.enabled=false' \
+      --set 'server.service.headless.enabled=true' \
+      . | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+
+  local actual=$(helm template \
+      -x templates/server-service-headless.yaml  \
+      --set 'server.ha.enabled=true' \
+      --set 'global.enabled=false' \
+      --set 'server.service.headless.enabled=true' \
+      . | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+
+  local actual=$(helm template \
+      -x templates/server-service-headless.yaml  \
+      --set 'server.standalone.enabled=true' \
+      --set 'global.enabled=false' \
+      --set 'server.service.headless.enabled=true' \
+      . | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+}
+
+@test "server/Service-Headless: disable with server.service.headless.enabled false" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/server-service-headless.yaml  \
+      --set 'server.dev.enabled=true' \
+      --set 'server.service.headless.enabled=false' \
+      . | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+
+  local actual=$(helm template \
+      -x templates/server-service-headless.yaml  \
+      --set 'server.ha.enabled=true' \
+      --set 'server.service.headless.enabled=false' \
+      . | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+
+  local actual=$(helm template \
+      -x templates/server-service-headless.yaml  \
+      --set 'server.standalone.enabled=true' \
+      --set 'server.service.headless.enabled=false' \
+      . | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+}
+
+@test "server/Service-Headless: disable with global.enabled false server.service.headless.enabled false" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/server-service-headless.yaml  \
+      --set 'server.dev.enabled=true' \
+      --set 'global.enabled=false' \
+      --set 'server.service.headless.enabled=false' \
+      . | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+
+  local actual=$(helm template \
+      -x templates/server-service-headless.yaml  \
+      --set 'server.ha.enabled=true' \
+      --set 'global.enabled=false' \
+      --set 'server.service.headless.enabled=false' \
+      . | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+
+  local actual=$(helm template \
+      -x templates/server-service-headless.yaml  \
+      --set 'server.standalone.enabled=true' \
+      --set 'global.enabled=false' \
+      --set 'server.service.headless.enabled=false' \
+      . | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+}
+
+@test "server/Service-Headless: clusterIP is None by default" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/server-service-headless.yaml \
+      --set 'server.dev.enabled=true' \
+      . | tee /dev/stderr |
+      yq -r '.spec.clusterIP' | tee /dev/stderr)
+  [ "${actual}" = "None" ]
+
+  local actual=$(helm template \
+      -x templates/server-service-headless.yaml \
+      --set 'server.ha.enabled=true' \
+      . | tee /dev/stderr |
+      yq -r '.spec.clusterIP' | tee /dev/stderr)
+  [ "${actual}" = "None" ]
+
+  local actual=$(helm template \
+      -x templates/server-service-headless.yaml \
+      . | tee /dev/stderr |
+      yq -r '.spec.clusterIP' | tee /dev/stderr)
+  [ "${actual}" = "None" ]
+}
+
+@test "server/Service-Headless: port and targetPort will be 8200 by default" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/server-service-headless.yaml \
+      . | tee /dev/stderr |
+      yq -r '.spec.ports[0].port' | tee /dev/stderr)
+  [ "${actual}" = "8200" ]
+
+  local actual=$(helm template \
+      -x templates/server-service-headless.yaml \
+      . | tee /dev/stderr |
+      yq -r '.spec.ports[0].targetPort' | tee /dev/stderr)
+  [ "${actual}" = "8200" ]
+}
+
+@test "server/Service-Headless: port and targetPort can be set" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/server-service-headless.yaml \
+      --set 'server.service.port=8000' \
+      . | tee /dev/stderr |
+      yq -r '.spec.ports[0].port' | tee /dev/stderr)
+  [ "${actual}" = "8000" ]
+
+  local actual=$(helm template \
+      -x templates/server-service-headless.yaml \
+      --set 'server.service.targetPort=80' \
+      . | tee /dev/stderr |
+      yq -r '.spec.ports[0].targetPort' | tee /dev/stderr)
+  [ "${actual}" = "80" ]
+}

--- a/test/unit/server-service.bats
+++ b/test/unit/server-service.bats
@@ -187,32 +187,6 @@ load _helpers
   [ "${actual}" = "null" ]
 }
 
-@test "server/Service: clusterIP can set" {
-  cd `chart_dir`
-  local actual=$(helm template \
-      -x templates/server-service.yaml \
-      --set 'server.dev.enabled=true' \
-      --set 'server.service.clusterIP=None' \
-      . | tee /dev/stderr |
-      yq -r '.spec.clusterIP' | tee /dev/stderr)
-  [ "${actual}" = "None" ]
-
-  local actual=$(helm template \
-      -x templates/server-service.yaml \
-      --set 'server.ha.enabled=true' \
-      --set 'server.service.clusterIP=None' \
-      . | tee /dev/stderr |
-      yq -r '.spec.clusterIP' | tee /dev/stderr)
-  [ "${actual}" = "None" ]
-
-  local actual=$(helm template \
-      -x templates/server-service.yaml \
-      --set 'server.service.clusterIP=None' \
-      . | tee /dev/stderr |
-      yq -r '.spec.clusterIP' | tee /dev/stderr)
-  [ "${actual}" = "None" ]
-}
-
 @test "server/Service: port and targetPort will be 8200 by default" {
   cd `chart_dir`
   local actual=$(helm template \

--- a/values.yaml
+++ b/values.yaml
@@ -147,6 +147,7 @@ server:
     # using a stateful set. This should be HCL.
     config: |
       ui = true
+      cluster_addr = https://$POD_IP:8201
 
       listener "tcp" {
         tls_disable = 1
@@ -176,20 +177,23 @@ server:
     enabled: false
     replicas: 3
 
+    raft:
+      enabled: true
+
     # config is a raw string of default configuration when using a Stateful
     # deployment. Default is to use a Consul for its HA storage backend.
     # This should be HCL.
     config: |
       ui = true
+      cluster_addr = "https://POD_IP:8201"
 
       listener "tcp" {
         tls_disable = 1
         address = "[::]:8200"
         cluster_address = "[::]:8201"
       }
-      storage "consul" {
-        path = "vault"
-        address = "HOST_IP:8500"
+      storage "raft" {
+        path = "/vault/data"
       }
 
       # Example configuration for using auto-unseal, using Google Cloud KMS. The

--- a/values.yaml
+++ b/values.yaml
@@ -85,13 +85,12 @@ server:
   # Enables a headless service to be used by the Vault Statefulset
   service:
     enabled: true
-    # clusterIP controls whether a Cluster IP address is attached to the
-    # Vault service within Kubernetes.  By default the Vault service will
-    # be given a Cluster IP address, set to None to disable.  When disabled
-    # Kubernetes will create a "headless" service.  Headless services can be
-    # used to communicate with pods directly through DNS instead of a round robin
-    # load balancer.
-    # clusterIP: None
+
+    # Headless service allows pods within the statefulset to find and communicate 
+    # with each other.  This is important for replication architectures (HA deployment 
+    # and Raft). 
+    headless:
+      enabled: true
 
     # Port on which Vault server is listening
     port: 8200
@@ -147,7 +146,6 @@ server:
     # using a stateful set. This should be HCL.
     config: |
       ui = true
-      cluster_addr = https://$POD_IP:8201
 
       listener "tcp" {
         tls_disable = 1
@@ -176,9 +174,10 @@ server:
   ha:
     enabled: false
     replicas: 3
-
+    
+    # Enables the tech preview of Raft storage
     raft:
-      enabled: true
+      enabled: false
 
     # config is a raw string of default configuration when using a Stateful
     # deployment. Default is to use a Consul for its HA storage backend.
@@ -192,8 +191,10 @@ server:
         address = "[::]:8200"
         cluster_address = "[::]:8201"
       }
-      storage "raft" {
-        path = "/vault/data"
+
+      storage "consul" {
+        path = "vault"
+        address = "HOST_IP:8500"
       }
 
       # Example configuration for using auto-unseal, using Google Cloud KMS. The


### PR DESCRIPTION
This adds tentative support for Raft storage in Vault Helm.  This required allowing HA mode to create PVCs during installation for persistence needs (we were relying on external HA storage before, so creating PVCs as disabled in HA mode).

Additionally there was a problem with the StatefulSet.  Long story short, the StatefulSet needs to know how to lookup the other Vault pods in the set.  To do this we require a headless service to be used for DNS purposes (regular services do not suffice here because they round robin load balance).  This means we will now have two services (configurable): one for our internal DNS uses (raft) and the other for ingress/load balance/cluster traffic.