### PR TITLE
Add ability to use custom auth path

### DIFF
--- a/templates/injector-deployment.yaml
+++ b/templates/injector-deployment.yaml
@@ -35,6 +35,8 @@ spec:
           image: "{{ .Values.injector.image.repository }}:{{ .Values.injector.image.tag }}"
           imagePullPolicy: "{{ .Values.injector.image.pullPolicy }}"
           env:
+            - name: AGENT_INJECT_VAULT_AUTH_PATH
+              value: {{ .Values.injector.auth_path }}
             - name: AGENT_INJECT_LISTEN
               value: ":8080"
             - name: AGENT_INJECT_LOG_LEVEL

--- a/values.yaml
+++ b/values.yaml
@@ -19,6 +19,11 @@ injector:
   # disable deployment of a vault server along with the injector.
   externalVaultAddr: ""
 
+  # Path to kubernetes authentication, default auth/kubernetes
+  # Desirable when using in multiple clusters
+  # Set in vault by running `vault auth enable -path some-path kubernetes`
+  auth_path: "auth/kubernetes"
+
   # image sets the repo and tag of the vault-k8s image to use for the injector.
   image:
     repository: "hashicorp/vault-k8s"


### PR DESCRIPTION
It's desirable to use a different auth path when using multiple k8s clusters. I noticed [most of the work](https://github.com/hashicorp/vault-k8s/blob/ed146a2114aa1cc08c12f6dc29fae5ee23c69552/subcommand/injector/flags.go#L51) was already there to accomplish this and wanted to add the functionality to the Helm Chart

I will be out most of next week, I can get to suggestions when I get back - feel free to make any changes