### PR TITLE
Add Raft HA support

### DIFF
--- a/templates/server-config-configmap.yaml
+++ b/templates/server-config-configmap.yaml
@@ -17,8 +17,10 @@ data:
     disable_mlock = true
   {{- if eq .mode "standalone" }}
     {{ tpl .Values.server.standalone.config . | nindent 4 | trim }}
-  {{- else if eq .mode "ha" }}
+  {{- else if and (eq .mode "ha") (eq (.Values.server.ha.raft.enabled | toString) "false") }}
     {{ tpl .Values.server.ha.config . | nindent 4 | trim }}
+  {{- else if and (eq .mode "ha") (eq (.Values.server.ha.raft.enabled | toString) "true") }}
+    {{ tpl .Values.server.ha.raft.config . | nindent 4 | trim }}
   {{ end }}
 {{- end }}
 {{- end }}

--- a/templates/server-headless-service.yaml
+++ b/templates/server-headless-service.yaml
@@ -1,0 +1,35 @@
+{{ template "vault.mode" . }}
+{{- if ne .mode "external" }}
+{{- if and (eq (.Values.server.service.enabled | toString) "true" ) (eq (.Values.global.enabled | toString) "true") }}
+# Service for Vault cluster
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "vault.fullname" . }}-internal
+  namespace: {{ .Release.Namespace }}
+  labels:
+    helm.sh/chart: {{ include "vault.chart" . }}
+    app.kubernetes.io/name: {{ include "vault.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+  annotations:
+    service.alpha.kubernetes.io/tolerate-unready-endpoints: "true"
+{{- if .Values.server.service.annotations }}
+{{ toYaml .Values.server.service.annotations | indent 4 }}
+{{- end }}
+spec:
+  clusterIP: None
+  publishNotReadyAddresses: true
+  ports:
+    - name: http
+      port: {{ .Values.server.service.port }}
+      targetPort: {{ .Values.server.service.targetPort }}
+    - name: internal
+      port: 8201
+      targetPort: 8201
+  selector:
+    app.kubernetes.io/name: {{ include "vault.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    component: server
+{{- end }}
+{{- end }}

--- a/templates/server-headless-service.yaml
+++ b/templates/server-headless-service.yaml
@@ -21,7 +21,7 @@ spec:
   clusterIP: None
   publishNotReadyAddresses: true
   ports:
-    - name: http
+    - name: "{{ include "vault.scheme" . }}"
       port: {{ .Values.server.service.port }}
       targetPort: {{ .Values.server.service.targetPort }}
     - name: internal

--- a/templates/server-statefulset.yaml
+++ b/templates/server-statefulset.yaml
@@ -12,7 +12,7 @@ metadata:
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
 spec:
-  serviceName: {{ template "vault.fullname" . }}
+  serviceName: {{ template "vault.fullname" . }}-internal
   podManagementPolicy: Parallel
   replicas: {{ template "vault.replicas" . }}
   updateStrategy:
@@ -71,11 +71,15 @@ spec:
             - name: VAULT_ADDR
               value: "{{ include "vault.scheme" . }}://127.0.0.1:8200"
             - name: VAULT_API_ADDR
-              value: "{{ include "vault.scheme" . }}://$(POD_IP):8200"
+              value: "{{ include "vault.scheme" . }}-internal://$(POD_IP):8200"
             - name: SKIP_CHOWN
               value: "true"
             - name: SKIP_SETCAP
               value: "true"
+            - name: HOSTNAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
             {{ template "vault.envs" . }}
             {{- include "vault.extraEnvironmentVars" .Values.server | nindent 12 }}
             {{- include "vault.extraSecretEnvironmentVars" .Values.server | nindent 12 }}

--- a/test/acceptance/server-ha-raft.bats
+++ b/test/acceptance/server-ha-raft.bats
@@ -1,0 +1,110 @@
+#!/usr/bin/env bats
+
+load _helpers
+
+@test "server/ha: testing deployment" {
+  cd `chart_dir`
+
+  helm install "$(name_prefix)" \
+    --set='server.ha.enabled=true' .
+  wait_for_running $(name_prefix)-0
+
+  # Sealed, not initialized
+  local sealed_status=$(kubectl exec "$(name_prefix)-0" -- vault status -format=json |
+    jq -r '.sealed' )
+  [ "${sealed_status}" == "true" ]
+
+  local init_status=$(kubectl exec "$(name_prefix)-0" -- vault status -format=json |
+    jq -r '.initialized')
+  [ "${init_status}" == "false" ]
+
+  # Security
+  local ipc=$(kubectl get statefulset "$(name_prefix)" --output json |
+    jq -r '.spec.template.spec.containers[0].securityContext.capabilities.add[0]')
+  [ "${ipc}" == "IPC_LOCK" ]
+
+  # Replicas
+  local replicas=$(kubectl get statefulset "$(name_prefix)" --output json |
+    jq -r '.spec.replicas')
+  [ "${replicas}" == "3" ]
+
+  # Volume Mounts
+  local volumeCount=$(kubectl get statefulset "$(name_prefix)" --output json |
+    jq -r '.spec.template.spec.containers[0].volumeMounts | length')
+  [ "${volumeCount}" == "1" ]
+
+  # Volumes
+  local volumeCount=$(kubectl get statefulset "$(name_prefix)" --output json |
+    jq -r '.spec.template.spec.volumes | length')
+  [ "${volumeCount}" == "1" ]
+
+  local volume=$(kubectl get statefulset "$(name_prefix)" --output json |
+    jq -r '.spec.template.spec.volumes[0].configMap.name')
+  [ "${volume}" == "$(name_prefix)-config" ]
+
+  # Service
+  local service=$(kubectl get service "$(name_prefix)" --output json |
+    jq -r '.spec.clusterIP')
+  [ "${service}" != "None" ]
+
+  local service=$(kubectl get service "$(name_prefix)" --output json |
+    jq -r '.spec.type')
+  [ "${service}" == "ClusterIP" ]
+
+  local ports=$(kubectl get service "$(name_prefix)" --output json |
+    jq -r '.spec.ports | length')
+  [ "${ports}" == "2" ]
+
+  local ports=$(kubectl get service "$(name_prefix)" --output json |
+    jq -r '.spec.ports[0].port')
+  [ "${ports}" == "8200" ]
+
+  local ports=$(kubectl get service "$(name_prefix)" --output json |
+    jq -r '.spec.ports[1].port')
+  [ "${ports}" == "8201" ]
+
+  # Vault Init
+  local token=$(kubectl exec -ti "$(name_prefix)-0" -- \
+    vault operator init -format=json -n 1 -t 1 | \
+    jq -r '.unseal_keys_b64[0]')
+  [ "${token}" != "" ]
+
+  # Vault Unseal
+  local pods=($(kubectl get pods --selector='app.kubernetes.io/name=vault' -o json | jq -r '.items[].metadata.name'))
+  for pod in "${pods[@]}"
+  do
+      kubectl exec -ti ${pod} -- vault operator unseal ${token}
+  done
+
+  wait_for_ready "$(name_prefix)-0"
+
+  # Sealed, not initialized
+  local sealed_status=$(kubectl exec "$(name_prefix)-0" -- vault status -format=json |
+    jq -r '.sealed' )
+  [ "${sealed_status}" == "false" ]
+
+  local init_status=$(kubectl exec "$(name_prefix)-0" -- vault status -format=json |
+    jq -r '.initialized')
+  [ "${init_status}" == "true" ]
+}
+
+# setup a consul env
+setup() {
+  kubectl delete namespace acceptance --ignore-not-found=true
+  kubectl create namespace acceptance
+  kubectl config set-context --current --namespace=acceptance
+
+  helm install consul \
+    https://github.com/hashicorp/consul-helm/archive/v0.16.2.tar.gz \
+    --set 'ui.enabled=false' \
+
+  wait_for_running_consul
+}
+
+#cleanup
+teardown() {
+  helm delete vault
+  helm delete consul
+  kubectl delete --all pvc
+  kubectl delete namespace acceptance --ignore-not-found=true
+}

--- a/test/acceptance/server-ha-raft.bats
+++ b/test/acceptance/server-ha-raft.bats
@@ -2,11 +2,12 @@
 
 load _helpers
 
-@test "server/ha: testing deployment" {
+@test "server/ha-raft: testing deployment" {
   cd `chart_dir`
 
   helm install "$(name_prefix)" \
-    --set='server.ha.enabled=true' .
+    --set='server.ha.enabled=true' \
+    --set='server.ha.raft.enabled=true' .
   wait_for_running $(name_prefix)-0
 
   # Sealed, not initialized
@@ -31,7 +32,7 @@ load _helpers
   # Volume Mounts
   local volumeCount=$(kubectl get statefulset "$(name_prefix)" --output json |
     jq -r '.spec.template.spec.containers[0].volumeMounts | length')
-  [ "${volumeCount}" == "1" ]
+  [ "${volumeCount}" == "2" ]
 
   # Volumes
   local volumeCount=$(kubectl get statefulset "$(name_prefix)" --output json |
@@ -64,19 +65,31 @@ load _helpers
   [ "${ports}" == "8201" ]
 
   # Vault Init
-  local token=$(kubectl exec -ti "$(name_prefix)-0" -- \
-    vault operator init -format=json -n 1 -t 1 | \
-    jq -r '.unseal_keys_b64[0]')
+  local init=$(kubectl exec -ti "$(name_prefix)-0" -- \
+    vault operator init -format=json -n 1 -t 1)
+
+  local token=$(echo ${init} | jq -r '.unseal_keys_b64[0]')
   [ "${token}" != "" ]
+  
+  local root=$(echo ${init} | jq -r '.root_token')
+  [ "${root}" != "" ]
+
+  kubectl exec -ti vault-0 -- vault operator unseal ${token}
+  wait_for_ready "$(name_prefix)-0"
+
+  sleep 5
 
   # Vault Unseal
   local pods=($(kubectl get pods --selector='app.kubernetes.io/name=vault' -o json | jq -r '.items[].metadata.name'))
   for pod in "${pods[@]}"
   do
-      kubectl exec -ti ${pod} -- vault operator unseal ${token}
+      if [[ ${pod?} != "$(name_prefix)-0" ]]
+      then
+          kubectl exec -ti ${pod} -- vault operator raft join http://$(name_prefix)-0.$(name_prefix)-internal:8200
+          kubectl exec -ti ${pod} -- vault operator unseal ${token}
+          wait_for_ready "${pod}"
+      fi
   done
-
-  wait_for_ready "$(name_prefix)-0"
 
   # Sealed, not initialized
   local sealed_status=$(kubectl exec "$(name_prefix)-0" -- vault status -format=json |
@@ -86,25 +99,23 @@ load _helpers
   local init_status=$(kubectl exec "$(name_prefix)-0" -- vault status -format=json |
     jq -r '.initialized')
   [ "${init_status}" == "true" ]
+
+  kubectl exec "$(name_prefix)-0" -- vault login ${root}
+
+  local raft_status=$(kubectl exec "$(name_prefix)-0" -- vault operator raft configuration -format=json | 
+    jq -r '.data.config.servers | length')
+  [ "${raft_status}" == "3" ]
 }
 
-# setup a consul env
 setup() {
   kubectl delete namespace acceptance --ignore-not-found=true
   kubectl create namespace acceptance
   kubectl config set-context --current --namespace=acceptance
-
-  helm install consul \
-    https://github.com/hashicorp/consul-helm/archive/v0.16.2.tar.gz \
-    --set 'ui.enabled=false' \
-
-  wait_for_running_consul
 }
 
 #cleanup
 teardown() {
   helm delete vault
-  helm delete consul
   kubectl delete --all pvc
   kubectl delete namespace acceptance --ignore-not-found=true
 }

--- a/test/unit/server-configmap.bats
+++ b/test/unit/server-configmap.bats
@@ -19,11 +19,41 @@ load _helpers
 
   local actual=$(helm template \
       --show-only templates/server-config-configmap.yaml \
+      --set 'server.ha.enabled=true' \
+      --set 'server.ha.raft.enabled=true' \
+      . | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+
+  local actual=$(helm template \
+      --show-only templates/server-config-configmap.yaml \
       --set 'server.standalone.enabled=true' \
       . | tee /dev/stderr |
       yq 'length > 0' | tee /dev/stderr)
   [ "${actual}" = "true" ]
 }
+
+@test "server/ConfigMap: raft config disabled by default" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/server-config-configmap.yaml \
+      --set 'server.ha.enabled=true' \
+      . | tee /dev/stderr |
+      grep "raft" | yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" != "true" ]
+}
+
+@test "server/ConfigMap: raft config can be enabled" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/server-config-configmap.yaml \
+      --set 'server.ha.enabled=true' \
+      --set 'server.ha.raft.enabled=true' \
+      . | tee /dev/stderr |
+      grep "raft" | yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}
+
 
 @test "server/ConfigMap: disabled by server.dev.enabled true" {
   cd `chart_dir`

--- a/test/unit/server-dev-statefulset.bats
+++ b/test/unit/server-dev-statefulset.bats
@@ -249,19 +249,19 @@ load _helpers
       yq -r '.spec.template.spec.containers[0].env' | tee /dev/stderr)
 
   local actual=$(echo $object |
-     yq -r '.[7].name' | tee /dev/stderr)
+     yq -r '.[8].name' | tee /dev/stderr)
   [ "${actual}" = "FOO" ]
 
   local actual=$(echo $object |
-      yq -r '.[7].value' | tee /dev/stderr)
+      yq -r '.[8].value' | tee /dev/stderr)
   [ "${actual}" = "bar" ]
 
   local actual=$(echo $object |
-      yq -r '.[8].name' | tee /dev/stderr)
+      yq -r '.[9].name' | tee /dev/stderr)
   [ "${actual}" = "FOOBAR" ]
 
   local actual=$(echo $object |
-      yq -r '.[8].value' | tee /dev/stderr)
+      yq -r '.[9].value' | tee /dev/stderr)
   [ "${actual}" = "foobar" ]
 }
 
