### PR TITLE
Add selectors for injector deployment

### DIFF
--- a/templates/injector-deployment.yaml
+++ b/templates/injector-deployment.yaml
@@ -24,6 +24,9 @@ spec:
         app.kubernetes.io/instance: {{ .Release.Name }}
         component: webhook
     spec:
+      {{ template "vault.affinity" . }}
+      {{ template "vault.tolerations" . }}
+      {{ template "vault.nodeselector" . }}
       serviceAccountName: "{{ template "vault.fullname" . }}-agent-injector"
       securityContext:
         runAsNonRoot: true


### PR DESCRIPTION
Added specs to injector deployment:
- affinity
- toleration
- nodeselector

It will give ability to place the pod on proper node.
Better to have separate configuration for server itself and injector, but then it required more changes.

Signed-off-by: Sergei Shishov <sergei.shishov@dubizzle.com>