### PR TITLE
Use a standard way to define the container image

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: vault
-version: 0.2.2
+version: 0.2.1
 description: Install and configure Vault on Kubernetes.
 home: https://www.vaultproject.io
 icon: https://github.com/hashicorp/vault/raw/f22d202cde2018f9455dec755118a9b84586e082/Vault_PrimaryLogo_Black.png

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: vault
-version: 0.2.1
+version: 0.2.2
 description: Install and configure Vault on Kubernetes.
 home: https://www.vaultproject.io
 icon: https://github.com/hashicorp/vault/raw/f22d202cde2018f9455dec755118a9b84586e082/Vault_PrimaryLogo_Black.png

--- a/templates/server-statefulset.yaml
+++ b/templates/server-statefulset.yaml
@@ -53,8 +53,8 @@ spec:
           securityContext:
             capabilities:
               add: ["IPC_LOCK"]
-          image: {{ .Values.image.repository }}:{{ .Values.image.tag | default "latest" }}
-          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          image: {{ .Values.server.image.repository }}:{{ .Values.server.image.tag | default "latest" }}
+          imagePullPolicy: {{ .Values.server.image.pullPolicy }}
           command: {{ template "vault.command" . }}
           args: {{ template "vault.args" . }}
           env:

--- a/templates/server-statefulset.yaml
+++ b/templates/server-statefulset.yaml
@@ -53,8 +53,8 @@ spec:
           securityContext:
             capabilities:
               add: ["IPC_LOCK"]
-          image: "{{ .Values.global.image }}"
-          imagePullPolicy: {{ .Values.global.imagePullPolicy }}
+          image: {{ .Values.image.repository }}:{{ .Values.image.tag | default "latest" }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
           command: {{ template "vault.command" . }}
           args: {{ template "vault.args" . }}
           env:

--- a/test/unit/server-dev-statefulset.bats
+++ b/test/unit/server-dev-statefulset.bats
@@ -23,15 +23,29 @@ load _helpers
   [ "${actual}" = "false" ]
 }
 
