### PR TITLE
Add load balancer source range for UI service

### DIFF
--- a/templates/ui-service.yaml
+++ b/templates/ui-service.yaml
@@ -30,6 +30,11 @@ spec:
       nodePort: {{ .Values.ui.serviceNodePort }}
       {{- end }}
   type: {{ .Values.ui.serviceType }}
+  loadBalancerSourceRanges:
+    {{- range $cidr := .Values.ui.loadBalancerSourceRanges }}
+      - {{ $cidr }}
+    {{- end }}
+  {{- end }}
   {{- if and (eq (.Values.ui.serviceType | toString) "LoadBalancer") (.Values.ui.loadBalancerIP) }}
   loadBalancerIP: {{ .Values.ui.loadBalancerIP }}
   {{- end }}

--- a/templates/ui-service.yaml
+++ b/templates/ui-service.yaml
@@ -30,6 +30,7 @@ spec:
       nodePort: {{ .Values.ui.serviceNodePort }}
       {{- end }}
   type: {{ .Values.ui.serviceType }}
+  {{- if and (eq (.Values.ui.serviceType | toString) "LoadBalancer") (.Values.ui.loadBalancerSourceRanges) }}
   loadBalancerSourceRanges:
     {{- range $cidr := .Values.ui.loadBalancerSourceRanges }}
       - {{ $cidr }}

--- a/test/unit/ui-service.bats
+++ b/test/unit/ui-service.bats
@@ -133,6 +133,29 @@ load _helpers
   [ "${actual}" = "null" ]
 }
 
+@test "ui/Service: set loadBalancerSourceRanges when LoadBalancer is configured as serviceType == " {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/ui-service.yaml  \
+      --set 'server.dev.enabled=true' \
+      --set 'ui.serviceType=LoadBalancer' \
+      --set 'ui.enabled=true' \
+      --set 'ui.loadBalancerSourceRanges={"123.123.123.123"}' \
+      . | tee /dev/stderr |
+      yq -r '.spec.loadBalancerSourceRanges[0]' | tee /dev/stderr)
+  [ "${actual}" = "123.123.123.123" ]
+
+  local actual=$(helm template \
+      -x templates/ui-service.yaml  \
+      --set 'server.dev.enabled=true' \
+      --set 'ui.serviceType=ClusterIP' \
+      --set 'ui.enabled=true' \
+      --set 'ui.loadBalancerSourceRanges={"123.123.123.123"}' \
+      . | tee /dev/stderr |
+      yq -r '.spec.loadBalancerSourceRanges[0]' | tee /dev/stderr)
+  [ "${actual}" = "null" ]
+}
+
 @test "ui/Service: specify annotations" {
   cd `chart_dir`
   local actual=$(helm template \

--- a/test/unit/ui-service.bats
+++ b/test/unit/ui-service.bats
@@ -133,7 +133,7 @@ load _helpers
   [ "${actual}" = "null" ]
 }
 
-@test "ui/Service: set loadBalancerSourceRanges when LoadBalancer is configured as serviceType == " {
+@test "ui/Service: set loadBalancerSourceRanges when LoadBalancer is configured as serviceType" {
   cd `chart_dir`
   local actual=$(helm template \
       -x templates/ui-service.yaml  \

--- a/values.yaml
+++ b/values.yaml
@@ -256,6 +256,11 @@ ui:
   serviceType: "ClusterIP"
   serviceNodePort: null
   externalPort: 8200
+
+  # loadBalancerSourceRanges:
+  #   - 10.0.0.0/16
+  #   - 1.78.23.3/32
+
   # loadBalancerIP:
 
   # Extra annotations to attach to the ui service


### PR DESCRIPTION
Configure the UI service so that it is able to be locked down to specified source IPs if specified. This same logic or similar should be added into all the services.