### PR TITLE
Add support for setting service type

### DIFF
--- a/templates/server-service.yaml
+++ b/templates/server-service.yaml
@@ -19,6 +19,9 @@ metadata:
 {{ toYaml .Values.server.service.annotations | indent 4 }}
 {{- end }}
 spec:
+  {{- if .Values.server.service.type}}
+  type: {{ .Values.server.service.type }}
+  {{- end}}
   {{- if .Values.server.service.clusterIP }}
   clusterIP: {{ .Values.server.service.clusterIP }}
   {{- end }}

--- a/test/unit/server-service.bats
+++ b/test/unit/server-service.bats
@@ -164,6 +164,55 @@ load _helpers
   [ "${actual}" = "true" ]
 }
 
+@test "server/Service: type empty by default" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/server-service.yaml \
+      --set 'server.dev.enabled=true' \
+      . | tee /dev/stderr |
+      yq -r '.spec.type' | tee /dev/stderr)
+  [ "${actual}" = "null" ]
+
+    local actual=$(helm template \
+      -x templates/server-service.yaml \
+      --set 'server.ha.enabled=true' \
+      . | tee /dev/stderr |
+      yq -r '.spec.type' | tee /dev/stderr)
+  [ "${actual}" = "null" ]
+
+  local actual=$(helm template \
+      -x templates/server-service.yaml \
+      . | tee /dev/stderr |
+      yq -r '.spec.type' | tee /dev/stderr)
+  [ "${actual}" = "null" ]
+}
+
+@test "server/Service: type can set" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/server-service.yaml \
+      --set 'server.dev.enabled=true' \
+      --set 'server.service.type=NodePort' \
+      . | tee /dev/stderr |
+      yq -r '.spec.type' | tee /dev/stderr)
+  [ "${actual}" = "NodePort" ]
+
+  local actual=$(helm template \
+      -x templates/server-service.yaml \
+      --set 'server.ha.enabled=true' \
+      --set 'server.service.type=NodePort' \
+      . | tee /dev/stderr |
+      yq -r '.spec.type' | tee /dev/stderr)
+  [ "${actual}" = "NodePort" ]
+
+  local actual=$(helm template \
+      -x templates/server-service.yaml \
+      --set 'server.service.type=NodePort' \
+      . | tee /dev/stderr |
+      yq -r '.spec.type' | tee /dev/stderr)
+  [ "${actual}" = "NodePort" ]
+}
+
 @test "server/Service: clusterIP empty by default" {
   cd `chart_dir`
   local actual=$(helm template \


### PR DESCRIPTION
Allow users to set different [service types](https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types). 

Currently there is not service type set so it defaults to `ClusterIp`. We setup our ingresses in such a way that they [require services to be of type NodePort](https://kubernetes-sigs.github.io/aws-alb-ingress-controller/guide/controller/how-it-works/#instance-mode). 

Also, thank you for this project! I'm really excited about it.

Note: looks like there's a failing ui annotations test which is addressed in #59, I'm happy to merge with master once it makes its way in. 