### PR TITLE
Remove chart from labels

### DIFF
--- a/templates/server-statefulset.yaml
+++ b/templates/server-statefulset.yaml
@@ -7,7 +7,6 @@ metadata:
   name: {{ template "vault.fullname" . }}
   namespace: {{ .Release.Namespace }}
   labels:
-    helm.sh/chart: {{ include "vault.chart" . }}
     app.kubernetes.io/name: {{ include "vault.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
@@ -19,7 +18,6 @@ spec:
     type: OnDelete
   selector:
     matchLabels:
-      helm.sh/chart: {{ template "vault.chart" . }}
       app.kubernetes.io/name: {{ template "vault.name" . }}
       app.kubernetes.io/instance: {{ .Release.Name }}
       component: server


### PR DESCRIPTION
The label `{{ include "vault.chart" . }}` has the version included in the name, which prevented upgrades on StatefulSets.  Removed this from the StatefulSet label to prevent this from happening.