-@test "server/dev-StatefulSet: image defaults to global.image" {
+@test "server/dev-StatefulSet: image defaults to image.repository:tag" {
   cd `chart_dir`
   local actual=$(helm template \
       -x templates/server-statefulset.yaml  \
-      --set 'global.image=foo' \
+      --set 'image.repository=foo' \
+      --set 'image.tag=1.2.3' \
       --set 'server.dev.enabled=true' \
       . | tee /dev/stderr |
       yq -r '.spec.template.spec.containers[0].image' | tee /dev/stderr)
-  [ "${actual}" = "foo" ]
+  [ "${actual}" = "foo:1.2.3" ]
+}
+
+@test "server/ha-StatefulSet: image tag defaults to latest" {
+  cd `chart_dir`
+
+  local actual=$(helm template \
+      -x templates/server-statefulset.yaml  \
+      --set 'image.repository=foo' \
+      --set 'image.tag=' \
+      --set 'server.dev.enabled=true' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.containers[0].image' | tee /dev/stderr)
+  [ "${actual}" = "foo:latest" ]
 }
 
 #--------------------------------------------------------------------

--- a/test/unit/server-dev-statefulset.bats
+++ b/test/unit/server-dev-statefulset.bats
@@ -23,12 +23,12 @@ load _helpers
   [ "${actual}" = "false" ]
 }
 
-@test "server/dev-StatefulSet: image defaults to image.repository:tag" {
+@test "server/dev-StatefulSet: image defaults to server.image.repository:tag" {
   cd `chart_dir`
   local actual=$(helm template \
       -x templates/server-statefulset.yaml  \
-      --set 'image.repository=foo' \
-      --set 'image.tag=1.2.3' \
+      --set 'server.image.repository=foo' \
+      --set 'server.image.tag=1.2.3' \
       --set 'server.dev.enabled=true' \
       . | tee /dev/stderr |
       yq -r '.spec.template.spec.containers[0].image' | tee /dev/stderr)
@@ -40,8 +40,8 @@ load _helpers
 
   local actual=$(helm template \
       -x templates/server-statefulset.yaml  \
-      --set 'image.repository=foo' \
-      --set 'image.tag=' \
+      --set 'server.image.repository=foo' \
+      --set 'server.image.tag=' \
       --set 'server.dev.enabled=true' \
       . | tee /dev/stderr |
       yq -r '.spec.template.spec.containers[0].image' | tee /dev/stderr)

--- a/test/unit/server-ha-statefulset.bats
+++ b/test/unit/server-ha-statefulset.bats
@@ -23,12 +23,12 @@ load _helpers
   [ "${actual}" = "false" ]
 }
 
-@test "server/ha-StatefulSet: image defaults to image.repository:tag" {
+@test "server/ha-StatefulSet: image defaults to server.image.repository:tag" {
   cd `chart_dir`
   local actual=$(helm template \
       -x templates/server-statefulset.yaml  \
-      --set 'image.repository=foo' \
-      --set 'image.tag=1.2.3' \
+      --set 'server.image.repository=foo' \
+      --set 'server.image.tag=1.2.3' \
       --set 'server.ha.enabled=true' \
       . | tee /dev/stderr |
       yq -r '.spec.template.spec.containers[0].image' | tee /dev/stderr)
@@ -40,8 +40,8 @@ load _helpers
 
   local actual=$(helm template \
       -x templates/server-statefulset.yaml  \
-      --set 'image.repository=foo' \
-      --set 'image.tag=' \
+      --set 'server.image.repository=foo' \
+      --set 'server.image.tag=' \
       --set 'server.ha.enabled=true' \
       . | tee /dev/stderr |
       yq -r '.spec.template.spec.containers[0].image' | tee /dev/stderr)

--- a/test/unit/server-ha-statefulset.bats
+++ b/test/unit/server-ha-statefulset.bats
@@ -23,22 +23,29 @@ load _helpers
   [ "${actual}" = "false" ]
 }
 
-@test "server/ha-StatefulSet: image defaults to global.image" {
+@test "server/ha-StatefulSet: image defaults to image.repository:tag" {
   cd `chart_dir`
   local actual=$(helm template \
       -x templates/server-statefulset.yaml  \
-      --set 'global.image=foo' \
-      . | tee /dev/stderr |
-      yq -r '.spec.template.spec.containers[0].image' | tee /dev/stderr)
-  [ "${actual}" = "foo" ]
-
-  local actual=$(helm template \
-      -x templates/server-statefulset.yaml  \
-      --set 'global.image=foo' \
+      --set 'image.repository=foo' \
+      --set 'image.tag=1.2.3' \
       --set 'server.ha.enabled=true' \
       . | tee /dev/stderr |
       yq -r '.spec.template.spec.containers[0].image' | tee /dev/stderr)
-  [ "${actual}" = "foo" ]
+  [ "${actual}" = "foo:1.2.3" ]
+}
+
+@test "server/ha-StatefulSet: image tag defaults to latest" {
+  cd `chart_dir`
+
+  local actual=$(helm template \
+      -x templates/server-statefulset.yaml  \
+      --set 'image.repository=foo' \
+      --set 'image.tag=' \
+      --set 'server.ha.enabled=true' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.containers[0].image' | tee /dev/stderr)
+  [ "${actual}" = "foo:latest" ]
 }
 
 #--------------------------------------------------------------------

--- a/test/unit/server-statefulset.bats
+++ b/test/unit/server-statefulset.bats
@@ -32,20 +32,20 @@ load _helpers
   [ "${actual}" = "false" ]
 }
 
-@test "server/standalone-StatefulSet: image defaults to image.repository:tag" {
+@test "server/standalone-StatefulSet: image defaults to server.image.repository:tag" {
   cd `chart_dir`
   local actual=$(helm template \
       -x templates/server-statefulset.yaml  \
-      --set 'image.repository=foo' \
-      --set 'image.tag=1.2.3' \
+      --set 'server.image.repository=foo' \
+      --set 'server.image.tag=1.2.3' \
       . | tee /dev/stderr |
       yq -r '.spec.template.spec.containers[0].image' | tee /dev/stderr)
   [ "${actual}" = "foo:1.2.3" ]
 
   local actual=$(helm template \
       -x templates/server-statefulset.yaml  \
-      --set 'image.repository=foo' \
-      --set 'image.tag=1.2.3' \
+      --set 'server.image.repository=foo' \
+      --set 'server.image.tag=1.2.3' \
       --set 'server.standalone.enabled=true' \
       . | tee /dev/stderr |
       yq -r '.spec.template.spec.containers[0].image' | tee /dev/stderr)
@@ -56,16 +56,16 @@ load _helpers
   cd `chart_dir`
   local actual=$(helm template \
       -x templates/server-statefulset.yaml  \
-      --set 'image.repository=foo' \
-      --set 'image.tag=' \
+      --set 'server.image.repository=foo' \
+      --set 'server.image.tag=' \
       . | tee /dev/stderr |
       yq -r '.spec.template.spec.containers[0].image' | tee /dev/stderr)
   [ "${actual}" = "foo:latest" ]
 
   local actual=$(helm template \
       -x templates/server-statefulset.yaml  \
-      --set 'image.repository=foo' \
-      --set 'image.tag=' \
+      --set 'server.image.repository=foo' \
+      --set 'server.image.tag=' \
       --set 'server.standalone.enabled=true' \
       . | tee /dev/stderr |
       yq -r '.spec.template.spec.containers[0].image' | tee /dev/stderr)
@@ -85,7 +85,7 @@ load _helpers
   cd `chart_dir`
   local actual=$(helm template \
       -x templates/server-statefulset.yaml  \
-      --set 'image.pullPolicy=Always' \
+      --set 'server.image.pullPolicy=Always' \
       . | tee /dev/stderr |
       yq -r '.spec.template.spec.containers[0].imagePullPolicy' | tee /dev/stderr)
   [ "${actual}" = "Always" ]

--- a/test/unit/server-statefulset.bats
+++ b/test/unit/server-statefulset.bats
@@ -32,29 +32,50 @@ load _helpers
   [ "${actual}" = "false" ]
 }
 
-@test "server/standalone-StatefulSet: image defaults to global.image" {
+@test "server/standalone-StatefulSet: image defaults to image.repository:tag" {
   cd `chart_dir`
   local actual=$(helm template \
       -x templates/server-statefulset.yaml  \
-      --set 'global.image=foo' \
+      --set 'image.repository=foo' \
+      --set 'image.tag=1.2.3' \
       . | tee /dev/stderr |
       yq -r '.spec.template.spec.containers[0].image' | tee /dev/stderr)
-  [ "${actual}" = "foo" ]
+  [ "${actual}" = "foo:1.2.3" ]
 
   local actual=$(helm template \
       -x templates/server-statefulset.yaml  \
-      --set 'global.image=foo' \
+      --set 'image.repository=foo' \
+      --set 'image.tag=1.2.3' \
       --set 'server.standalone.enabled=true' \
       . | tee /dev/stderr |
       yq -r '.spec.template.spec.containers[0].image' | tee /dev/stderr)
-  [ "${actual}" = "foo" ]
+  [ "${actual}" = "foo:1.2.3" ]
+}
+
+@test "server/standalone-StatefulSet: image tag defaults to latest" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/server-statefulset.yaml  \
+      --set 'image.repository=foo' \
+      --set 'image.tag=' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.containers[0].image' | tee /dev/stderr)
+  [ "${actual}" = "foo:latest" ]
+
+  local actual=$(helm template \
+      -x templates/server-statefulset.yaml  \
+      --set 'image.repository=foo' \
+      --set 'image.tag=' \
+      --set 'server.standalone.enabled=true' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.containers[0].image' | tee /dev/stderr)
+  [ "${actual}" = "foo:latest" ]
 }
 
 @test "server/standalone-StatefulSet: default imagePullPolicy" {
   cd `chart_dir`
   local actual=$(helm template \
       -x templates/server-statefulset.yaml  \
-      --set 'global.image=foo' \
       . | tee /dev/stderr |
       yq -r '.spec.template.spec.containers[0].imagePullPolicy' | tee /dev/stderr)
   [ "${actual}" = "IfNotPresent" ]
@@ -64,10 +85,10 @@ load _helpers
   cd `chart_dir`
   local actual=$(helm template \
       -x templates/server-statefulset.yaml  \
-      --set 'global.imagePullPolicy=foo' \
+      --set 'image.pullPolicy=Always' \
       . | tee /dev/stderr |
       yq -r '.spec.template.spec.containers[0].imagePullPolicy' | tee /dev/stderr)
-  [ "${actual}" = "foo" ]
+  [ "${actual}" = "Always" ]
 }
 
 @test "server/standalone-StatefulSet: Custom imagePullSecrets" {

--- a/values.yaml
+++ b/values.yaml
@@ -4,17 +4,18 @@ global:
   # enabled is the master enabled switch. Setting this to true or false
   # will enable or disable all the components within this chart by default.
   enabled: true
-
-  # Image is the name (and tag) of the Vault Docker image.
-  image: "vault:1.2.4"
-  # Overrides the default Image Pull Policy
-  imagePullPolicy: IfNotPresent
   # Image pull secret to use for registry authentication.
   imagePullSecrets: []
   # imagePullSecrets:
   #   - name: image-pull-secret
   # TLS for end-to-end encrypted transport
   tlsDisable: true
+
+image:
+  repository: "vault"
+  tag: 1.2.4
+  # Overrides the default Image Pull Policy
+  pullPolicy: IfNotPresent
 
 server:
   # Resource requests, limits, etc. for the server cluster placement. This

--- a/values.yaml
+++ b/values.yaml
@@ -11,16 +11,16 @@ global:
   # TLS for end-to-end encrypted transport
   tlsDisable: true
 
-image:
-  repository: "vault"
-  tag: 1.2.4
-  # Overrides the default Image Pull Policy
-  pullPolicy: IfNotPresent
-
 server:
   # Resource requests, limits, etc. for the server cluster placement. This
   # should map directly to the value of the resources field for a PodSpec.
   # By default no direct resource request is made.
+
+  image:
+    repository: "vault"
+    tag: 1.2.4
+    # Overrides the default Image Pull Policy
+    pullPolicy: IfNotPresent
 
   resources:
   # resources:


### PR DESCRIPTION
Fixes https://github.com/hashicorp/vault-helm/issues/68

Refactor the way that the image repository and tag are defined avoiding globals.

Example:

```
server:
  image:
    repository: vault
    tag: 1.2.2
    pullPolicy: Always
```