### PR TITLE
adding custom Vault Address value for injector deployment

### DIFF
--- a/templates/injector-deployment.yaml
+++ b/templates/injector-deployment.yaml
@@ -40,7 +40,11 @@ spec:
             - name: AGENT_INJECT_LOG_LEVEL
               value: {{ .Values.injector.logLevel | default "info" }}
             - name: AGENT_INJECT_VAULT_ADDR
+            {{- if .Values.injector.vaultAddress }}
+              value: {{ include "vault.scheme" . }}://{{ .Values.injector.vaultAddress }}:{{ .Values.server.service.port }}
+            {{- else}}
               value: {{ include "vault.scheme" . }}://{{ template "vault.fullname" . }}.{{ .Release.Namespace }}.svc:{{ .Values.server.service.port }}
+            {{- end}}
             - name: AGENT_INJECT_VAULT_IMAGE
               value: "{{ .Values.injector.agentImage.repository }}:{{ .Values.injector.agentImage.tag }}"
             {{- if .Values.injector.certs.secretName }}

--- a/test/unit/injector-deployment.bats
+++ b/test/unit/injector-deployment.bats
@@ -154,3 +154,36 @@ load _helpers
       yq -r '.[5].name' | tee /dev/stderr)
   [ "${actual}" = "AGENT_INJECT_TLS_AUTO_HOSTS" ]
 }
+
+@test "injector/deployment: default Vault address" {
+  cd `chart_dir`
+  local object=$(helm template \
+      -x templates/injector-deployment.yaml  \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.containers[0].env' | tee /dev/stderr)
+
+  local actual=$(echo $object |
+      yq -r '.[2].name' | tee /dev/stderr)
+  [ "${actual}" = "AGENT_INJECT_VAULT_ADDR" ]
+
+  local actual=$(echo $object |
+      yq -r '.[2].value' | tee /dev/stderr)
+  [ "${actual}" = "http://release-name-vault.default.svc:8200" ]
+}
+
+@test "injector/deployment: custom Vault address" {
+  cd `chart_dir`
+  local object=$(helm template \
+      -x templates/injector-deployment.yaml  \
+      --set 'injector.vaultAddress=vault.service.consul' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.containers[0].env' | tee /dev/stderr)
+
+  local actual=$(echo $object |
+      yq -r '.[2].name' | tee /dev/stderr)
+  [ "${actual}" = "AGENT_INJECT_VAULT_ADDR" ]
+
+  local actual=$(echo $object |
+      yq -r '.[2].value' | tee /dev/stderr)
+  [ "${actual}" = "http://vault.service.consul:8200" ]
+}

--- a/values.yaml
+++ b/values.yaml
@@ -65,6 +65,12 @@ injector:
   #     memory: 256Mi
   #     cpu: 250m
 
+  # vaultAddress is a custom Vault FQDN to configure injector with. It's useful
+  # when running Vault with custom service discovery like Consul as it eliminates
+  # the necessity of having 'vault.hashicorp.com/service' annotation for each pod.
+  vaultAddress: ""
+  # vaultAddress: "vault.service.consul"
+
 server:
   # Resource requests, limits, etc. for the server cluster placement. This
   # should map directly to the value of the resources field for a PodSpec.
@@ -120,7 +126,7 @@ server:
   # shareProcessNamespace enables process namespace sharing between Vault and the extraContainers
   # This is useful if Vault must be signaled, e.g. to send a SIGHUP for log rotation
   shareProcessNamespace: false
-  
+
   # extraArgs is a string containing additional Vault server arguments.
   extraArgs: ""
 


### PR DESCRIPTION
Addresses the issue with running Vault and custom service discovery like Consul.
Agent injector defaults to Kubernetes native service discovery so in order to use consul it's required to put `vault.hashicorp.com/service` for each pod. This PR makes it configurable on the servers side.

Unit/Acceptance tests are passing.