### PR TITLE
Label selector and failure policy for injector

### DIFF
--- a/values.yaml
+++ b/values.yaml
@@ -43,15 +43,15 @@ injector:
   # Label selectors are only available in Kubernetes 1.15 or higher.
   # Possible options:
   # *disabled*: The webhook is applied to all pods.
-  # *explicit*: The webhook is only applied to pods with the label present. Set the label to *failure* to enfore the injection (else the pod is rejected).
-  # *defaultIgnore*: If the label is not present, the webhook is applied but any errors are ignored. Set the label to *failure* to enfore the injection (else the pod is rejected).
+  # *explicit*: The webhook is only applied to pods with the label present. Set the label to *failure* to enforce the injection (else the pod is rejected).
+  # *defaultIgnore*: If the label is not present, the webhook is applied but any errors are ignored. Set the label to *failure* to enforce the injection (else the pod is rejected).
   # Example:
   # labels:
   #   vault.hashicorp.com/agent-inject: failure
   # If labelSelector is set to explicit or defaultIgnore, two webhooks with the corresponding failure policies are created.
   labelSelector: disabled
 
-  # If labelSeletor is set to disabled, the failurePolicy for the webhook can be set explicitly.
+  # If labelSelector is set to disabled, the failurePolicy for the webhook can be set explicitly.
   # See https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/#failure-policy
   failurePolicy: ignore
 

--- a/values.yaml
+++ b/values.yaml
@@ -38,6 +38,23 @@ injector:
   #      sidecar-injector: enabled
   namespaceSelector: {}
 
+  # labelSelector limits the application of the webhook to pods with the label vault.hashicorp.com/agent-inject.
+  # This reduces the load on the webhook and prevents pods from being rejected in case the webhook is unavailable.
+  # Label selectors are only available in Kubernetes 1.15 or higher.
+  # Possible options:
+  # *disabled*: The webhook is applied to all pods.
+  # *explicit*: The webhook is only applied to pods with the label present. Set the label to *failure* to enfore the injection (else the pod is rejected).
+  # *defaultIgnore*: If the label is not present, the webhook is applied but any errors are ignored. Set the label to *failure* to enfore the injection (else the pod is rejected).
+  # Example:
+  # labels:
+  #   vault.hashicorp.com/agent-inject: failure
+  # If labelSelector is set to explicit or defaultIgnore, two webhooks with the corresponding failure policies are created.
+  labelSelector: disabled
+
+  # If labelSeletor is set to disabled, the failurePolicy for the webhook can be set explicitly.
+  # See https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/#failure-policy
+  failurePolicy: ignore
+
   certs:
     # secretName is the name of the secret that has the TLS certificate and
     # private key to serve the injector webhook. If this is null, then the


### PR DESCRIPTION
This is related to https://github.com/hashicorp/vault-k8s/issues/40#issuecomment-572445785

This is just the change in the `values.yaml`. I've tried to keep it flexible but excluded options which don't make sense (e.g. `defaultFailure`). This change would be non-breaking and as long as the label selector is disabled Kubernetes 1.15 is not required.

If I get positive feedback, I can implement the rest.

