### PR TITLE
Allow annotations on UI dev service

### DIFF
--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -253,7 +253,7 @@ Sets extra pod annotations
 Sets extra ui service annotations
 */}}
 {{- define "vault.ui.annotations" -}}
-  {{- if and (ne .mode "dev") .Values.ui.annotations }}
+  {{- if .Values.ui.annotations }}
   annotations:
     {{- toYaml .Values.ui.annotations | nindent 4 }}
   {{- end }}


### PR DESCRIPTION
Removing opinionated logic that didn't allow annotations to be set on the UI service if running in dev mode.  There are use cases where annotations are required for dev mode (such as ingress) so this didn't make sense.

This fixes a busted test that was failing because the annotation was being rejected.