### PR TITLE
make shareProcessNamespace configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Unreleased
 
+Improvements:
+
+* Allow process namespace sharing between Vault and sidecar containers
+
 ## 0.3.3 (January 14th, 2020)
 
 Security:

--- a/templates/server-statefulset.yaml
+++ b/templates/server-statefulset.yaml
@@ -38,6 +38,9 @@ spec:
       {{ template "vault.nodeselector" . }}
       terminationGracePeriodSeconds: 10
       serviceAccountName: {{ template "vault.fullname" . }}
+      {{ if  .Values.server.shareProcessNamespace }}
+      shareProcessNamespace: true
+      {{ end }}
       securityContext:
         runAsNonRoot: true
         runAsGroup: {{ .Values.server.gid | default 1000 }}

--- a/test/unit/server-statefulset.bats
+++ b/test/unit/server-statefulset.bats
@@ -670,6 +670,33 @@ load _helpers
   [ "${containers_count}" = 1 ]  
 }
 
+# sharedProcessNamespace
+
+@test "server/standalone-StatefulSet: shareProcessNamespace disabled by default" {
+  cd `chart_dir`
+
+  # Test that it defines it
+  local actual=$(helm template \
+      -x templates/server-statefulset.yaml  \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.shareProcessNamespace' | tee /dev/stderr)
+
+  [ "${actual}" = "null" ]  
+}
+
+@test "server/standalone-StatefulSet: shareProcessNamespace enabled" {
+  cd `chart_dir`
+
+  # Test that it defines it
+  local actual=$(helm template \
+      -x templates/server-statefulset.yaml  \
+      --set 'server.shareProcessNamespace=true' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.shareProcessNamespace' | tee /dev/stderr)
+
+  [ "${actual}" = "true" ]  
+}
+
 # extra labels
 
 @test "server/standalone-StatefulSet: specify extraLabels" {

--- a/values.yaml
+++ b/values.yaml
@@ -113,6 +113,10 @@ server:
   # extraContainers is a list of sidecar containers. Specified as a raw YAML string.
   extraContainers: null
 
+  # shareProcessNamespace enables process namespace sharing between Vault and the extraContainers
+  # This is useful if Vault must be signaled, e.g. to send a SIGHUP for log rotation
+  shareProcessNamespace: false
+  
   # extraArgs is a string containing additional Vault server arguments.
   extraArgs: ""
 


### PR DESCRIPTION
I've noticed that some unit tests are replicated for standalone and HA. What's the way to go here? For now, I've only added standalone tests.

related to #142 