### PR TITLE
Promote Docker image version to 1.3.0

### DIFF
--- a/values.yaml
+++ b/values.yaml
@@ -18,7 +18,7 @@ server:
 
   image:
     repository: "vault"
-    tag: 1.2.4
+    tag: 1.3.0
     # Overrides the default Image Pull Policy
     pullPolicy: IfNotPresent
 


### PR DESCRIPTION
This PR changes the default value of the Docker image tag to 1.3.0