### PR TITLE
Fix audit storage mount in HA mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,5 +6,7 @@ terraform.tfvars
 values.dev.yaml
 vaul-helm-dev-creds.json
 ./test/acceptance/vaul-helm-dev-creds.json
+./test/terraform/vaul-helm-dev-creds.json
+./test/unit/vaul-helm-dev-creds.json
 ./test/acceptance/values.yaml
 ./test/acceptance/values.yml

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -150,11 +150,11 @@ Set's which additional volumes should be mounted to the container
 based on the mode configured.
 */}}
 {{- define "vault.mounts" -}}
-  {{ if eq .mode "standalone" }}
-    {{ if eq (.Values.server.auditStorage.enabled | toString) "true" }}
+  {{ if eq (.Values.server.auditStorage.enabled | toString) "true" }}
             - name: audit
               mountPath: /vault/audit
-    {{ end }}
+  {{ end }}
+  {{ if eq .mode "standalone" }}
     {{ if eq (.Values.server.dataStorage.enabled | toString) "true" }}
             - name: data
               mountPath: /vault/data

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -76,17 +76,6 @@ Set's the replica count based on the different modes configured by user
 {{- end -}}
 
 {{/*
-Set's fsGroup based on different modes.  Standalone is the only mode
-that requires fsGroup at this time because it uses PVC for the file
-storage backend.
-*/}}
-{{- define "vault.fsgroup" -}}
-  {{ if eq .mode "standalone" }}
-    {{- .Values.server.storageFsGroup | default 1000 -}}
-  {{ end }}
-{{- end -}}
-
-{{/*
 Set's up configmap mounts if this isn't a dev deployment and the user
 defined a custom configuration.  Additionally iterates over any
 extra volumes the user may have specified (such as a secret with TLS).
@@ -130,7 +119,6 @@ for users looking to use this chart with Consul Helm.
           - |
             sed -E "s/HOST_IP/${HOST_IP?}/g" /vault/config/extraconfig-from-values.hcl > /tmp/storageconfig.hcl;
             sed -Ei "s/POD_IP/${POD_IP?}/g" /tmp/storageconfig.hcl;
-            chown vault:vault /tmp/storageconfig.hcl;
             /usr/local/bin/docker-entrypoint.sh vault server -config=/tmp/storageconfig.hcl
   {{ end }}
 {{- end -}}

--- a/templates/server-statefulset.yaml
+++ b/templates/server-statefulset.yaml
@@ -41,7 +41,7 @@ spec:
       terminationGracePeriodSeconds: 10
       serviceAccountName: {{ template "vault.fullname" . }}
       securityContext:
-        fsGroup: {{ template "vault.fsgroup" . }}
+        fsGroup: 1000
       volumes:
         {{ template "vault.volumes" . }}
       containers:

--- a/test/unit/server-ha-statefulset.bats
+++ b/test/unit/server-ha-statefulset.bats
@@ -434,6 +434,16 @@ load _helpers
   [ "${actual}" = "1" ]
 }
 
+@test "server/ha-StatefulSet: can mount audit" {
+  cd `chart_dir`
+  local object=$(helm template \
+      -x templates/server-statefulset.yaml  \
+      --set 'server.ha.enabled=true' \
+      --set 'server.auditStorage.enabled=true' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.containers[0].volumeMounts[] | select(.name == "audit")' | tee /dev/stderr)
+}
+
 @test "server/ha-StatefulSet: no data storage" {
   cd `chart_dir`
   local actual=$(helm template \

--- a/test/unit/server-statefulset.bats
+++ b/test/unit/server-statefulset.bats
@@ -282,6 +282,15 @@ load _helpers
   [ "${actual}" = "/vault/userconfig/foo" ]
 }
 
+@test "server/standalone-StatefulSet: can mount audit" {
+  cd `chart_dir`
+  local object=$(helm template \
+      -x templates/server-statefulset.yaml  \
+      --set 'server.auditStorage.enabled=true' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.containers[0].volumeMounts[] | select(.name == "audit")' | tee /dev/stderr)
+}
+
 #--------------------------------------------------------------------
 # extraEnvironmentVars
 


### PR DESCRIPTION
Addressed #75 by allowing audit storage to be mounted in HA mode.  The volumeClaimTemplate was being populated but the volumes were not being mounted to the pods.