@@ -282,23 +282,23 @@ load _helpers
       yq -r '.spec.template.spec.containers[0].env' | tee /dev/stderr)
 
   local actual=$(echo $object |
-      yq -r '.[6].name' | tee /dev/stderr)
+      yq -r '.[7].name' | tee /dev/stderr)
   [ "${actual}" = "ENV_FOO_0" ]
   local actual=$(echo $object |
-      yq -r '.[6].valueFrom.secretKeyRef.name' | tee /dev/stderr)
+      yq -r '.[7].valueFrom.secretKeyRef.name' | tee /dev/stderr)
   [ "${actual}" = "secret_name_0" ]
   local actual=$(echo $object |
-      yq -r '.[6].valueFrom.secretKeyRef.key' | tee /dev/stderr)
+      yq -r '.[7].valueFrom.secretKeyRef.key' | tee /dev/stderr)
   [ "${actual}" = "secret_key_0" ]
 
   local actual=$(echo $object |
-      yq -r '.[7].name' | tee /dev/stderr)
+      yq -r '.[8].name' | tee /dev/stderr)
   [ "${actual}" = "ENV_FOO_1" ]
   local actual=$(echo $object |
-      yq -r '.[7].valueFrom.secretKeyRef.name' | tee /dev/stderr)
+      yq -r '.[8].valueFrom.secretKeyRef.name' | tee /dev/stderr)
   [ "${actual}" = "secret_name_1" ]
   local actual=$(echo $object |
-      yq -r '.[7].valueFrom.secretKeyRef.key' | tee /dev/stderr)
+      yq -r '.[8].valueFrom.secretKeyRef.key' | tee /dev/stderr)
   [ "${actual}" = "secret_key_1" ]
 }
 

