### PR TITLE
Added support for external vault

### DIFF
--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -51,7 +51,9 @@ Set the variable 'mode' to the server mode requested by the user to simplify
 template logic.
 */}}
 {{- define "vault.mode" -}}
-  {{- if eq (.Values.server.dev.enabled | toString) "true" -}}
+  {{- if .Values.injector.externalVaultAddr -}}
+    {{- $_ := set . "mode" "external" -}}
+  {{- else if eq (.Values.server.dev.enabled | toString) "true" -}}
     {{- $_ := set . "mode" "dev" -}}
   {{- else if eq (.Values.server.ha.enabled | toString) "true" -}}
     {{- $_ := set . "mode" "ha" -}}

--- a/templates/injector-deployment.yaml
+++ b/templates/injector-deployment.yaml
@@ -40,7 +40,11 @@ spec:
             - name: AGENT_INJECT_LOG_LEVEL
               value: {{ .Values.injector.logLevel | default "info" }}
             - name: AGENT_INJECT_VAULT_ADDR
+            {{- if .Values.injector.externalVaultAddr }}
+              value: "{{ .Values.injector.externalVaultAddr }}"
+            {{- else }}
               value: {{ include "vault.scheme" . }}://{{ template "vault.fullname" . }}.{{ .Release.Namespace }}.svc:{{ .Values.server.service.port }}
+            {{- end }}
             - name: AGENT_INJECT_VAULT_IMAGE
               value: "{{ .Values.injector.agentImage.repository }}:{{ .Values.injector.agentImage.tag }}"
             {{- if .Values.injector.certs.secretName }}

--- a/templates/server-clusterrolebinding.yaml
+++ b/templates/server-clusterrolebinding.yaml
@@ -1,4 +1,5 @@
 {{ template "vault.mode" . }}
+{{- if ne .mode "external" }}
 {{- if and (ne .mode "") (and (eq (.Values.global.enabled | toString) "true") (eq (.Values.server.authDelegator.enabled | toString) "true")) }}
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
@@ -18,4 +19,5 @@ subjects:
 - kind: ServiceAccount
   name: {{ template "vault.fullname" . }}
   namespace: {{ .Release.Namespace }}
+{{ end }}
 {{ end }}

--- a/templates/server-config-configmap.yaml
+++ b/templates/server-config-configmap.yaml
@@ -1,4 +1,5 @@
 {{ template "vault.mode" . }}
+{{- if ne .mode "external" }}
 {{- if and (eq (.Values.global.enabled | toString) "true") (ne .mode "dev") -}}
 {{ if or (ne .Values.server.standalone.config "")  (ne .Values.server.ha.config "") -}}
 apiVersion: v1
@@ -19,5 +20,6 @@ data:
   {{- else if eq .mode "ha" }}
     {{ tpl .Values.server.ha.config . | nindent 4 | trim }}
   {{ end }}
+{{- end }}
 {{- end }}
 {{- end }}

--- a/templates/server-disruptionbudget.yaml
+++ b/templates/server-disruptionbudget.yaml
@@ -1,4 +1,5 @@
 {{ template "vault.mode" . }}
+{{- if ne .mode "external" -}}
 {{- if and (and (eq (.Values.global.enabled | toString) "true") (eq .mode "ha")) (eq (.Values.server.ha.disruptionBudget.enabled | toString) "true") -}}
 # PodDisruptionBudget to prevent degrading the server cluster through
 # voluntary cluster changes.
@@ -19,4 +20,5 @@ spec:
       app.kubernetes.io/name: {{ include "vault.name" . }}
       app.kubernetes.io/instance: {{ .Release.Name }}
       component: server
+{{- end -}}
 {{- end -}}

--- a/templates/server-ingress.yaml
+++ b/templates/server-ingress.yaml
@@ -1,3 +1,5 @@
+{{ template "vault.mode" . }}
+{{- if ne .mode "external" }}
 {{- if .Values.server.ingress.enabled -}}
 {{- $serviceName := include "vault.fullname" . -}}
 {{- $servicePort := .Values.server.service.port -}}
