### PR TITLE
Make readOnlyRootFilesystem configurable

### DIFF
--- a/templates/server-statefulset.yaml
+++ b/templates/server-statefulset.yaml
@@ -41,7 +41,9 @@ spec:
       terminationGracePeriodSeconds: 10
       serviceAccountName: {{ template "vault.fullname" . }}
       securityContext:
+        {{- if .Values.server.securityContext.readOnlyRootFilesystem }}
         readOnlyRootFilesystem: true
+        {{- end }}
         runAsNonRoot: true
         runAsGroup: {{ .Values.server.gid | default 1000 }}
         runAsUser: {{ .Values.server.uid | default 100 }}

--- a/test/unit/server-dev-statefulset.bats
+++ b/test/unit/server-dev-statefulset.bats
@@ -314,7 +314,7 @@ load _helpers
 
 #--------------------------------------------------------------------
 # Security Contexts
-@test "server/standalone-StatefulSet: uid default" {
+@test "server/dev-StatefulSet: uid default" {
   cd `chart_dir`
   local actual=$(helm template \
       -x templates/server-statefulset.yaml \
@@ -324,7 +324,7 @@ load _helpers
   [ "${actual}" = "100" ]
 }
 
-@test "server/standalone-StatefulSet: uid configurable" {
+@test "server/dev-StatefulSet: uid configurable" {
   cd `chart_dir`
   local actual=$(helm template \
       -x templates/server-statefulset.yaml \
@@ -335,7 +335,7 @@ load _helpers
   [ "${actual}" = "2000" ]
 }
 
-@test "server/standalone-StatefulSet: gid default" {
+@test "server/dev-StatefulSet: gid default" {
   cd `chart_dir`
   local actual=$(helm template \
       -x templates/server-statefulset.yaml \
@@ -345,7 +345,7 @@ load _helpers
   [ "${actual}" = "1000" ]
 }
 
-@test "server/standalone-StatefulSet: gid configurable" {
+@test "server/dev-StatefulSet: gid configurable" {
   cd `chart_dir`
   local actual=$(helm template \
       -x templates/server-statefulset.yaml \
@@ -356,7 +356,7 @@ load _helpers
   [ "${actual}" = "2000" ]
 }
 
-@test "server/standalone-StatefulSet: fsgroup default" {
+@test "server/dev-StatefulSet: fsgroup default" {
   cd `chart_dir`
   local actual=$(helm template \
       -x templates/server-statefulset.yaml \
@@ -366,7 +366,7 @@ load _helpers
   [ "${actual}" = "1000" ]
 }
 
-@test "server/standalone-StatefulSet: fsgroup configurable" {
+@test "server/dev-StatefulSet: fsgroup configurable" {
   cd `chart_dir`
   local actual=$(helm template \
       -x templates/server-statefulset.yaml \
@@ -375,4 +375,25 @@ load _helpers
       . | tee /dev/stderr |
       yq -r '.spec.template.spec.securityContext.fsGroup' | tee /dev/stderr)
   [ "${actual}" = "2000" ]
+}
+
+@test "server/dev-StatefulSet: readOnlyRootFilesystem default" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/server-statefulset.yaml \
+      --set 'server.dev.enabled=true' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.securityContext.readOnlyRootFilesystem' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}
+
+@test "server/dev-StatefulSet: readOnlyRootFilesystem configurable" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/server-statefulset.yaml \
+      --set 'server.dev.enabled=true' \
+      --set 'server.securityContext.readOnlyRootFilesystem=false' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.securityContext.readOnlyRootFilesystem' | tee /dev/stderr)
+  [ "${actual}" = "null" ]
 }

--- a/test/unit/server-ha-statefulset.bats
+++ b/test/unit/server-ha-statefulset.bats
@@ -509,7 +509,7 @@ load _helpers
 
 #--------------------------------------------------------------------
 # Security Contexts
-@test "server/standalone-StatefulSet: uid default" {
+@test "server/ha-StatefulSet: uid default" {
   cd `chart_dir`
   local actual=$(helm template \
       -x templates/server-statefulset.yaml \
@@ -519,7 +519,7 @@ load _helpers
   [ "${actual}" = "100" ]
 }
 
-@test "server/standalone-StatefulSet: uid configurable" {
+@test "server/ha-StatefulSet: uid configurable" {
   cd `chart_dir`
   local actual=$(helm template \
       -x templates/server-statefulset.yaml \
@@ -530,7 +530,7 @@ load _helpers
   [ "${actual}" = "2000" ]
 }
 
-@test "server/standalone-StatefulSet: gid default" {
+@test "server/ha-StatefulSet: gid default" {
   cd `chart_dir`
   local actual=$(helm template \
       -x templates/server-statefulset.yaml \
@@ -540,7 +540,7 @@ load _helpers
   [ "${actual}" = "1000" ]
 }
 
-@test "server/standalone-StatefulSet: gid configurable" {
+@test "server/ha-StatefulSet: gid configurable" {
   cd `chart_dir`
   local actual=$(helm template \
       -x templates/server-statefulset.yaml \
@@ -551,7 +551,7 @@ load _helpers
   [ "${actual}" = "2000" ]
 }
 
-@test "server/standalone-StatefulSet: fsgroup default" {
+@test "server/ha-StatefulSet: fsgroup default" {
   cd `chart_dir`
   local actual=$(helm template \
       -x templates/server-statefulset.yaml \
@@ -561,7 +561,7 @@ load _helpers
   [ "${actual}" = "1000" ]
 }
 
-@test "server/standalone-StatefulSet: fsgroup configurable" {
+@test "server/ha-StatefulSet: fsgroup configurable" {
   cd `chart_dir`
   local actual=$(helm template \
       -x templates/server-statefulset.yaml \
@@ -570,4 +570,25 @@ load _helpers
       . | tee /dev/stderr |
       yq -r '.spec.template.spec.securityContext.fsGroup' | tee /dev/stderr)
   [ "${actual}" = "2000" ]
+}
+
+@test "server/ha-StatefulSet: readOnlyRootFilesystem default" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/server-statefulset.yaml \
+      --set 'server.ha.enabled=true' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.securityContext.readOnlyRootFilesystem' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}
+
+@test "server/ha-StatefulSet: readOnlyRootFilesystem configurable" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/server-statefulset.yaml \
+      --set 'server.ha.enabled=true' \
+      --set 'server.securityContext.readOnlyRootFilesystem=false' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.securityContext.readOnlyRootFilesystem' | tee /dev/stderr)
+  [ "${actual}" = "null" ]
 }

--- a/test/unit/server-statefulset.bats
+++ b/test/unit/server-statefulset.bats
@@ -592,3 +592,22 @@ load _helpers
       yq -r '.spec.template.spec.securityContext.fsGroup' | tee /dev/stderr)
   [ "${actual}" = "2000" ]
 }
+
+@test "server/standalone-StatefulSet: readOnlyRootFilesystem default" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/server-statefulset.yaml \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.securityContext.readOnlyRootFilesystem' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}
+
+@test "server/standalone-StatefulSet: readOnlyRootFilesystem configurable" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/server-statefulset.yaml \
+      --set 'server.securityContext.readOnlyRootFilesystem=false' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.securityContext.readOnlyRootFilesystem' | tee /dev/stderr)
+  [ "${actual}" = "null" ]
+}

--- a/values.yaml
+++ b/values.yaml
@@ -14,6 +14,10 @@ server:
   # Resource requests, limits, etc. for the server cluster placement. This
   # should map directly to the value of the resources field for a PodSpec.
   # By default no direct resource request is made.
+
+  securityContext:
+    readOnlyRootFilesystem: true
+
   resources:
   # resources:
   #   requests:


### PR DESCRIPTION
Fixes #91 by making `readOnlyRootFilesystem` configurable.