### PR TITLE
Fix affinity labels in values

### DIFF
--- a/values.yaml
+++ b/values.yaml
@@ -78,8 +78,8 @@ server:
       requiredDuringSchedulingIgnoredDuringExecution:
         - labelSelector:
             matchLabels:
-              app: {{ template "vault.name" . }}
-              release: "{{ .Release.Name }}"
+              app.kubernetes.io/name: {{ template "vault.name" . }}
+              app.kubernetes.io/instance: "{{ .Release.Name }}"
               component: server
           topologyKey: kubernetes.io/hostname
 


### PR DESCRIPTION
#73 when the old style of Helm labels were replaced with the newer `app.kubernetes.io` labels, the affinity rules were not updated to reflect this change.  This updates the labels to be correct which enforces the rule.