### PR TITLE
Add CircleCI publish step for

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,6 +37,6 @@ workflows:
           requires:
             - bats-unit-test
           context: publish
-          # filters:
-          #   branches:
-          #     only: master
+          filters:
+            branches:
+              only: master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,8 +6,36 @@ jobs:
       - checkout
       - run: make test-image
       - run: make test-unit
+  publish:
+    docker:
+      - image: $DOCKER_REGISTRY_URL/circleci-kubernetes:3
+        auth:
+          username: $DOCKER_REGISTRY_USERNAME
+          password: $DOCKER_REGISTRY_PASSWORD
+    steps:
+      - checkout
+      - run: 
+          name: Install and initialize helm
+          command: |
+            curl https://storage.googleapis.com/kubernetes-helm/helm-v2.14.0-linux-386.tar.gz | tar xvz
+            curl -fL https://getcli.jfrog.io | sh
+            ./linux-386/helm init --client-only
+      - run: 
+          name: Upload helm-vault to helm repo
+          command: |
+            ./linux-386/helm package .
+            ./jfrog rt upload *.tgz / --url https://takescoop.jfrog.io/takescoop/helm-local --user $DOCKER_REGISTRY_USERNAME --apikey $DOCKER_REGISTRY_PASSWORD
+          environment:
+            JFROG_CLI_OFFER_CONFIG: false
 workflows:
   version: 2
   build_and_test:
     jobs:
-      - bats-unit-test 
+      - bats-unit-test
+      - publish:
+          requires:
+            - bats-unit-test
+          context: publish
+          # filters:
+          #   branches:
+          #     only: master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,6 +12,7 @@ jobs:
         auth:
           username: $DOCKER_REGISTRY_USERNAME
           password: $DOCKER_REGISTRY_PASSWORD
+    working_directory: /vault
     steps:
       - checkout
       - run: 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,7 @@ jobs:
             curl -fL https://getcli.jfrog.io | sh
             ./linux-386/helm init --client-only
       - run: 
-          name: Upload helm-vault to helm repo
+          name: Upload vault-helm to helm repo
           command: |
             ./linux-386/helm package .
             ./jfrog rt upload *.tgz / --url https://takescoop.jfrog.io/takescoop/helm-local --user $DOCKER_REGISTRY_USERNAME --apikey $DOCKER_REGISTRY_PASSWORD

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -7,3 +7,4 @@ icon: https://github.com/hashicorp/vault/raw/f22d202cde2018f9455dec755118a9b8458
 sources:
   - https://github.com/hashicorp/vault
   - https://github.com/hashicorp/vault-helm
+  - https://github.com/takescoop/vault-helm

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Vault Helm Chart
+# Vault Helm Chart [![CircleCI](https://circleci.com/gh/TakeScoop/vault-helm/tree/master.svg?style=svg)](https://circleci.com/gh/TakeScoop/vault-helm/tree/master)
 
 This repository contains the official HashiCorp Helm chart for installing
 and configuring Vault on Kubernetes. This chart supports multiple use

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Vault Helm Chart [![CircleCI](https://circleci.com/gh/TakeScoop/vault-helm/tree/master.svg?style=svg)](https://circleci.com/gh/TakeScoop/vault-helm/tree/master)
 
+**Maintainer:** [@ryanwholey](github.com/ryanwholey)
+
 This repository contains the official HashiCorp Helm chart for installing
 and configuring Vault on Kubernetes. This chart supports multiple use
 cases of Vault on Kubernetes depending on the values provided.


### PR DESCRIPTION
Publishes the scoop vault helm chart to our artifactory repository because hashicorp [are not publishing to a helm repository at the moment](https://github.com/hashicorp/vault-helm#usage).