### PR TITLE
Add support for image pull policy and secrets

### DIFF
--- a/templates/server-statefulset.yaml
+++ b/templates/server-statefulset.yaml
@@ -55,6 +55,7 @@ spec:
             capabilities:
               add: ["IPC_LOCK"]
           image: "{{ .Values.global.image }}"
+          imagePullPolicy: {{ .Values.global.imagePullPolicy }}
           command: {{ template "vault.command" . }}
           args: {{ template "vault.args" . }}
           env:
@@ -99,5 +100,9 @@ spec:
             periodSeconds: 3
             successThreshold: 1
             timeoutSeconds: 5
+      {{- if .Values.global.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml .Values.global.imagePullSecrets | nindent 8 }}
+      {{- end }}
   {{ template "vault.volumeclaims" . }}
 {{ end }}

--- a/test/unit/server-statefulset.bats
+++ b/test/unit/server-statefulset.bats
@@ -50,6 +50,53 @@ load _helpers
   [ "${actual}" = "foo" ]
 }
 
+@test "server/standalone-StatefulSet: default imagePullPolicy" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/server-statefulset.yaml  \
+      --set 'global.image=foo' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.containers[0].imagePullPolicy' | tee /dev/stderr)
+  [ "${actual}" = "IfNotPresent" ]
+}
+
+@test "server/standalone-StatefulSet: Custom imagePullPolicy" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/server-statefulset.yaml  \
+      --set 'global.imagePullPolicy=foo' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.containers[0].imagePullPolicy' | tee /dev/stderr)
+  [ "${actual}" = "foo" ]
+}
+
+@test "server/standalone-StatefulSet: Custom imagePullSecrets" {
+  cd `chart_dir`
+  local object=$(helm template \
+      -x templates/server-statefulset.yaml  \
+      --set 'global.imagePullSecrets[0].name=foo' \
+      --set 'global.imagePullSecrets[1].name=bar' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.imagePullSecrets' | tee /dev/stderr)
+
+  local actual=$(echo $object |
+     yq -r '.[0].name' | tee /dev/stderr)
+  [ "${actual}" = "foo" ]
+
+  local actual=$(echo $object |
+      yq -r '.[1].name' | tee /dev/stderr)
+  [ "${actual}" = "bar" ]
+}
+
+@test "server/standalone-StatefulSet: default imagePullSecrets" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/server-statefulset.yaml  \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.imagePullSecrets' | tee /dev/stderr)
+  [ "${actual}" = "null" ]
+}
+
 #--------------------------------------------------------------------
 # updateStrategy
 

--- a/values.yaml
+++ b/values.yaml
@@ -7,6 +7,12 @@ global:
 
   # Image is the name (and tag) of the Vault Docker image.
   image: "vault:1.2.2"
+  # Overrides the default Image Pull Policy
+  imagePullPolicy: IfNotPresent
+  # Image pull secret to use for registry authentication.
+  imagePullSecrets: []
+  # imagePullSecrets:
+  #   - name: image-pull-secret
   # TLS for end-to-end encrypted transport
   tlsDisable: true
 


### PR DESCRIPTION
This PR adds support for `imagePullPolicy` and `imagePullSecrets`.

Closes https://github.com/hashicorp/vault-helm/issues/84

Signed-off-by: Janusz Bialy <jbialy@gmail.com>