@@ -41,4 +43,5 @@ spec:
               servicePort: {{ $servicePort }}
         {{- end }}
   {{- end }}
+{{- end }}
 {{- end }}

--- a/templates/server-service.yaml
+++ b/templates/server-service.yaml
@@ -1,3 +1,5 @@
+{{ template "vault.mode" . }}
+{{- if ne .mode "external" }}
 {{- if and (eq (.Values.server.service.enabled | toString) "true" ) (eq (.Values.global.enabled | toString) "true") }}
 # Service for Vault cluster
 apiVersion: v1
@@ -42,4 +44,5 @@ spec:
     app.kubernetes.io/name: {{ include "vault.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     component: server
+{{- end }}
 {{- end }}

--- a/templates/server-serviceaccount.yaml
+++ b/templates/server-serviceaccount.yaml
@@ -1,4 +1,5 @@
 {{ template "vault.mode" . }}
+{{- if ne .mode "external" }}
 {{- if and (ne .mode "") (eq (.Values.global.enabled | toString) "true") }}
 apiVersion: v1
 kind: ServiceAccount
@@ -11,4 +12,5 @@ metadata:
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
   {{ template "vault.serviceAccount.annotations" . }}
+{{ end }}
 {{ end }}

--- a/templates/server-statefulset.yaml
+++ b/templates/server-statefulset.yaml
@@ -1,4 +1,5 @@
 {{ template "vault.mode" . }}
+{{- if ne .mode "external" }}
 {{- if and (ne .mode "") (eq (.Values.global.enabled | toString) "true") }}
 # StatefulSet to run the actual vault server cluster.
 apiVersion: apps/v1
@@ -142,4 +143,5 @@ spec:
         {{- toYaml .Values.global.imagePullSecrets | nindent 8 }}
       {{- end }}
   {{ template "vault.volumeclaims" . }}
+{{ end }}
 {{ end }}

--- a/templates/ui-service.yaml
+++ b/templates/ui-service.yaml
@@ -1,4 +1,5 @@
 {{ template "vault.mode" . }}
+{{- if ne .mode "external" }}
 {{- if and (ne .mode "") (eq (.Values.global.enabled | toString) "true") }}
 {{- if eq (.Values.ui.enabled | toString) "true" }}
 # Headless service for Vault server DNS entries. This service should only
@@ -42,4 +43,5 @@ spec:
   {{- end }}
 {{- end -}}
 
+{{ end }}
 {{ end }}

--- a/test/unit/server-clusterrolebinding.bats
+++ b/test/unit/server-clusterrolebinding.bats
@@ -60,3 +60,13 @@ load _helpers
       yq 'length > 0' | tee /dev/stderr)
   [ "${actual}" = "false" ]
 }
+
+@test "server/ClusterRoleBinding: disable with injector.externalVaultAddr" {
+  cd `chart_dir`
+  local actual=$( (helm template \
+      --show-only templates/server-clusterrolebinding.yaml  \
+      --set 'injector.externalVaultAddr=http://vault-outside' \
+      . || echo "---") | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+}

--- a/test/unit/server-configmap.bats
+++ b/test/unit/server-configmap.bats
@@ -82,3 +82,13 @@ load _helpers
       yq '.data["extraconfig-from-values.hcl"] | match("bar") | length' | tee /dev/stderr)
   [ ! -z "${actual}" ]
 }
+
+@test "server/ConfigMap: disabled by injector.externalVaultAddr" {
+  cd `chart_dir`
+  local actual=$( (helm template \
+      --show-only templates/server-config-configmap.yaml \
+      --set 'injector.externalVaultAddr=http://vault-outside' \
+      . || echo "---") | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+}

--- a/test/unit/server-dev-statefulset.bats
+++ b/test/unit/server-dev-statefulset.bats
@@ -23,6 +23,17 @@ load _helpers
   [ "${actual}" = "false" ]
 }
 
