### PR TITLE
build: add circleci config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,13 @@
+version: 2
+jobs:
+  bats-unit-test:
+    machine: true
+    steps:
+      - checkout
+      - run: make test-image
+      - run: make test-unit
+workflows:
+  version: 2
+  build_and_test:
+    jobs:
+      - bats-unit-test 


### PR DESCRIPTION
Adds a circleci configuration for executing bats unit tests. Acceptance tests will require more care in CI and will come in a later PR. 