--- a/test/unit/server-ha-statefulset.bats
+++ b/test/unit/server-ha-statefulset.bats
@@ -349,19 +349,19 @@ load _helpers
       yq -r '.spec.template.spec.containers[0].env' | tee /dev/stderr)
 
   local actual=$(echo $object |
-     yq -r '.[6].name' | tee /dev/stderr)
+     yq -r '.[7].name' | tee /dev/stderr)
   [ "${actual}" = "FOO" ]
 
   local actual=$(echo $object |
-      yq -r '.[6].value' | tee /dev/stderr)
+      yq -r '.[7].value' | tee /dev/stderr)
   [ "${actual}" = "bar" ]
 
   local actual=$(echo $object |
-      yq -r '.[7].name' | tee /dev/stderr)
+      yq -r '.[8].name' | tee /dev/stderr)
   [ "${actual}" = "FOOBAR" ]
 
   local actual=$(echo $object |
-      yq -r '.[7].value' | tee /dev/stderr)
+      yq -r '.[8].value' | tee /dev/stderr)
   [ "${actual}" = "foobar" ]
 }
 
@@ -383,23 +383,23 @@ load _helpers
       yq -r '.spec.template.spec.containers[0].env' | tee /dev/stderr)
 
   local actual=$(echo $object |
-      yq -r '.[6].name' | tee /dev/stderr)
+      yq -r '.[7].name' | tee /dev/stderr)
   [ "${actual}" = "ENV_FOO_0" ]
   local actual=$(echo $object |
-      yq -r '.[6].valueFrom.secretKeyRef.name' | tee /dev/stderr)
+      yq -r '.[7].valueFrom.secretKeyRef.name' | tee /dev/stderr)
   [ "${actual}" = "secret_name_0" ]
   local actual=$(echo $object |
-      yq -r '.[6].valueFrom.secretKeyRef.key' | tee /dev/stderr)
+      yq -r '.[7].valueFrom.secretKeyRef.key' | tee /dev/stderr)
   [ "${actual}" = "secret_key_0" ]
 
   local actual=$(echo $object |
-      yq -r '.[7].name' | tee /dev/stderr)
+      yq -r '.[8].name' | tee /dev/stderr)
   [ "${actual}" = "ENV_FOO_1" ]
   local actual=$(echo $object |
-      yq -r '.[7].valueFrom.secretKeyRef.name' | tee /dev/stderr)
+      yq -r '.[8].valueFrom.secretKeyRef.name' | tee /dev/stderr)
   [ "${actual}" = "secret_name_1" ]
   local actual=$(echo $object |
-      yq -r '.[7].valueFrom.secretKeyRef.key' | tee /dev/stderr)
+      yq -r '.[8].valueFrom.secretKeyRef.key' | tee /dev/stderr)
   [ "${actual}" = "secret_key_1" ]
 }
 

