### PR TITLE
Remove IPC_LOCK capability

### DIFF
--- a/templates/server-statefulset.yaml
+++ b/templates/server-statefulset.yaml
@@ -51,9 +51,6 @@ spec:
       containers:
         - name: vault
           {{ template "vault.resources" . }}
-          securityContext:
-            capabilities:
-              add: ["IPC_LOCK"]
           image: {{ .Values.server.image.repository }}:{{ .Values.server.image.tag | default "latest" }}
           imagePullPolicy: {{ .Values.server.image.pullPolicy }}
           command: {{ template "vault.command" . }}


### PR DESCRIPTION
Since we know we're deploying to k8s and are already [disabling `mlock`](https://github.com/hashicorp/vault-helm/blob/master/templates/server-config-configmap.yaml#L16) (also see #80), is there a need for `IPC_LOCK`?
This also helps with deploying on for example Openshift as we now only need `--set server.uid` and `--set server.gid` for the ranges allowed by the `restricted` SCC. No more mucking around with SCCs and capabilities.