### PR TITLE
Add preStop lifecycle hook

### DIFF
--- a/templates/server-statefulset.yaml
+++ b/templates/server-statefulset.yaml
@@ -105,7 +105,7 @@ spec:
           lifecycle:
             # Vault container doesn't receive SIGTERM from Kubernetes
             # and after the grace period ends, Kube sends SIGKILL.  This 
-            # causes issues with grace shutdowns such as deregistering itself
+            # causes issues with graceful shutdowns such as deregistering itself
             # from Consul (zombie services).
             preStop:
               exec:

--- a/templates/server-statefulset.yaml
+++ b/templates/server-statefulset.yaml
@@ -102,6 +102,14 @@ spec:
             periodSeconds: 3
             successThreshold: 1
             timeoutSeconds: 5
+          lifecycle:
+            # Vault container doesn't receive SIGTERM from Kubernetes
+            # and after the grace period ends, Kube sends SIGKILL.  This 
+            # causes issues with grace shutdowns such as deregistering itself
+            # from Consul (zombie services).
+            preStop:
+              exec:
+                command: ["/bin/sh","-c","kill -SIGTERM $(pidof vault)"]
       {{- if .Values.global.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml .Values.global.imagePullSecrets | nindent 8 }}


### PR DESCRIPTION
Kubernetes sends SIGTERM signals to pods being deleted and waits for a grace period before sending SIGKILL.  The Vault pod wasn't receiving SIGTERM, so it never got the shutdown request, so the server was not shutting down gracefully.  This resulted in slow failover, sluggish pod deletions and zombie Consul services.

Fixes #29 