### PR TITLE
Remove readOnlyRootFilesystem from securityContext

### DIFF
--- a/templates/server-statefulset.yaml
+++ b/templates/server-statefulset.yaml
@@ -41,7 +41,6 @@ spec:
       terminationGracePeriodSeconds: 10
       serviceAccountName: {{ template "vault.fullname" . }}
       securityContext:
-        readOnlyRootFilesystem: true
         runAsNonRoot: true
         runAsGroup: {{ .Values.server.gid | default 1000 }}
         runAsUser: {{ .Values.server.uid | default 100 }}


### PR DESCRIPTION
This is a psp restriction rather than something we set here.