### PR TITLE
Fix enterprise branch unit and acceptance tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@ vaul-helm-dev-creds.json
 ./test/unit/vaul-helm-dev-creds.json
 ./test/acceptance/values.yaml
 ./test/acceptance/values.yml
+
+# IDEs
+.idea/*

--- a/templates/server-statefulset.yaml
+++ b/templates/server-statefulset.yaml
@@ -72,8 +72,6 @@ spec:
               value: "{{ include "vault.scheme" . }}://127.0.0.1:8200"
             - name: VAULT_API_ADDR
               value: "{{ include "vault.scheme" . }}://$(POD_IP):8200"
-            - name: VAULT_CLUSTER_ADDR
-              value: "https://$(POD_IP):8201"
             - name: SKIP_CHOWN
               value: "true"
             - name: SKIP_SETCAP

--- a/test/acceptance/server-ha.bats
+++ b/test/acceptance/server-ha.bats
@@ -6,6 +6,7 @@ load _helpers
   cd `chart_dir`
 
   helm install "$(name_prefix)" \
+    --set server.affinity=null \
     --set='server.ha.enabled=true' .
   
   # Breathing room
@@ -97,10 +98,10 @@ setup() {
   kubectl create namespace acceptance
   kubectl config set-context --current --namespace=acceptance
 
-  helm install consul \
-    https://github.com/hashicorp/consul-helm/archive/v0.16.2.tar.gz \
+  helm install consul https://github.com/hashicorp/consul-helm/archive/v0.8.1.tar.gz \
     --set 'ui.enabled=false' \
-    --wait 
+    --set server.affinity=null \
+    --wait
 }
 
 #cleanup

--- a/test/acceptance/values-us-west.yaml
+++ b/test/acceptance/values-us-west.yaml
@@ -4,6 +4,8 @@ server:
     replicas: 3
 
     config: |
+      ui = true
+
       listener "tcp" {
         tls_disable = 1
         address = "[::]:8200"


### PR DESCRIPTION
This PR fixes unit and acceptance tests on the `enterprise` branch.

Because I'm testing on `minikube`, I needed to add a line of `--set server.affinity=null` in a few places. That's because `minikube` is the only node, and this allows everything to be tested on it. However, if it's preferable I strip that line because the tests are intended to be run on EKS or in some other, more fully fledged environment, I'm happy to do that.