### PR TITLE
Add vault-init and externalTrafficPolicy to ui svc

### DIFF
--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -258,6 +258,22 @@ Sets extra service account annotations
 {{- end -}}
 
 {{/*
+Adds vault-init container for automated initialization and unsealing on Google Cloud Platform
+*/}}
+{{- define "vault.vault_init" -}}
+        - name: vault-init
+          image: "{{ .Values.vault_init.image }}"
+  {{- if .Values.vault_init.resources }}
+          resources:
+{{ toYaml .Values.vault_init.resources | indent 12}}
+    {{- end }}
+  {{- if .Values.vault_init.EnvironmentVars }}
+          env:
+{{ toYaml .Values.vault_init.EnvironmentVars | indent 12}}
+  {{- end -}}
+{{- end -}}
+
+{{/*
 Set's the container resources if the user has set any.
 */}}
 {{- define "vault.resources" -}}

--- a/templates/server-statefulset.yaml
+++ b/templates/server-statefulset.yaml
@@ -48,6 +48,9 @@ spec:
       volumes:
         {{ template "vault.volumes" . }}
       containers:
+        {{- if eq (.Values.vault_init.enabled | toString) "true" }}
+        {{ template "vault.vault_init" . }}
+        {{- end }}
         - name: vault
           {{ template "vault.resources" . }}
           securityContext:

--- a/templates/ui-service.yaml
+++ b/templates/ui-service.yaml
@@ -38,6 +38,7 @@ spec:
   {{- end }}
   {{- if and (eq (.Values.ui.serviceType | toString) "LoadBalancer") (.Values.ui.loadBalancerIP) }}
   loadBalancerIP: {{ .Values.ui.loadBalancerIP }}
+  externalTrafficPolicy: {{ .Values.ui.externalTrafficPolicy }}
   {{- end }}
 {{- end -}}
 

--- a/values.yaml
+++ b/values.yaml
@@ -262,6 +262,7 @@ ui:
   serviceType: "ClusterIP"
   serviceNodePort: null
   externalPort: 8200
+  externalTrafficPolicy: Cluster
 
   # loadBalancerSourceRanges:
   #   - 10.0.0.0/16
@@ -273,3 +274,17 @@ ui:
   # This should be a multi-line string mapping directly to the a map of
   # the annotations to apply to the ui service
   annotations: {}
+
+# Vault-init for Google Cloud Platform
+vault_init:
+  # The vault-init service automates the process of initializing and unsealing HashiCorp Vault
+  # instances running on Google Cloud Platform.
+  # After vault-init initializes a Vault server it stores master keys and root tokens
+  # encrypted using Google Cloud KMS, to a user defined Google Cloud Storage bucket.
+  enabled: false
+  image: "vault-init:latest"
+  EnvironmentVars: {}
+  resources:
+    requests:
+      cpu: "100m"
+      memory: "64Mi"


### PR DESCRIPTION
Adds support for Seth Vargo's helm-init image, which automates the process of initializing and unsealing HashiCorp Vault instances running on Google Cloud Platform.

After vault-init initializes a Vault server, it stores master keys and root tokens which is encrypted using Google Cloud KMS, to a user defined Google Cloud Storage bucket.
His repository and tutorial is available here: https://github.com/sethvargo/vault-on-gke/