--- a/test/unit/server-statefulset.bats
+++ b/test/unit/server-statefulset.bats
@@ -384,19 +384,19 @@ load _helpers
       yq -r '.spec.template.spec.containers[0].env' | tee /dev/stderr)
 
   local actual=$(echo $object |
-     yq -r '.[6].name' | tee /dev/stderr)
+     yq -r '.[7].name' | tee /dev/stderr)
   [ "${actual}" = "FOO" ]
 
   local actual=$(echo $object |
-      yq -r '.[6].value' | tee /dev/stderr)
+      yq -r '.[7].value' | tee /dev/stderr)
   [ "${actual}" = "bar" ]
 
   local actual=$(echo $object |
-      yq -r '.[7].name' | tee /dev/stderr)
+      yq -r '.[8].name' | tee /dev/stderr)
   [ "${actual}" = "FOOBAR" ]
 
   local actual=$(echo $object |
-      yq -r '.[7].value' | tee /dev/stderr)
+      yq -r '.[8].value' | tee /dev/stderr)
   [ "${actual}" = "foobar" ]
 
   local object=$(helm template \
@@ -407,19 +407,19 @@ load _helpers
       yq -r '.spec.template.spec.containers[0].env' | tee /dev/stderr)
 
   local actual=$(echo $object |
-     yq -r '.[6].name' | tee /dev/stderr)
+     yq -r '.[7].name' | tee /dev/stderr)
   [ "${actual}" = "FOO" ]
 
   local actual=$(echo $object |
-      yq -r '.[6].value' | tee /dev/stderr)
+      yq -r '.[7].value' | tee /dev/stderr)
   [ "${actual}" = "bar" ]
 
   local actual=$(echo $object |
-      yq -r '.[7].name' | tee /dev/stderr)
+      yq -r '.[8].name' | tee /dev/stderr)
   [ "${actual}" = "FOOBAR" ]
 
   local actual=$(echo $object |
-      yq -r '.[7].value' | tee /dev/stderr)
+      yq -r '.[8].value' | tee /dev/stderr)
   [ "${actual}" = "foobar" ]
 }
 

