### PR TITLE
Remove IPC_LOCK capability

### DIFF
--- a/templates/server-statefulset.yaml
+++ b/templates/server-statefulset.yaml
@@ -51,9 +51,6 @@ spec:
       containers:
         - name: vault
           {{ template "vault.resources" . }}
-          securityContext:
-            capabilities:
-              add: ["IPC_LOCK"]
           image: {{ .Values.server.image.repository }}:{{ .Values.server.image.tag | default "latest" }}
           imagePullPolicy: {{ .Values.server.image.pullPolicy }}
           command: {{ template "vault.command" . }}

--- a/test/acceptance/server-ha.bats
+++ b/test/acceptance/server-ha.bats
@@ -18,11 +18,6 @@ load _helpers
     jq -r '.initialized')
   [ "${init_status}" == "false" ]
 
-  # Security
-  local ipc=$(kubectl get statefulset "$(name_prefix)" --output json |
-    jq -r '.spec.template.spec.containers[0].securityContext.capabilities.add[0]')
-  [ "${ipc}" == "IPC_LOCK" ]
-
   # Replicas
   local replicas=$(kubectl get statefulset "$(name_prefix)" --output json |
     jq -r '.spec.replicas')

--- a/test/acceptance/server.bats
+++ b/test/acceptance/server.bats
@@ -21,11 +21,6 @@ load _helpers
     jq -r '.initialized')
   [ "${init_status}" == "false" ]
 
-  # Security
-  local ipc=$(kubectl get statefulset "$(name_prefix)" --output json |
-    jq -r '.spec.template.spec.containers[0].securityContext.capabilities.add[0]')
-  [ "${ipc}" == "IPC_LOCK" ]
-
   # Replicas
   local replicas=$(kubectl get statefulset "$(name_prefix)" --output json |
     jq -r '.spec.replicas')


### PR DESCRIPTION
Since we know we're deploying to k8s and are already [disabling `mlock`](https://github.com/hashicorp/vault-helm/blob/master/templates/server-config-configmap.yaml#L16) (also see #80), is there a need for `IPC_LOCK`?
This also helps with deploying on for example Openshift as we now only need `--set server.uid` and `--set server.gid` for the ranges allowed by the `restricted` SCC. No more mucking around with SCCs and capabilities.