### PR TITLE
Change config specification

### DIFF
--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -83,7 +83,7 @@ defined a custom configuration.  Additionally iterates over any
 extra volumes the user may have specified (such as a secret with TLS).
 */}}
 {{- define "vault.volumes" -}}
-  {{- if and (ne .mode "dev") (or (ne .Values.server.standalone.config "")  (ne .Values.server.ha.config "")) }}
+  {{- if and (ne .mode "dev") (or (.Values.server.standalone.config) (.Values.server.ha.config)) }}
         - name: config
           configMap:
             name: {{ template "vault.fullname" . }}-config
@@ -150,7 +150,7 @@ based on the mode configured.
               mountPath: /vault/data
     {{ end }}
   {{ end }}
-  {{ if and (ne .mode "dev") (or (ne .Values.server.standalone.config "")  (ne .Values.server.ha.config "")) }}
+  {{ if and (ne .mode "dev") (or (.Values.server.standalone.config)  (.Values.server.ha.config)) }}
             - name: config
               mountPath: /vault/config
   {{ end }}

--- a/templates/server-config-configmap.yaml
+++ b/templates/server-config-configmap.yaml
@@ -14,7 +14,7 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
 data:
   extraconfig-from-values.hcl: |-
-  {{- if or (eq .mode "ha") (eq .mode "standalone")}}
+  {{- if or (eq .mode "ha") (eq .mode "standalone") }}
   {{- $type := typeOf (index .Values.server .mode).config }}
   {{- if eq $type "string" }}
     disable_mlock = true
@@ -26,8 +26,11 @@ data:
     {{ tpl .Values.server.ha.raft.config . | nindent 4 | trim }}
   {{ end }}
   {{- else }}
-  {{- $config := merge (dict "disable_mlock" true) (index .Values.server .mode).config }}
-{{ $config | toPrettyJson | indent 4 }}
+  {{- if and (eq .mode "ha") (eq (.Values.server.ha.raft.enabled | toString) "true") }}
+{{ merge (dict "disable_mlock" true) (index .Values.server .mode).raft.config | toPrettyJson | indent 4 }}
+  {{- else }}
+{{ merge (dict "disable_mlock" true) (index .Values.server .mode).config | toPrettyJson | indent 4 }}
+  {{- end }}
   {{- end }}
   {{- end }}
 {{- end }}

--- a/templates/server-config-configmap.yaml
+++ b/templates/server-config-configmap.yaml
@@ -1,7 +1,7 @@
 {{ template "vault.mode" . }}
 {{- if ne .mode "external" }}
 {{- if and (eq (.Values.global.enabled | toString) "true") (ne .mode "dev") -}}
-{{ if or (ne .Values.server.standalone.config "")  (ne .Values.server.ha.config "") -}}
+{{ if or (.Values.server.standalone.config) (.Values.server.ha.config) -}}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/templates/server-config-configmap.yaml
+++ b/templates/server-config-configmap.yaml
@@ -15,13 +15,10 @@ metadata:
 data:
   extraconfig-from-values.hcl: |-
     disable_mlock = true