+@test "server/dev-StatefulSet: disable with injector.externalVaultAddr" {
+  cd `chart_dir`
+  local actual=$( (helm template \
+      --show-only templates/server-statefulset.yaml  \
+      --set 'injector.externalVaultAddr=http://vault-outside' \
+      --set 'server.dev.enabled=true' \
+      . || echo "---") | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+}
+
 @test "server/dev-StatefulSet: image defaults to server.image.repository:tag" {
   cd `chart_dir`
   local actual=$(helm template \

--- a/test/unit/server-ha-disruptionbudget.bats
+++ b/test/unit/server-ha-disruptionbudget.bats
@@ -43,6 +43,16 @@ load _helpers
   [ "${actual}" = "false" ]
 }
 
+@test "server/DisruptionBudget: disable with injector.exernalVaultAddr" {
+  cd `chart_dir`
+  local actual=$( (helm template \
+      --show-only templates/server-disruptionbudget.yaml  \
+      --set 'injector.externalVaultAddr=http://vault-outside' \
+      . || echo "---") | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+}
+
 @test "server/DisruptionBudget: correct maxUnavailable with n=1" {
   cd `chart_dir`
   local actual=$(helm template \

--- a/test/unit/server-ha-statefulset.bats
+++ b/test/unit/server-ha-statefulset.bats
@@ -23,6 +23,17 @@ load _helpers
   [ "${actual}" = "false" ]
 }
 
+@test "server/ha-StatefulSet: disable with injector.externalVaultAddr" {
+  cd `chart_dir`
+  local actual=$( (helm template \
+      --show-only templates/server-statefulset.yaml  \
+      --set 'injector.externalVaultAddr=http://vault-outside' \
+      --set 'server.ha.enabled=true' \
+      . || echo "---") | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+}
+
 @test "server/ha-StatefulSet: image defaults to server.image.repository:tag" {
   cd `chart_dir`
   local actual=$(helm template \

--- a/test/unit/server-ingress.bats
+++ b/test/unit/server-ingress.bats
@@ -11,6 +11,17 @@ load _helpers
   [ "${actual}" = "false" ]
 }
 
+@test "server/ingress: disable by injector.externalVaultAddr" {
+  cd `chart_dir`
+  local actual=$( (helm template \
+      --show-only templates/server-ingress.yaml  \
+      --set 'server.ingress.enabled=true' \
+      --set 'injector.externalVaultAddr=http://vault-outside' \
+      . || echo "---") | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+}
+
 @test "server/ingress: checking host entry gets added and path is /" {
   cd `chart_dir`
   local actual=$(helm template \

--- a/test/unit/server-service.bats
+++ b/test/unit/server-service.bats
@@ -113,6 +113,36 @@ load _helpers
   [ "${actual}" = "false" ]
 }
 
+@test "server/Service: disable with injector.externalVaultAddr" {
+  cd `chart_dir`
+  local actual=$( (helm template \
+      --show-only templates/server-service.yaml  \
+      --set 'server.dev.enabled=true' \
+      --set 'injector.externalVaultAddr=http://vault-outside' \
+      --set 'server.service.enabled=true' \
+      . || echo "---") | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+
+  local actual=$( (helm template \
+      --show-only templates/server-service.yaml  \
+      --set 'server.ha.enabled=true' \
+      --set 'injector.externalVaultAddr=http://vault-outside' \
+      --set 'server.service.enabled=true' \
+      . || echo "---") | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+
+  local actual=$( (helm template \
+      --show-only templates/server-service.yaml  \
+      --set 'server.standalone.enabled=true' \
+      --set 'injector.externalVaultAddr=http://vault-outside' \
+      --set 'server.service.enabled=true' \
+      . || echo "---") | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+}
+
 # This can be seen as testing just what we put into the YAML raw, but
 # this is such an important part of making everything work we verify it here.
 @test "server/Service: tolerates unready endpoints" {

--- a/test/unit/server-serviceaccount.bats
+++ b/test/unit/server-serviceaccount.bats
@@ -27,3 +27,57 @@ load _helpers
       yq -r '.metadata.annotations["foo"]' | tee /dev/stderr)
   [ "${actual}" = "null" ]
 }
+
+@test "server/ServiceAccount: disable with global.enabled false" {
+  cd `chart_dir`
+  local actual=$( (helm template \
+      --show-only templates/server-service.yaml  \
+      --set 'server.dev.enabled=true' \
+      --set 'global.enabled=false' \
+      . || echo "---") | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+
+  local actual=$( (helm template \
+      --show-only templates/server-service.yaml  \
+      --set 'server.ha.enabled=true' \
+      --set 'global.enabled=false' \
+      . || echo "---") | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+
+  local actual=$( (helm template \
+      --show-only templates/server-service.yaml  \
+      --set 'server.standalone.enabled=true' \
+      --set 'global.enabled=false' \
+      . || echo "---") | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+}
+
+@test "server/ServiceAccount: disable by injector.externalVaultAddr" {
+  cd `chart_dir`
+  local actual=$( (helm template \
+      --show-only templates/server-service.yaml  \
+      --set 'server.dev.enabled=true' \
+      --set 'injector.externalVaultAddr=http://vault-outside' \
+      . || echo "---") | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+
+  local actual=$( (helm template \
+      --show-only templates/server-service.yaml  \
+      --set 'server.ha.enabled=true' \
+      --set 'injector.externalVaultAddr=http://vault-outside' \
+      . || echo "---") | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+
+  local actual=$( (helm template \
+      --show-only templates/server-service.yaml  \
+      --set 'server.standalone.enabled=true' \
+      --set 'injector.externalVaultAddr=http://vault-outside' \
+      . || echo "---") | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+}

--- a/test/unit/server-statefulset.bats
+++ b/test/unit/server-statefulset.bats
@@ -32,6 +32,17 @@ load _helpers
   [ "${actual}" = "false" ]
 }
 
+@test "server/standalone-StatefulSet: disable with injector.externalVaultAddr" {
+  cd `chart_dir`
+  local actual=$( (helm template \
+      --show-only templates/server-statefulset.yaml  \
+      --set 'injector.externalVaultAddr=http://vault-outside' \
+      --set 'server.standalone.enabled=true' \
+      . || echo "---") | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+}
+
 @test "server/standalone-StatefulSet: image defaults to server.image.repository:tag" {
   cd `chart_dir`
   local actual=$(helm template \

--- a/test/unit/ui-service.bats
+++ b/test/unit/ui-service.bats
@@ -53,6 +53,33 @@ load _helpers
   [ "${actual}" = "false" ]
 }
 
+@test "ui/Service: disable with injector.externalVaultAddr" {
+  cd `chart_dir`
+  local actual=$( (helm template \
+      --show-only templates/ui-service.yaml  \
+      --set 'server.dev.enabled=true' \
+      --set 'injector.externalVaultAddr=http://vault-outside' \
+      . || echo "---") | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+
+  local actual=$( (helm template \
+      --show-only templates/ui-service.yaml  \
+      --set 'server.ha.enabled=true' \
+      --set 'injector.externalVaultAddr=http://vault-outside' \
+      . || echo "---") | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+
+  local actual=$( (helm template \
+      --show-only templates/ui-service.yaml  \
+      --set 'server.standalone.enabled=true' \
+      --set 'injector.externalVaultAddr=http://vault-outside' \
+      . || echo "---") | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+}
+
 @test "ui/Service: ClusterIP type by default" {
   cd `chart_dir`
   local actual=$(helm template \

--- a/values.yaml
+++ b/values.yaml
@@ -15,6 +15,10 @@ injector:
   # True if you want to enable vault agent injection.
   enabled: true
 
+  # External vault server address for the injector to use. Setting this will
+  # disable deployment of a vault server along with the injector.
+  externalVaultAddr: ""
+
   # image sets the repo and tag of the vault-k8s image to use for the injector.
   image:
     repository: "hashicorp/vault-k8s"


### PR DESCRIPTION
Uses `Values.injector.externalVaultAddr` to control the vault address
env variable and server yaml rendering. 

If `injector.externalVaultAddr` is empty, both the injector and vault are deployed, with the injector using the local vault. If `injector.externalVaultAddr` is not empty, only the injector is deployed, and it uses the vault at the address specified in `injector.externalVaultAddr`.

Related to #167, #173, #202 