--- a/values.yaml
+++ b/values.yaml
@@ -314,8 +314,14 @@ server:
   ha:
     enabled: false
     replicas: 3
-
+    
+    # Enables Vault's integrated Raft storage.  Unlike the typical HA modes where 
+    # Vault's persistence is external (such as Consul), enabling Raft mode will create 
+    # persistent volumes for Vault to store data.  The Vault cluster will coordinate leader 
+    # elections and failovers internally.
     raft:
+      
+      # Enables Raft integrated storage
       enabled: false
       config: |
         ui = true

--- a/values.yaml
+++ b/values.yaml
@@ -315,11 +315,28 @@ server:
     enabled: false
     replicas: 3
 
+    raft:
+      enabled: false
+      config: |
+        ui = true
+        cluster_addr = "https://POD_IP:8201"
+
+        listener "tcp" {
+          tls_disable = 1
+          address = "[::]:8200"
+          cluster_address = "[::]:8201"
+        }
+
+        storage "raft" {
+          path = "/vault/data"
+        }
+
     # config is a raw string of default configuration when using a Stateful
     # deployment. Default is to use a Consul for its HA storage backend.
     # This should be HCL.
     config: |
       ui = true
+      cluster_addr = "https://POD_IP:8201"
 
       listener "tcp" {
         tls_disable = 1


### PR DESCRIPTION
This adds a new HA option, raft, for the upcoming Vault 1.4 release.  This makes the following changes:

* Creates a new headless service required to allow the pods communicate directly with each other
* Lifts limitations on HA mode not creating PVCs for storage
* Adds new configurations specifically for Raft.

```bash
helm install vault \
  --set='server.ha.enabled=true' \
  --set='server.ha.raft.enabled=true' .
```

Once deployed you can initialize vault-0 and unseal:

```bash
# Note: vault-0 is going to be our leader initially.
kubectl exec -ti vault-0 -- vault operator init
kubectl exec -ti vault-0 -- vault operator unseal
```

Next, for each other vault pod, join the raft cluster and unseal:

```bash
kubectl exec -ti <NAME OF POD> -- vault operator raft join http://vault-0.vault-internal:8200
kubectl exec -ti <NAME OF POD> -- vault operator unseal
```

After logging into Vault using a token, you can check the configuration of Raft:

```bash
kubectl exec -ti vault-0 -- vault login
kubectl exec -ti vault-0 -- vault operator raft configuration -format=json
```

Or using status:

```bash
kubectl exec -ti vault-0 -- vault status
```