### PR TITLE
Option to add additional files to ConfigMap

### DIFF
--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -94,6 +94,9 @@ extra volumes the user may have specified (such as a secret with TLS).
           {{- else if (eq .type "secret") }}
             secretName: {{ .name }}
           {{- end }}
+          {{- with .defaultMode }}
+          defaultMode: {{ . }}
+          {{- end }}
   {{- end }}
 {{- end -}}
 

--- a/templates/server-config-configmap.yaml
+++ b/templates/server-config-configmap.yaml
@@ -19,5 +19,6 @@ data:
   {{- else if eq .mode "ha" }}
     {{ tpl .Values.server.ha.config . | nindent 4 | trim }}
   {{ end }}
+  {{- .Values.server.extraConfigFiles | nindent 2 }}
 {{- end }}
 {{- end }}

--- a/values.yaml
+++ b/values.yaml
@@ -117,6 +117,15 @@ server:
   # extraContainers is a list of sidecar containers. Specified as a raw YAML string.
   extraContainers: null
 
+  # extraConfigFiles is a list of extra files to add to the ConfigMap containing the vault configuration.
+  # These files are mounted to /vault/config in the vault containers and could be referenced via extraArgs.
+  # This could also be useful if trying to add files to the containers specified with extraContainers.
+  extraConfigFiles: ""
+  # extraConfigFiles: |
+  #   init-script.sh: |
+  #     #!/bin/sh -ve
+  #     echo "Init commands here"
+
   # shareProcessNamespace enables process namespace sharing between Vault and the extraContainers
   # This is useful if Vault must be signaled, e.g. to send a SIGHUP for log rotation
   shareProcessNamespace: false
@@ -159,6 +168,7 @@ server:
     # - type: secret (or "configMap")
     #   name: my-secret
     #   path: null # default is `/vault/userconfig`
+    #   defaultMode: 0777 # optional
 
   # Affinity Settings
   # Commenting out or setting as empty the affinity variable, will allow


### PR DESCRIPTION
Add the option to add additional files to the ConfigMap and set a defaultMode on the volumes in the Pod. 

This makes the extraContainers option a little more useful for me as I can easily throw the script used to run it in the ConfigMap and make that script executable.