### PR TITLE
Removed readOnlyRootFilesystem configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.2.1 (November 12th, 2019)
+
+Bugs:
+
+* Removed `readOnlyRootFilesystem` causing issues when validating deployments
+
 ## 0.2.0 (October 29th, 2019)
 
 Features:

--- a/templates/server-statefulset.yaml
+++ b/templates/server-statefulset.yaml
@@ -41,9 +41,6 @@ spec:
       terminationGracePeriodSeconds: 10
       serviceAccountName: {{ template "vault.fullname" . }}
       securityContext:
-        {{- if .Values.server.securityContext.readOnlyRootFilesystem }}
-        readOnlyRootFilesystem: true
-        {{- end }}
         runAsNonRoot: true
         runAsGroup: {{ .Values.server.gid | default 1000 }}
         runAsUser: {{ .Values.server.uid | default 100 }}

--- a/test/unit/server-dev-statefulset.bats
+++ b/test/unit/server-dev-statefulset.bats
@@ -376,24 +376,3 @@ load _helpers
       yq -r '.spec.template.spec.securityContext.fsGroup' | tee /dev/stderr)
   [ "${actual}" = "2000" ]
 }
-
-@test "server/dev-StatefulSet: readOnlyRootFilesystem default" {
-  cd `chart_dir`
-  local actual=$(helm template \
-      -x templates/server-statefulset.yaml \
-      --set 'server.dev.enabled=true' \
-      . | tee /dev/stderr |
-      yq -r '.spec.template.spec.securityContext.readOnlyRootFilesystem' | tee /dev/stderr)
-  [ "${actual}" = "true" ]
-}
-
-@test "server/dev-StatefulSet: readOnlyRootFilesystem configurable" {
-  cd `chart_dir`
-  local actual=$(helm template \
-      -x templates/server-statefulset.yaml \
-      --set 'server.dev.enabled=true' \
-      --set 'server.securityContext.readOnlyRootFilesystem=false' \
-      . | tee /dev/stderr |
-      yq -r '.spec.template.spec.securityContext.readOnlyRootFilesystem' | tee /dev/stderr)
-  [ "${actual}" = "null" ]
-}

--- a/test/unit/server-ha-statefulset.bats
+++ b/test/unit/server-ha-statefulset.bats
@@ -571,24 +571,3 @@ load _helpers
       yq -r '.spec.template.spec.securityContext.fsGroup' | tee /dev/stderr)
   [ "${actual}" = "2000" ]
 }
-
-@test "server/ha-StatefulSet: readOnlyRootFilesystem default" {
-  cd `chart_dir`
-  local actual=$(helm template \
-      -x templates/server-statefulset.yaml \
-      --set 'server.ha.enabled=true' \
-      . | tee /dev/stderr |
-      yq -r '.spec.template.spec.securityContext.readOnlyRootFilesystem' | tee /dev/stderr)
-  [ "${actual}" = "true" ]
-}
-
-@test "server/ha-StatefulSet: readOnlyRootFilesystem configurable" {
-  cd `chart_dir`
-  local actual=$(helm template \
-      -x templates/server-statefulset.yaml \
-      --set 'server.ha.enabled=true' \
-      --set 'server.securityContext.readOnlyRootFilesystem=false' \
-      . | tee /dev/stderr |
-      yq -r '.spec.template.spec.securityContext.readOnlyRootFilesystem' | tee /dev/stderr)
-  [ "${actual}" = "null" ]
-}

--- a/test/unit/server-statefulset.bats
+++ b/test/unit/server-statefulset.bats
@@ -639,22 +639,3 @@ load _helpers
       yq -r '.spec.template.spec.securityContext.fsGroup' | tee /dev/stderr)
   [ "${actual}" = "2000" ]
 }
-
-@test "server/standalone-StatefulSet: readOnlyRootFilesystem default" {
-  cd `chart_dir`
-  local actual=$(helm template \
-      -x templates/server-statefulset.yaml \
-      . | tee /dev/stderr |
-      yq -r '.spec.template.spec.securityContext.readOnlyRootFilesystem' | tee /dev/stderr)
-  [ "${actual}" = "true" ]
-}
-
-@test "server/standalone-StatefulSet: readOnlyRootFilesystem configurable" {
-  cd `chart_dir`
-  local actual=$(helm template \
-      -x templates/server-statefulset.yaml \
-      --set 'server.securityContext.readOnlyRootFilesystem=false' \
-      . | tee /dev/stderr |
-      yq -r '.spec.template.spec.securityContext.readOnlyRootFilesystem' | tee /dev/stderr)
-  [ "${actual}" = "null" ]
-}

--- a/values.yaml
+++ b/values.yaml
@@ -21,9 +21,6 @@ server:
   # should map directly to the value of the resources field for a PodSpec.
   # By default no direct resource request is made.
 
-  securityContext:
-    readOnlyRootFilesystem: true
-
   resources:
   # resources:
   #   requests:


### PR DESCRIPTION
When validation is turned on, `readOnlyRootFilesystem` would cause errors because it's not a valid security context in pod spec.  Removing this all together to avoid errors with validation.