### PR TITLE
feat: add support for specifying loadBalancerSourceRanges on UI service

### DIFF
--- a/templates/ui-service.yaml
+++ b/templates/ui-service.yaml
@@ -33,6 +33,11 @@ spec:
   {{- if and (eq (.Values.ui.serviceType | toString) "LoadBalancer") (.Values.ui.loadBalancerIP) }}
   loadBalancerIP: {{ .Values.ui.loadBalancerIP }}
   {{- end }}
+  {{- if and (eq (.Values.ui.serviceType | toString) "LoadBalancer") (.Values.ui.loadBalancerSourceRanges) }}
+  loadBalancerSourceRanges:
+    {{- range .Values.ui.loadBalancerSourceRanges | default "[]" }}
+    - {{ . | toString }}
+    {{- end }}
+  {{- end }}
 {{- end -}}
-
 {{ end }}

--- a/test/unit/ui-service.bats
+++ b/test/unit/ui-service.bats
@@ -133,6 +133,29 @@ load _helpers
   [ "${actual}" = "null" ]
 }
 
+@test "ui/Service: loadBalancerSourceRanges set if specified and serviceType == LoadBalancer" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/ui-service.yaml  \
+      --set 'server.dev.enabled=true' \
+      --set 'ui.serviceType=LoadBalancer' \
+      --set 'ui.enabled=true' \
+      --set 'ui.loadBalancerSourceRanges={"123.123.123.123"}' \
+      . | tee /dev/stderr |
+      yq -r '.spec.loadBalancerSourceRanges[0]' | tee /dev/stderr)
+  [ "${actual}" = "123.123.123.123" ]
+
+  local actual=$(helm template \
+      -x templates/ui-service.yaml  \
+      --set 'server.dev.enabled=true' \
+      --set 'ui.serviceType=ClusterIP' \
+      --set 'ui.enabled=true' \
+      --set 'ui.loadBalancerSourceRanges={"123.123.123.123"}' \
+      . | tee /dev/stderr |
+      yq -r '.spec.loadBalancerSourceRanges[0]' | tee /dev/stderr)
+  [ "${actual}" = "null" ]
+}
+
 @test "ui/Service: specify annotations" {
   cd `chart_dir`
   local actual=$(helm template \


### PR DESCRIPTION
I am currently working under a set of requirements that require me to be able to white list IPs that have access to Vault.

This PR adds support for adding a loadBalancerSourceRanges array to the UI service when it is of `type: LoadBalancer`.