### PR TITLE
Configuration option for extra label to Ingress

### DIFF
--- a/templates/server-ingress.yaml
+++ b/templates/server-ingress.yaml
@@ -11,6 +11,9 @@ metadata:
     app.kubernetes.io/name: {{ include "vault.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
+    {{- with .Values.server.ingress.labels }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
   {{- with .Values.server.ingress.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/test/unit/server-ingress.bats
+++ b/test/unit/server-ingress.bats
@@ -45,3 +45,16 @@ load _helpers
   [ "${actual}" = "true" ]
 
 }
+
+@test "server/ingress: labels gets added to object" {
+  cd `chart_dir`
+
+  local actual=$(helm template \
+      -x templates/server-ingress.yaml \
+      --set 'server.ingress.enabled=true' \
+      --set 'server.ingress.labels.traffic=external' \
+      --set 'server.ingress.labels.team=dev' \
+      . | tee /dev/stderr |
+      yq -r '.metadata.labels.traffic' | tee /dev/stderr)
+  [ "${actual}" = "external" ]
+}

--- a/values.yaml
+++ b/values.yaml
@@ -38,6 +38,8 @@ server:
   # cluster, very useful if you want to expose the Vault UI
   ingress:
     enabled: false
+    labels: {}
+      # traffic: external
     annotations: {}
       # kubernetes.io/ingress.class: nginx
       # kubernetes.io/tls-acme: "true"


### PR DESCRIPTION
It's possible to use Ingress labels to distinguish between different Ingress Controllers in cluster.  Added option to values.