### PR TITLE
Add configuration for StatefulSet updateStrategy

### DIFF
--- a/templates/server-statefulset.yaml
+++ b/templates/server-statefulset.yaml
@@ -15,7 +15,7 @@ spec:
   podManagementPolicy: Parallel
   replicas: {{ template "vault.replicas" . }}
   updateStrategy:
-    type: OnDelete
+    type: {{ .Values.server.updateStrategyType }}
   selector:
     matchLabels:
       app.kubernetes.io/name: {{ template "vault.name" . }}
@@ -122,7 +122,7 @@ spec:
         {{- end }}
           lifecycle:
             # Vault container doesn't receive SIGTERM from Kubernetes
-            # and after the grace period ends, Kube sends SIGKILL.  This 
+            # and after the grace period ends, Kube sends SIGKILL.  This
             # causes issues with graceful shutdowns such as deregistering itself
             # from Consul (zombie services).
             preStop:

--- a/test/unit/server-ha-statefulset.bats
+++ b/test/unit/server-ha-statefulset.bats
@@ -97,6 +97,17 @@ load _helpers
   [ "${actual}" = "OnDelete" ]
 }
 
+@test "server/ha-StatefulSet: RollingUpdate updateStrategy" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/server-statefulset.yaml  \
+      --set 'server.ha.enabled=true' \
+      --set 'server.updateStrategyType="RollingUpdate"' \
+      . | tee /dev/stderr |
+      yq -r '.spec.updateStrategy.type' | tee /dev/stderr)
+  [ "${actual}" = "RollingUpdate" ]
+}
+
 #--------------------------------------------------------------------
 # affinity
 

--- a/values.yaml
+++ b/values.yaml
@@ -21,8 +21,8 @@ injector:
     tag: "0.1.2"
     pullPolicy: IfNotPresent
 
-  # agentImage sets the repo and tag of the Vault image to use for the Vault Agent 
-  # containers.  This should be set to the official Vault image.  Vault 1.3.1+ is 
+  # agentImage sets the repo and tag of the Vault image to use for the Vault Agent
+  # containers.  This should be set to the official Vault image.  Vault 1.3.1+ is
   # required.
   agentImage:
     repository: "vault"
@@ -76,6 +76,10 @@ server:
     # Overrides the default Image Pull Policy
     pullPolicy: IfNotPresent
 
+  # Configure the Update Strategy Type for the StatefulSet
+  # See https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#update-strategies
+  updateStrategyType: "OnDelete"
+
   resources:
   # resources:
   #   requests:
@@ -85,7 +89,7 @@ server:
   #     memory: 256Mi
   #     cpu: 250m
 
-  # Ingress allows ingress services to be created to allow external access 
+  # Ingress allows ingress services to be created to allow external access
   # from Kubernetes to access Vault pods.
   ingress:
     enabled: false
@@ -109,7 +113,7 @@ server:
   # method.  https://www.vaultproject.io/docs/auth/kubernetes.html
   authDelegator:
     enabled: true
-  
+
   # extraContainers is a list of sidecar containers. Specified as a raw YAML string.
   extraContainers: null
 
@@ -192,12 +196,12 @@ server:
     # used to communicate with pods directly through DNS instead of a round robin
     # load balancer.
     # clusterIP: None
-    
-    # Configures the service type for the main Vault service.  Can be ClusterIP 
+
+    # Configures the service type for the main Vault service.  Can be ClusterIP
     # or NodePort.
     #type: ClusterIP
 
-    # If type is set to "NodePort", a specific nodePort value can be configured, 
+    # If type is set to "NodePort", a specific nodePort value can be configured,
     # will be random if left blank.
     #nodePort: 30000
 


### PR DESCRIPTION
If Auto Unseal is configured, it should be safe to allow a rolling update strategy. This should be an option for a less involved upgrade process.

I have been using the "incubator/vault" chart which deploys Vault as a Deployment and I've not had issues performing upgrades. 