### PR TITLE
Add configurable nodeport

### DIFF
--- a/templates/server-service.yaml
+++ b/templates/server-service.yaml
@@ -32,6 +32,9 @@ spec:
     - name: http
       port: {{ .Values.server.service.port }}
       targetPort: {{ .Values.server.service.targetPort }}
+      {{- if and (.Values.server.service.nodePort) (eq (.Values.server.service.type | toString) "NodePort") }}
+      nodePort: {{ .Values.server.service.nodePort }}
+      {{- end }}
     - name: internal
       port: 8201
       targetPort: 8201

--- a/test/unit/server-service.bats
+++ b/test/unit/server-service.bats
@@ -303,3 +303,59 @@ load _helpers
       yq -r '.spec.ports[0].targetPort' | tee /dev/stderr)
   [ "${actual}" = "80" ]
 }
+
+@test "server/Service: nodeport can set" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/server-service.yaml \
+      --set 'server.dev.enabled=true' \
+      --set 'server.service.type=NodePort' \
+      --set 'server.service.nodePort=30008' \
+      . | tee /dev/stderr |
+      yq -r '.spec.ports[0].nodePort' | tee /dev/stderr)
+  [ "${actual}" = "30008" ]
+
+  local actual=$(helm template \
+      -x templates/server-service.yaml \
+      --set 'server.ha.enabled=true' \
+      --set 'server.service.type=NodePort' \
+      --set 'server.service.nodePort=30009' \
+      . | tee /dev/stderr |
+      yq -r '.spec.ports[0].nodePort' | tee /dev/stderr)
+  [ "${actual}" = "30009" ]
+
+  local actual=$(helm template \
+      -x templates/server-service.yaml \
+      --set 'server.service.type=NodePort' \
+      --set 'server.service.nodePort=30010' \
+      . | tee /dev/stderr |
+      yq -r '.spec.ports[0].nodePort' | tee /dev/stderr)
+  [ "${actual}" = "30010" ]
+}
+
+@test "server/Service: nodeport can't set when type isn't NodePort" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/server-service.yaml \
+      --set 'server.dev.enabled=true' \
+      --set 'server.service.nodePort=30008' \
+      . | tee /dev/stderr |
+      yq -r '.spec.ports[0].nodePort' | tee /dev/stderr)
+  [ "${actual}" = "null" ]
+
+  local actual=$(helm template \
+      -x templates/server-service.yaml \
+      --set 'server.ha.enabled=true' \
+      --set 'server.service.nodePort=30009' \
+      . | tee /dev/stderr |
+      yq -r '.spec.ports[0].nodePort' | tee /dev/stderr)
+  [ "${actual}" = "null" ]
+
+  local actual=$(helm template \
+      -x templates/server-service.yaml \
+      --set 'server.standalone.enabled=true' \
+      --set 'server.service.nodePort=30010' \
+      . | tee /dev/stderr |
+      yq -r '.spec.ports[0].nodePort' | tee /dev/stderr)
+  [ "${actual}" = "null" ]
+}

--- a/values.yaml
+++ b/values.yaml
@@ -138,6 +138,14 @@ server:
     # used to communicate with pods directly through DNS instead of a round robin
     # load balancer.
     # clusterIP: None
+    
+    # Configures the service type for the main Vault service.  Can be ClusterIP 
+    # or NodePort.
+    #type: ClusterIP
+
+    # If type is set to "NodePort", a specific nodePort value can be configured, 
+    # will be random if left blank.
+    #nodePort: 30000
 
     # Port on which Vault server is listening
     port: 8200


### PR DESCRIPTION
This adds the ability to configure the node port value if NodePort services are being used, instead of using the randomly assigned port.

Closes #127.