### PR TITLE
Making all annotations multi-line strings

### DIFF
--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -244,7 +244,7 @@ Sets extra ui service annotations
 {{- define "vault.ui.annotations" -}}
   {{- if .Values.ui.annotations }}
   annotations:
-    {{- toYaml .Values.ui.annotations | nindent 4 }}
+    {{- tpl .Values.ui.annotations . | nindent 4 }}
   {{- end }}
 {{- end -}}
 
@@ -254,7 +254,17 @@ Sets extra service account annotations
 {{- define "vault.serviceAccount.annotations" -}}
   {{- if and (ne .mode "dev") .Values.server.serviceAccount.annotations }}
   annotations:
-    {{- toYaml .Values.server.serviceAccount.annotations | nindent 4 }}
+    {{- tpl .Values.server.serviceAccount.annotations . | nindent 4 }}
+  {{- end }}
+{{- end -}}
+
+{{/*
+Sets extra ingress annotations
+*/}}
+{{- define "vault.ingress.annotations" -}}
+  {{- if .Values.server.ingress.annotations }}
+  annotations:
+    {{- tpl .Values.server.ingress.annotations . | nindent 4 }}
   {{- end }}
 {{- end -}}
 

--- a/templates/server-ingress.yaml
+++ b/templates/server-ingress.yaml
@@ -16,10 +16,7 @@ metadata:
     {{- with .Values.server.ingress.labels }}
       {{- toYaml . | nindent 4 }}
     {{- end }}
-  {{- with .Values.server.ingress.annotations }}
-  annotations:
-    {{- toYaml . | nindent 4 }}
-  {{- end }}
+  {{- template "vault.ingress.annotations" . }}
 spec:
 {{- if .Values.server.ingress.tls }}
   tls:

--- a/templates/server-service.yaml
+++ b/templates/server-service.yaml
@@ -18,7 +18,7 @@ metadata:
     # https://github.com/kubernetes/kubernetes/issues/58662
     service.alpha.kubernetes.io/tolerate-unready-endpoints: "true"
 {{- if .Values.server.service.annotations }}
-{{ toYaml .Values.server.service.annotations | indent 4 }}
+{{ tpl .Values.server.service.annotations . | indent 4 }}
 {{- end }}
 spec:
   {{- if .Values.server.service.type}}

--- a/test/unit/server-ingress.bats
+++ b/test/unit/server-ingress.bats
@@ -69,3 +69,15 @@ load _helpers
       yq -r '.metadata.labels.traffic' | tee /dev/stderr)
   [ "${actual}" = "external" ]
 }
+
+@test "server/ingress: annotations added to object" {
+  cd `chart_dir`
+
+  local actual=$(helm template \
+      --show-only templates/server-ingress.yaml \
+      --set 'server.ingress.enabled=true' \
+      --set 'server.ingress.annotations=kubernetes.io/ingress.class: nginx' \
+      . | tee /dev/stderr |
+      yq -r '.metadata.annotations["kubernetes.io/ingress.class"]' | tee /dev/stderr)
+  [ "${actual}" = "nginx" ]
+}

--- a/test/unit/server-service.bats
+++ b/test/unit/server-service.bats
@@ -173,7 +173,7 @@ load _helpers
   cd `chart_dir`
   local actual=$(helm template \
       --show-only templates/server-service.yaml \
-      --set 'server.service.annotations.vaultIsAwesome=true' \
+      --set 'server.service.annotations=vaultIsAwesome: true' \
       . | tee /dev/stderr |
       yq -r '.metadata.annotations["vaultIsAwesome"]' | tee /dev/stderr)
   [ "${actual}" = "true" ]

--- a/test/unit/server-serviceaccount.bats
+++ b/test/unit/server-serviceaccount.bats
@@ -7,7 +7,7 @@ load _helpers
   local actual=$(helm template \
       --show-only templates/server-serviceaccount.yaml  \
       --set 'server.dev.enabled=true' \
-      --set 'server.serviceAccount.annotations.foo=bar' \
+      --set 'server.serviceAccount.annotations=foo: bar' \
       . | tee /dev/stderr |
       yq -r '.metadata.annotations["foo"]' | tee /dev/stderr)
   [ "${actual}" = "null" ]
@@ -15,7 +15,7 @@ load _helpers
   local actual=$(helm template \
       --show-only templates/server-serviceaccount.yaml  \
       --set 'server.ha.enabled=true' \
-      --set 'server.serviceAccount.annotations.foo=bar' \
+      --set 'server.serviceAccount.annotations=foo: bar' \
       . | tee /dev/stderr |
       yq -r '.metadata.annotations["foo"]' | tee /dev/stderr)
   [ "${actual}" = "bar" ]

--- a/test/unit/ui-service.bats
+++ b/test/unit/ui-service.bats
@@ -190,7 +190,7 @@ load _helpers
       --set 'server.dev.enabled=true' \
       --set 'ui.serviceType=LoadBalancer' \
       --set 'ui.enabled=true' \
-      --set 'ui.annotations.foo=bar' \
+      --set 'ui.annotations=foo: bar' \
       . | tee /dev/stderr |
       yq -r '.metadata.annotations["foo"]' | tee /dev/stderr)
   [ "${actual}" = "bar" ]
@@ -200,7 +200,7 @@ load _helpers
       --set 'server.ha.enabled=true' \
       --set 'ui.serviceType=LoadBalancer' \
       --set 'ui.enabled=true' \
-      --set 'ui.annotations.foo=bar' \
+      --set 'ui.annotations=foo: bar' \
       . | tee /dev/stderr |
       yq -r '.metadata.annotations["foo"]' | tee /dev/stderr)
   [ "${actual}" = "bar" ]

--- a/values.yaml
+++ b/values.yaml
@@ -45,11 +45,11 @@ injector:
   revokeOnShutdown: false
 
   # namespaceSelector is the selector for restricting the webhook to only
-  # specific namespaces. This should be set to a multiline string.
+  # specific namespaces.
   # See https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/#matching-requests-namespaceselector
   # for more details.
   # Example:
-  # namespaceSelector: |
+  # namespaceSelector:
   #    matchLabels:
   #      sidecar-injector: enabled
   namespaceSelector: {}
@@ -112,6 +112,7 @@ server:
     labels: {}
       # traffic: external
     annotations: {}
+      # |
       # kubernetes.io/ingress.class: nginx
       # kubernetes.io/tls-acme: "true"
     hosts:
@@ -234,7 +235,8 @@ server:
     port: 8200
     # Target port to which the service should be mapped to
     targetPort: 8200
-    # Extra annotations for the service definition
+    # Extra annotations for the service definition. This should be a multi-line
+    # string formatted as a map of the annotations to apply to the service.
     annotations: {}
 
   # This configures the Vault Statefulset to create a PVC for data
@@ -352,6 +354,9 @@ server:
 
   # Definition of the serviceAccount used to run Vault.
   serviceAccount:
+    # Extra annotations for the serviceAccount definition. This should be a
+    # multi-line string formatted as a map of the annotations to apply to the
+    # serviceAccount.
     annotations: {}
 
 # Vault UI


### PR DESCRIPTION
Annotations for various objects were either multi-line strings or yaml
maps strings, so this is making them all multi-line strings for
consistency. Also updated the doc comment for namespaceSelector, since
it's being read as a yaml map (toYaml).

Relates to #117 