### PR TITLE
fix(templates/server): ingress has default paths of /

### DIFF
--- a/templates/server-ingress.yaml
+++ b/templates/server-ingress.yaml
@@ -36,7 +36,7 @@ spec:
     - host: {{ .host | quote }}
       http:
         paths:
-        {{- range (.paths | default (array "/")) }}
+        {{- range (.paths | default (list "/")) }}
           - path: {{ . }}
             backend:
               serviceName: {{ $serviceName }}

--- a/templates/server-ingress.yaml
+++ b/templates/server-ingress.yaml
@@ -36,7 +36,7 @@ spec:
     - host: {{ .host | quote }}
       http:
         paths:
-        {{- range .paths }}
+        {{- range (.paths | default (array "/")) }}
           - path: {{ . }}
             backend:
               serviceName: {{ $serviceName }}


### PR DESCRIPTION
**What this PR does**: Fixes an empty array for `paths` resulting in a generation error.

```
Error: unable to build kubernetes objects from release manifest: error validating "": error validating data: ValidationError(Ingress.spec.rules[0].http): missing required field "paths" in io.k8s.api.extensions.v1beta1.HTTPIngressRuleValue
```

Another way of doing this is just setting `paths` to be have `/` as a element, but I don't like relying on `values.yaml` personally.