### PR TITLE
Use correct default value for liveness probe path

### DIFF
--- a/values.yaml
+++ b/values.yaml
@@ -68,7 +68,7 @@ server:
   # Used to enable a livenessProbe for the pods
   livenessProbe:
     enabled: false
-    path: /v1/sys/health?standbyok
+    path: /v1/sys/health?standbyok=true
 
   # extraEnvironmentVars is a list of extra enviroment variables to set with the stateful set. These could be
   # used to include variables required for auto-unseal.


### PR DESCRIPTION
The query parameter `standbyok` must be set to `true` to have any effect. With the current version the standby pod is restarted due to 429 HTTP responses.