### PR TITLE
fix injector env var names for manual tls config

### DIFF
--- a/templates/injector-deployment.yaml
+++ b/templates/injector-deployment.yaml
@@ -44,9 +44,9 @@ spec:
             - name: AGENT_INJECT_VAULT_IMAGE
               value: "{{ .Values.injector.agentImage.repository }}:{{ .Values.injector.agentImage.tag }}"
             {{- if .Values.injector.certs.secretName }}
-            - name: AGENT_INJECT_CERT_FILE
+            - name: AGENT_INJECT_TLS_CERT_FILE
               value: "/etc/webhook/certs/{{ .Values.injector.certs.certName }}"
-            - name: AGENT_INJECT_KEY_FILE
+            - name: AGENT_INJECT_TLS_KEY_FILE
               value: "/etc/webhook/certs/{{ .Values.injector.certs.keyName }}"
             {{- else }}
             - name: AGENT_INJECT_TLS_AUTO

--- a/test/unit/injector-deployment.bats
+++ b/test/unit/injector-deployment.bats
@@ -118,7 +118,7 @@ load _helpers
 
   local actual=$(echo $object |
      yq -r '.[4].name' | tee /dev/stderr)
-  [ "${actual}" = "AGENT_INJECT_CERT_FILE" ]
+  [ "${actual}" = "AGENT_INJECT_TLS_CERT_FILE" ]
 
   local actual=$(echo $object |
       yq -r '.[4].value' | tee /dev/stderr)
@@ -126,7 +126,7 @@ load _helpers
 
   local actual=$(echo $object |
       yq -r '.[5].name' | tee /dev/stderr)
-  [ "${actual}" = "AGENT_INJECT_KEY_FILE" ]
+  [ "${actual}" = "AGENT_INJECT_TLS_KEY_FILE" ]
 
   local actual=$(echo $object |
       yq -r '.[5].value' | tee /dev/stderr)


### PR DESCRIPTION
AGENT_INJECT_CERT_FILE -> AGENT_INJECT_TLS_CERT_FILE
AGENT_INJECT_KEY_FILE -> AGENT_INJECT_TLS_KEY_FILE

see
https://github.com/hashicorp/vault-k8s/blob/611492d04b7bf2115e3b43e8d148cc643a47d10d/subcommand/injector/flags.go#L56

fixes #170