### PR TITLE
Add support for helm-init

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: vault
-version: 0.1.2
+version: 0.1.3
 description: Install and configure Vault on Kubernetes.
 home: https://www.vaultproject.io
 icon: https://github.com/hashicorp/vault/raw/f22d202cde2018f9455dec755118a9b84586e082/Vault_PrimaryLogo_Black.png

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -270,6 +270,21 @@ Sets extra service account annotations
 {{- end -}}
 
 {{/*
+Adds vault-init container for automated initialization and unsealing on Google Cloud Platform
+*/}}
+{{- define "vault.vault_init" -}}
+- name: vault-init
+  image: "{{ .Values.vault_init.image }}"
+  {{- if .Values.vault_init.resources -}}
+  resources:
+{{ toYaml .Values.vault_init.resources | indent 12}}
+  {{- end }}
+  {{- if .Values.vault_init.env -}}
+{{ toYaml .Values.vault_init.EnvironmentVars | indent 10}}
+  {{- end }}
+{{- end -}}
+
+{{/*
 Set's the container resources if the user has set any.
 */}}
 {{- define "vault.resources" -}}

--- a/templates/server-statefulset.yaml
+++ b/templates/server-statefulset.yaml
@@ -42,6 +42,9 @@ spec:
       volumes:
         {{ template "vault.volumes" . }}
       containers:
+        {{- if eq (.Values.vault_init.enabled | toString) "true" }}
+        {{ template "vault.vault_init" . }}
+        {{- end }}
         - name: vault
           {{ template "vault.resources" . }}
           {{- if eq (.Values.server.mlock.enabled | toString) "true" }}

--- a/templates/ui-service.yaml
+++ b/templates/ui-service.yaml
@@ -32,6 +32,7 @@ spec:
   type: {{ .Values.ui.serviceType }}
   {{- if and (eq (.Values.ui.serviceType | toString) "LoadBalancer") (.Values.ui.loadBalancerIP) }}
   loadBalancerIP: {{ .Values.ui.loadBalancerIP }}
+  externalTrafficPolicy: {{ .Values.ui.externalTrafficPolicy }}
   {{- end }}
 {{- end -}}
 

--- a/values.yaml
+++ b/values.yaml
@@ -40,7 +40,6 @@ server:
     #    hosts:
     #      - chart-example.local
 
-
   # authDelegator enables a cluster role binding to be attached to the service
   # account.  This cluster role binding can be used to setup Kubernetes auth
   # method.  https://www.vaultproject.io/docs/auth/kubernetes.html
@@ -117,7 +116,7 @@ server:
     targetPort: 8200
     # Extra annotations for the service definition
     annotations: {}
-    
+
   # This configures the Vault Statefulset to create a PVC for data
   # storage when using the file backend.
   # See https://www.vaultproject.io/docs/audit/index.html to know more
@@ -234,8 +233,8 @@ server:
   # Definition of the serviceaccount used to run Vault.
   serviceaccount:
     annotations: {}
-  
-  # mlock prevents memory from being swapped to disk.  If swap is enabled this should 
+
+  # mlock prevents memory from being swapped to disk.  If swap is enabled this should
   # be true.
   mlock:
     enabled: true
@@ -251,9 +250,24 @@ ui:
   serviceType: "ClusterIP"
   serviceNodePort: null
   externalPort: 8200
+  externalTrafficPolicy: Cluster
   # loadBalancerIP:
 
   # Extra annotations to attach to the ui service
   # This should be a multi-line string mapping directly to the a map of
   # the annotations to apply to the ui service
   annotations: {}
+
+# Vault-init for Google Cloud Platform
+vault_init:
+  # The vault-init service automates the process of initializing and unsealing HashiCorp Vault
+  # instances running on Google Cloud Platform.
+  # After vault-init initializes a Vault server it stores master keys and root tokens
+  # encrypted using Google Cloud KMS, to a user defined Google Cloud Storage bucket.
+  enabled: false
+  image: "vault-init:latest"
+  resources:
+    requests:
+      cpu: "100m"
+      memory: "64Mi"
+  EnvironmentVars: []


### PR DESCRIPTION
Adds support for Seth Vargo's helm-init image, which automates the process of initializing and unsealing HashiCorp Vault instances running Google Cloud Platform.

After vault-init initializes a Vault server, it stores master keys and root tokens which is encrypted using Google Cloud KMS, to a user defined Google Cloud Storage bucket.