### PR TITLE
Server additional labels

### DIFF
--- a/templates/server-statefulset.yaml
+++ b/templates/server-statefulset.yaml
@@ -30,6 +30,9 @@ spec:
         app.kubernetes.io/name: {{ template "vault.name" . }}
         app.kubernetes.io/instance: {{ .Release.Name }}
         component: server
+        {{- if  .Values.server.extraLabels -}}
+          {{- toYaml .Values.server.extraLabels | nindent 8 -}}
+        {{- end -}}
       {{ template "vault.annotations" . }}
     spec:
       {{ template "vault.affinity" . }}

--- a/test/unit/server-statefulset.bats
+++ b/test/unit/server-statefulset.bats
@@ -510,3 +510,16 @@ load _helpers
       yq -r '.spec.template.spec.nodeSelector' | tee /dev/stderr)
   [ "${actual}" = "testing" ]
 }
+
+#--------------------------------------------------------------------
+# extra labels
+
+@test "server/standalone-StatefulSet: specify extraLabels" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/server-statefulset.yaml \
+      --set 'server.extraLabels.foo=bar' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.metadata.labels.foo' | tee /dev/stderr)
+  [ "${actual}" = "bar" ]
+}

--- a/values.yaml
+++ b/values.yaml
@@ -95,6 +95,11 @@ server:
   #   beta.kubernetes.io/arch: amd64
   nodeSelector: {}
 
+  # Extra labels to attach to the server pods
+  # This should be a multi-line string mapping directly to the a map of
+  # the labels to apply to the server pods
+  extraLabels: {}
+
   # Extra annotations to attach to the server pods
   # This should be a multi-line string mapping directly to the a map of
   # the annotations to apply to the server pods


### PR DESCRIPTION
Hello.

Added possibility to add extra labels for server pods.
It is neccessary if you want for example add `AAD Pod Identity` to Vault pods coz [it depends on labels](https://github.com/Azure/aad-pod-identity#5-install-the-azure-identity-binding).

Also i fixed `ui/Service: specify annotations` test. 
There checked if annotation exist although it shouldn't because of dev-mode.