### PR TITLE
Fix typo: serviceaccount -> serviceAccount

### DIFF
--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -250,10 +250,10 @@ Sets extra ui service annotations
 {{/*
 Sets extra service account annotations
 */}}
-{{- define "vault.serviceaccount.annotations" -}}
-  {{- if and (ne .mode "dev") .Values.server.serviceaccount.annotations }}
+{{- define "vault.serviceAccount.annotations" -}}
+  {{- if and (ne .mode "dev") .Values.server.serviceAccount.annotations }}
   annotations:
-    {{- toYaml .Values.server.serviceaccount.annotations | nindent 4 }}
+    {{- toYaml .Values.server.serviceAccount.annotations | nindent 4 }}
   {{- end }}
 {{- end -}}
 

--- a/templates/server-serviceaccount.yaml
+++ b/templates/server-serviceaccount.yaml
@@ -10,5 +10,5 @@ metadata:
     app.kubernetes.io/name: {{ include "vault.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
-  {{ template "vault.serviceaccount.annotations" . }}
+  {{ template "vault.serviceAccount.annotations" . }}
 {{ end }}

--- a/test/unit/server-serviceaccount.bats
+++ b/test/unit/server-serviceaccount.bats
@@ -7,7 +7,7 @@ load _helpers
   local actual=$(helm template \
       -x templates/server-serviceaccount.yaml  \
       --set 'server.dev.enabled=true' \
-      --set 'server.serviceaccount.annotations.foo=bar' \
+      --set 'server.serviceAccount.annotations.foo=bar' \
       . | tee /dev/stderr |
       yq -r '.metadata.annotations["foo"]' | tee /dev/stderr)
   [ "${actual}" = "null" ]
@@ -15,7 +15,7 @@ load _helpers
   local actual=$(helm template \
       -x templates/server-serviceaccount.yaml  \
       --set 'server.ha.enabled=true' \
-      --set 'server.serviceaccount.annotations.foo=bar' \
+      --set 'server.serviceAccount.annotations.foo=bar' \
       . | tee /dev/stderr |
       yq -r '.metadata.annotations["foo"]' | tee /dev/stderr)
   [ "${actual}" = "bar" ]

--- a/values.yaml
+++ b/values.yaml
@@ -258,8 +258,8 @@ server:
     # replicas. If you'd like a custom value, you can specify an override here.
       maxUnavailable: null
 
-  # Definition of the serviceaccount used to run Vault.
-  serviceaccount:
+  # Definition of the serviceAccount used to run Vault.
+  serviceAccount:
     annotations: {}
 
 # Vault UI


### PR DESCRIPTION
Fixes a typo where `serviceaccount` should be `serviceAccount`. This will match up with the rest of the variable formatting as well as the official documentation for the chart.