### PR TITLE
Option to create service account outside the helm

### DIFF
--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -248,6 +248,17 @@ Sets extra ui service annotations
 {{- end -}}
 
 {{/*
+Set the service account name
+*/}}
+{{- define "vault.serviceAccount.name" -}}
+  {{- if ne .Values.server.serviceAccount.name "" -}}
+    {{- .Values.server.serviceAccount.name -}}
+  {{- else -}}
+    {{- template "vault.fullname" . -}}
+  {{- end -}}
+{{- end -}}
+
+{{/*
 Sets extra service account annotations
 */}}
 {{- define "vault.serviceAccount.annotations" -}}

--- a/templates/server-serviceaccount.yaml
+++ b/templates/server-serviceaccount.yaml
@@ -1,9 +1,9 @@
 {{ template "vault.mode" . }}
-{{- if and (ne .mode "") (eq (.Values.global.enabled | toString) "true") }}
+{{- if and (ne .mode "") (eq (.Values.global.enabled | toString) "true") (eq (.Values.server.serviceAccount.create | toString) "true") }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ template "vault.fullname" . }}
+  name: {{ template "vault.serviceAccount.name" . }}
   namespace: {{ .Release.Namespace }}
   labels:
     helm.sh/chart: {{ include "vault.chart" . }}

--- a/templates/server-statefulset.yaml
+++ b/templates/server-statefulset.yaml
@@ -37,7 +37,7 @@ spec:
       {{ template "vault.tolerations" . }}
       {{ template "vault.nodeselector" . }}
       terminationGracePeriodSeconds: 10
-      serviceAccountName: {{ template "vault.fullname" . }}
+      serviceAccountName: {{ template "vault.serviceAccount.name" . }}
       securityContext:
         runAsNonRoot: true
         runAsGroup: {{ .Values.server.gid | default 1000 }}
@@ -122,7 +122,7 @@ spec:
         {{- end }}
           lifecycle:
             # Vault container doesn't receive SIGTERM from Kubernetes
-            # and after the grace period ends, Kube sends SIGKILL.  This 
+            # and after the grace period ends, Kube sends SIGKILL.  This
             # causes issues with graceful shutdowns such as deregistering itself
             # from Consul (zombie services).
             preStop:

--- a/values.yaml
+++ b/values.yaml
@@ -31,7 +31,7 @@ server:
   #     memory: 256Mi
   #     cpu: 250m
 
-  # Ingress allows ingress services to be created to allow external access 
+  # Ingress allows ingress services to be created to allow external access
   # from Kubernetes to access Vault pods.
   ingress:
     enabled: false
@@ -55,7 +55,7 @@ server:
   # method.  https://www.vaultproject.io/docs/auth/kubernetes.html
   authDelegator:
     enabled: false
-  
+
   # extraContainers is a list of sidecar containers. Specified as a raw YAML string.
   extraContainers: null
 
@@ -261,6 +261,8 @@ server:
 
   # Definition of the serviceAccount used to run Vault.
   serviceAccount:
+    create: true
+    name: ""
     annotations: {}
 
 # Vault UI


### PR DESCRIPTION
Helps user to create their own service account with additional annotations and labels.

*Why I am raising this PR?*

I am using terraform to configure the vault with the Kubernetes authentication backend. To configure Kubernetes authentication backend, I need `token_reviewer_jwt` from the secret created by the `vault` service account but there is no straight forward way to find the secret created by the service account. I can use `local-exec` to get the secret name `kubectl get serviceaccounts -n vault vault -o jsonpath='{.secrets.*.name}'` and write it to a file or secret and then reference that but it is NOT straight forward.

This PR helps me create the service account outside helm. i.e. I can create the service account using terraform and use the `default_secret_name` attribute to reference it on the `vault_kubernetes_auth_backend_config`.

```hcl
resource "kubernetes_service_account" "vault" {
  metadata {
    name      = "vault"
    namespace = "vault"
  }

  automount_service_account_token = true
}

resource "vault_kubernetes_auth_backend_config" "kubernetes" {
  backend            = vault_auth_backend.kubernetes.path
  kubernetes_host    = data.terraform_remote_state.eks.outputs.k8s_endpoint
  kubernetes_ca_cert = data.terraform_remote_state.eks.outputs.k8s_cert
  token_reviewer_jwt = kubernetes_service_account.vault.default_secret_name
}
```