### PR TITLE
Support Affinity, Tolerations and nodeSelector for Injector

### DIFF
--- a/templates/injector-deployment.yaml
+++ b/templates/injector-deployment.yaml
@@ -29,6 +29,18 @@ spec:
         runAsNonRoot: true
         runAsGroup: {{ .Values.injector.gid | default 1000 }}
         runAsUser: {{ .Values.injector.uid | default 100 }}
+      {{- if .Values.injector.affinity }}
+      affinity:
+        {{ tpl .Values.injector.affinity . | nindent 8 | trim }}
+      {{- end }}
+      {{- if .Values.injector.tolerations }}
+      tolerations:
+        {{ tpl .Values.injector.tolerations . | nindent 8 | trim }}
+      {{- end }}
+      {{- if .Values.injector.nodeSelector }}
+      nodeSelector:
+        {{ tpl .Values.injector.nodeSelector . | nindent 8 | trim }}
+      {{- end }}
       containers:
         - name: sidecar-injector
           {{ template "injector.resources" . }}

--- a/test/unit/injector-deployment.bats
+++ b/test/unit/injector-deployment.bats
@@ -154,3 +154,69 @@ load _helpers
       yq -r '.[5].name' | tee /dev/stderr)
   [ "${actual}" = "AGENT_INJECT_TLS_AUTO_HOSTS" ]
 }
+
+#--------------------------------------------------------------------
+# affinity
+
+@test "injector/deployment: affinity not set by default" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/injector-deployment.yaml \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.affinity' | tee /dev/stderr)
+  [ "${actual}" == "null" ]
+}
+
+@test "injector/deployment: affinity can be set" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/injector-deployment.yaml \
+      --set 'injector.affinity=foobar' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.affinity' | tee /dev/stderr)
+  [ "${actual}" == "foobar" ]
+}
+
+#--------------------------------------------------------------------
+# tolerations
+
+@test "injector/deployment: tolerations not set by default" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/injector-deployment.yaml \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.tolerations' | tee /dev/stderr)
+  [ "${actual}" == "null" ]
+}
+
+@test "injector/deployment: tolerations can be set" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/injector-deployment.yaml \
+      --set 'injector.tolerations=foobar' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.tolerations' | tee /dev/stderr)
+  [ "${actual}" == "foobar" ]
+}
+
+#--------------------------------------------------------------------
+# nodeSelector
+
+@test "injector/deployment: nodeSelector not set by default" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/injector-deployment.yaml \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.nodeSelector' | tee /dev/stderr)
+  [ "${actual}" == "null" ]
+}
+
+@test "injector/deployment: nodeSelector can be set" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -x templates/injector-deployment.yaml \
+      --set 'injector.nodeSelector=foobar' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.nodeSelector' | tee /dev/stderr)
+  [ "${actual}" == "foobar" ]
+}

--- a/values.yaml
+++ b/values.yaml
@@ -65,6 +65,23 @@ injector:
   #     memory: 256Mi
   #     cpu: 250m
 
+  # Affinity Settings
+  # This should be a multi-line string matching the affinity object
+  # in a PodSpec.
+  affinity: ""
+
+  # Toleration Settings for injector pods
+  # This should be a multi-line string matching the Toleration array
+  # in a PodSpec.
+  tolerations: ""
+
+  # nodeSelector labels for injector pod assignment, formatted as a muli-line string.
+  # ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector
+  # Example:
+  # nodeSelector: |
+  #   beta.kubernetes.io/arch: amd64
+  nodeSelector: ""
+
 server:
   # Resource requests, limits, etc. for the server cluster placement. This
   # should map directly to the value of the resources field for a PodSpec.
@@ -120,7 +137,7 @@ server:
   # shareProcessNamespace enables process namespace sharing between Vault and the extraContainers
   # This is useful if Vault must be signaled, e.g. to send a SIGHUP for log rotation
   shareProcessNamespace: false
-  
+
   # extraArgs is a string containing additional Vault server arguments.
   extraArgs: ""
 
@@ -176,14 +193,14 @@ server:
   # Toleration Settings for server pods
   # This should be a multi-line string matching the Toleration array
   # in a PodSpec.
-  tolerations: {}
+  tolerations: ""
 
   # nodeSelector labels for server pod assignment, formatted as a muli-line string.
   # ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector
   # Example:
   # nodeSelector: |
   #   beta.kubernetes.io/arch: amd64
-  nodeSelector: {}
+  nodeSelector: ""
 
   # Extra labels to attach to the server pods
   # This should be a multi-line string mapping directly to the a map of


### PR DESCRIPTION
- Changed default for server tolerations and nodeSelector to string because the chart expects them to be strings

```
$ bats test/unit/injector-deployment.bats 
 ✓ injector/deployment: default injector.enabled
 ✓ injector/deployment: enable with injector.enabled true
 ✓ injector/deployment: disable with global.enabled
 ✓ injector/deployment: image defaults to injector.image
 ✓ injector/deployment: default imagePullPolicy
 ✓ injector/deployment: default resources
 ✓ injector/deployment: custom resources
 ✓ injector/deployment: manual TLS environment vars
 ✓ injector/deployment: auto TLS by default
 ✓ injector/deployment: affinity not set by default
 ✓ injector/deployment: affinity can be set
 ✓ injector/deployment: tolerations not set by default
 ✓ injector/deployment: tolerations can be set
 ✓ injector/deployment: nodeSelector not set by default
 ✓ injector/deployment: nodeSelector can be set

```