### PR TITLE
Configure pod probes

### DIFF
--- a/templates/server-statefulset.yaml
+++ b/templates/server-statefulset.yaml
@@ -102,6 +102,16 @@ spec:
             periodSeconds: 3
             successThreshold: 1
             timeoutSeconds: 5
+          {{- if .Values.server.livenessProbe.enabled }}
+          livenessProbe:
+            httpGet:
+              path: {{ .Values.server.livenessProbe.path | quote }}
+              port: 8200
+            initialDelaySeconds: 5
+            periodSeconds: 3
+            successThreshold: 1
+            timeoutSeconds: 5
+          {{- end }}
       {{- if .Values.global.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml .Values.global.imagePullSecrets | nindent 8 }}

--- a/templates/server-statefulset.yaml
+++ b/templates/server-statefulset.yaml
@@ -89,7 +89,13 @@ spec:
               name: internal
             - containerPort: 8202
               name: replication
+          {{- if .Values.server.readinessProbe.enabled }}
           readinessProbe:
+            {{- if .Values.server.readinessProbe.path }}
+            httpGet:
+              path: {{ .Values.server.readinessProbe.path | quote }}
+              port: 8200
+            {{- else }}
             # Check status; unsealed vault servers return 0
             # The exit code reflects the seal status:
             #   0 - unsealed
@@ -97,11 +103,13 @@ spec:
             #   2 - sealed
             exec:
               command: ["/bin/sh", "-ec", "vault status -tls-skip-verify"]
+            {{- end }}
             failureThreshold: 2
             initialDelaySeconds: 5
             periodSeconds: 3
             successThreshold: 1
             timeoutSeconds: 5
+          {{- end }}
           {{- if .Values.server.livenessProbe.enabled }}
           livenessProbe:
             httpGet:

--- a/test/unit/server-statefulset.bats
+++ b/test/unit/server-statefulset.bats
@@ -658,3 +658,45 @@ load _helpers
       yq -r '.spec.template.spec.securityContext.readOnlyRootFilesystem' | tee /dev/stderr)
   [ "${actual}" = "null" ]
 }
+
+#--------------------------------------------------------------------
+# health checks
+
+@test "server/standalone-StatefulSet: readinessProbe default" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/server-statefulset.yaml \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.containers[0].readinessProbe.exec.command[2]' | tee /dev/stderr)
+  [ "${actual}" = "vault status -tls-skip-verify" ]
+}
+
+@test "server/standalone-StatefulSet: readinessProbe configurable" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/server-statefulset.yaml \
+      --set 'server.readinessProbe.enabled=false' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.containers[0].readinessProbe' | tee /dev/stderr)
+  [ "${actual}" = "null" ]
+}
+
+
+@test "server/standalone-StatefulSet: livenessProbe default" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/server-statefulset.yaml \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.containers[0].livenessProbe' | tee /dev/stderr)
+  [ "${actual}" = "null" ]
+}
+
+@test "server/standalone-StatefulSet: livenessProbe configurable" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/server-statefulset.yaml \
+      --set 'server.livenessProbe.enabled=true' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.containers[0].livenessProbe.httpGet.path' | tee /dev/stderr)
+  [ "${actual}" = "/v1/sys/health?standbyok" ]
+}

--- a/values.yaml
+++ b/values.yaml
@@ -57,6 +57,11 @@ server:
   authDelegator:
     enabled: false
 
+  # Used to enable a livenessProbe for the pods
+  livenessProbe:
+    enabled: false
+    path: /v1/sys/health?standbyok
+
   # extraEnvironmentVars is a list of extra enviroment variables to set with the stateful set. These could be
   # used to include variables required for auto-unseal.
   extraEnvironmentVars: {}

--- a/values.yaml
+++ b/values.yaml
@@ -57,6 +57,11 @@ server:
   authDelegator:
     enabled: false
 
+  # Used to define custom readinessProbe settings
+  readinessProbe:
+    enabled: true
+    # If you need to use a http path instead of the default exec
+    # path: /v1/sys/health?standbyok
   # Used to enable a livenessProbe for the pods
   livenessProbe:
     enabled: false
@@ -137,7 +142,7 @@ server:
     targetPort: 8200
     # Extra annotations for the service definition
     annotations: {}
-    
+
   # This configures the Vault Statefulset to create a PVC for data
   # storage when using the file backend.
   # See https://www.vaultproject.io/docs/audit/index.html to know more
@@ -254,7 +259,7 @@ server:
   # Definition of the serviceaccount used to run Vault.
   serviceaccount:
     annotations: {}
-  
+
 # Vault UI
 ui:
   # True if you want to create a Service entry for the Vault UI.


### PR DESCRIPTION
While trying to use GKE ingresses with vault i ran into issues with the generated load balancers.

Current issue is that the created Google Backend is creating health checks on `/`. This is because the readinessProbe is set to use exec. See: https://cloud.google.com/kubernetes-engine/docs/concepts/ingress#health_checks 

![image](https://user-images.githubusercontent.com/5629164/68213084-e4d0f980-ffa8-11e9-97f9-5bef72a25242.png)

This is a problem because `/` redirects to `/ui/` causing the health check to fail.
```
curl 127.0.0.1:8200 -v
* Rebuilt URL to: 127.0.0.1:8200/
*   Trying 127.0.0.1...
* TCP_NODELAY set
* Connected to 127.0.0.1 (127.0.0.1) port 8200 (#0)
> GET / HTTP/1.1
> Host: 127.0.0.1:8200
> User-Agent: curl/7.54.0
> Accept: */*
>
< HTTP/1.1 307 Temporary Redirect
< Cache-Control: no-store
< Content-Type: text/html; charset=utf-8
< Location: /ui/
< Date: Tue, 05 Nov 2019 13:48:30 GMT
< Content-Length: 40
<
<a href="/ui/">Temporary Redirect</a>.

* Connection #0 to host 127.0.0.1 left intact
```

This can be fixed by using `/v1/sys/health?standbyok` instead. However when setting a new Health Check to a new one, it is eventually reverted.

This PR adds optional values that can be defined to configure the readiness and liveness probes based on user needs. If nothing is defined it will operate as normal with the readiness exec command.