-  {{- if eq .mode "standalone" }}
-    {{ tpl .Values.server.standalone.config . | nindent 4 | trim }}
-  {{- else if and (eq .mode "ha") (eq (.Values.server.ha.raft.enabled | toString) "false") }}
-    {{ tpl .Values.server.ha.config . | nindent 4 | trim }}
-  {{- else if and (eq .mode "ha") (eq (.Values.server.ha.raft.enabled | toString) "true") }}
-    {{ tpl .Values.server.ha.raft.config . | nindent 4 | trim }}
-  {{ end }}
+  {{- if or (eq .mode "ha") (eq .mode "standalone")}}
+  {{- $config := merge (dict "disable_mlock" true) (index .Values.server .mode).config }}
+{{ $config | toPrettyJson | indent 4 }}
+  {{- end }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/templates/server-config-configmap.yaml
+++ b/templates/server-config-configmap.yaml
@@ -14,10 +14,21 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
 data:
   extraconfig-from-values.hcl: |-
-    disable_mlock = true
   {{- if or (eq .mode "ha") (eq .mode "standalone")}}
+  {{- $type := typeOf (index .Values.server .mode).config }}
+  {{- if eq $type "string" }}
+    disable_mlock = true
+  {{- if eq .mode "standalone" }}
+    {{ tpl .Values.server.standalone.config . | nindent 4 | trim }}
+  {{- else if and (eq .mode "ha") (eq (.Values.server.ha.raft.enabled | toString) "false") }}
+    {{ tpl .Values.server.ha.config . | nindent 4 | trim }}
+  {{- else if and (eq .mode "ha") (eq (.Values.server.ha.raft.enabled | toString) "true") }}
+    {{ tpl .Values.server.ha.raft.config . | nindent 4 | trim }}
+  {{ end }}
+  {{- else }}
   {{- $config := merge (dict "disable_mlock" true) (index .Values.server .mode).config }}
 {{ $config | toPrettyJson | indent 4 }}
+  {{- end }}
   {{- end }}
 {{- end }}
 {{- end }}

--- a/values.yaml
+++ b/values.yaml
@@ -308,26 +308,27 @@ server:
     # deployment. Default is to use a PersistentVolumeClaim mounted at /vault/data
     # and store data there. This is only used when using a Replica count of 1, and
     # using a stateful set. This should be HCL.
-    config:
-      ui: true
-      listener:
-        tcp:
-          address: "[::]:8200"
-          cluster_address: "[::]:8201"
-          tls_disable: 1
-      storage:
-        file:
-          path: "/vault/data"
+    config: |
+      ui = true
+
+      listener "tcp" {
+        tls_disable = 1
+        address = "[::]:8200"
+        cluster_address = "[::]:8201"
+      }
+      storage "file" {
+        path = "/vault/data"
+      }
 
       # Example configuration for using auto-unseal, using Google Cloud KMS. The
       # GKMS keys must already exist, and the cluster must have a service account
       # that is authorized to access GCP KMS.
-      #seal:
-      #  - gcpckms:
-      #      crypto_key: "vault-helm-unseal-key"
-      #      key_ring: "vault-helm-unseal-kr"
-      #      project: "vault-helm-dev"
-      #      region: global
+      #seal "gcpckms" {
+      #   project     = "vault-helm-dev"
+      #   region      = "global"
+      #   key_ring    = "vault-helm-unseal-kr"
+      #   crypto_key  = "vault-helm-unseal-key"
+      #}
 
   # Run Vault in "HA" mode. There are no storage requirements unless audit log
   # persistence is required.  In HA mode Vault will configure itself to use Consul
@@ -363,26 +364,30 @@ server:
     # config is a raw string of default configuration when using a Stateful
     # deployment. Default is to use a Consul for its HA storage backend.
     # This should be HCL.
-    config:
-      ui: true
-      listener:
-        - tcp:
-            address: "[::]:8200"
-            cluster_address: "[::]:8201"
-            tls_disable: 1
-      storage:
-        - consul:
-            address: "HOST_IP:8500"
-            path: vault
+    config: |
+      ui = true
+
+      listener "tcp" {
+        tls_disable = 1
+        address = "[::]:8200"
+        cluster_address = "[::]:8201"
+      }
+      storage "consul" {
+        path = "vault"
+        address = "HOST_IP:8500"
+      }
+
+      service_registration "kubernetes" {}
+
       # Example configuration for using auto-unseal, using Google Cloud KMS. The
       # GKMS keys must already exist, and the cluster must have a service account
       # that is authorized to access GCP KMS.
-      #seal:
-      #  - gcpckms:
-      #      crypto_key: "vault-helm-unseal-key"
-      #      key_ring: "vault-helm-unseal-kr"
-      #      project: "vault-helm-dev"
-      #      region: global
+      #seal "gcpckms" {
+      #   project     = "vault-helm-dev-246514"
+      #   region      = "global"
+      #   key_ring    = "vault-helm-unseal-kr"
+      #   crypto_key  = "vault-helm-unseal-key"
+      #}
 
     # A disruption budget limits the number of pods of a replicated application
     # that are down simultaneously from voluntary disruptions

--- a/values.yaml
+++ b/values.yaml
@@ -308,27 +308,26 @@ server:
     # deployment. Default is to use a PersistentVolumeClaim mounted at /vault/data
     # and store data there. This is only used when using a Replica count of 1, and
     # using a stateful set. This should be HCL.
-    config: |
-      ui = true
-
-      listener "tcp" {
-        tls_disable = 1
-        address = "[::]:8200"
-        cluster_address = "[::]:8201"
-      }
-      storage "file" {
-        path = "/vault/data"
-      }
+    config:
+      ui: true
+      listener:
+        tcp:
+          address: "[::]:8200"
+          cluster_address: "[::]:8201"
+          tls_disable: 1
+      storage:
+        file:
+          path: "/vault/data"
 
       # Example configuration for using auto-unseal, using Google Cloud KMS. The
       # GKMS keys must already exist, and the cluster must have a service account
       # that is authorized to access GCP KMS.
-      #seal "gcpckms" {
-      #   project     = "vault-helm-dev"
-      #   region      = "global"
-      #   key_ring    = "vault-helm-unseal-kr"
-      #   crypto_key  = "vault-helm-unseal-key"
-      #}
+      #seal:
+      #  - gcpckms:
+      #      crypto_key: "vault-helm-unseal-key"
+      #      key_ring: "vault-helm-unseal-kr"
+      #      project: "vault-helm-dev"
+      #      region: global
 
   # Run Vault in "HA" mode. There are no storage requirements unless audit log
   # persistence is required.  In HA mode Vault will configure itself to use Consul
@@ -364,30 +363,26 @@ server:
     # config is a raw string of default configuration when using a Stateful
     # deployment. Default is to use a Consul for its HA storage backend.
     # This should be HCL.
-    config: |
-      ui = true
-
-      listener "tcp" {
-        tls_disable = 1
-        address = "[::]:8200"
-        cluster_address = "[::]:8201"
-      }
-      storage "consul" {
-        path = "vault"
-        address = "HOST_IP:8500"
-      }
-
-      service_registration "kubernetes" {}
-
+    config:
+      ui: true
+      listener:
+        - tcp:
+            address: "[::]:8200"
+            cluster_address: "[::]:8201"
+            tls_disable: 1
+      storage:
+        - consul:
+            address: "HOST_IP:8500"
+            path: vault
       # Example configuration for using auto-unseal, using Google Cloud KMS. The
       # GKMS keys must already exist, and the cluster must have a service account
       # that is authorized to access GCP KMS.
-      #seal "gcpckms" {
-      #   project     = "vault-helm-dev-246514"
-      #   region      = "global"
-      #   key_ring    = "vault-helm-unseal-kr"
-      #   crypto_key  = "vault-helm-unseal-key"
-      #}
+      #seal:
+      #  - gcpckms:
+      #      crypto_key: "vault-helm-unseal-key"
+      #      key_ring: "vault-helm-unseal-kr"
+      #      project: "vault-helm-dev"
+      #      region: global
 
     # A disruption budget limits the number of pods of a replicated application
     # that are down simultaneously from voluntary disruptions


### PR DESCRIPTION
As it is right now, the specification of the config is done through a string. When using storage backends like PostgreSQL, the password for the database has to be included in the config variable of the values file.

This change allows to specify the configuration through a map, making the chart GitOps friendly (eg. using it with [Flux](https://github.com/fluxcd/flux)). Now, sensitive values can be stored in a different values file or passed on deployment time with `--set`.

To have a very generic specification:
- I've assumed that the combination stanza (eg. storage) name (eg. file) is unique.
- Quoted values for all stanza parameters. I tested a generated configuration in a vault docker image and it seems to work just fine.

As an example, your values file could contain something like this:
```yaml
server:
  standalone:
    config:
      ui: true
      listener:
        tcp:
          address: "[::]:8200"
          cluster_address: "[::]:8201"
          tls_disable: 1
      storage:
        file:
          path: "/vault/data"
      telemetry:
        statsite_address: "127.0.0.1:8125"
        disable_hostname: true
```
**Edit**:

As stated by @jasonodonnell, Vault support json as a format for the configuration. The new change will generate the following ConfigMap when providing the values shown above:
```yaml
---
# Source: vault/templates/server-config-configmap.yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: RELEASE-NAME-vault-config
  namespace: default
  labels:
    helm.sh/chart: vault-0.4.0
    app.kubernetes.io/name: vault
    app.kubernetes.io/instance: RELEASE-NAME
    app.kubernetes.io/managed-by: Helm
data:
  extraconfig-from-values.hcl: |-
    {
      "disable_mlock": true,
      "listener": {
        "tcp": {
          "address": "[::]:8200",
          "cluster_address": "[::]:8201",
          "tls_disable": 1
        }
      },
      "storage": {
        "file": {
          "path": "/vault/data"
        }
      },
      "telemetry": {
        "disable_hostname": true,
        "statsite_address": "127.0.0.1:8125"
      },
      "ui": true
    }
```