### PR TITLE
Add injector.extraEnvironmentVars

### DIFF
--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -284,9 +284,9 @@ Inject extra environment vars in the format key:value, if populated
 {{- define "vault.extraEnvironmentVars" -}}
 {{- if .extraEnvironmentVars -}}
 {{- range $key, $value := .extraEnvironmentVars }}
-- name: {{ $key }}
+- name: {{ printf "%s" $key | replace "." "_" | upper | quote }}
   value: {{ $value | quote }}
-{{- end -}}
+{{- end }}
 {{- end -}}
 {{- end -}}
 

--- a/templates/injector-deployment.yaml
+++ b/templates/injector-deployment.yaml
@@ -64,6 +64,7 @@ spec:
               value: {{ .Values.injector.logFormat | default "standard" }}
             - name: AGENT_INJECT_REVOKE_ON_SHUTDOWN
               value: "{{ .Values.injector.revokeOnShutdown | default false }}"
+            {{- include "vault.extraEnvironmentVars" .Values.injector | nindent 12 }}
           args:
             - agent-inject
             - 2>&1

--- a/test/unit/injector-deployment.bats
+++ b/test/unit/injector-deployment.bats
@@ -321,3 +321,41 @@ load _helpers
       yq -r '.[8].value' | tee /dev/stderr)
   [ "${actual}" = "true" ]
 }
+
+#--------------------------------------------------------------------
+# extraEnvironmentVars
+
+@test "injector/deployment: set extraEnvironmentVars" {
+  cd `chart_dir`
+  local object=$(helm template \
+      --show-only templates/injector-deployment.yaml  \
+      --set 'injector.extraEnvironmentVars.FOO=bar' \
+      --set 'injector.extraEnvironmentVars.FOOBAR=foobar' \
+      --set 'injector.extraEnvironmentVars.lower\.case=sanitized' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.containers[0].env' | tee /dev/stderr)
+
+  local actual=$(echo $object |
+     yq -r '.[9].name' | tee /dev/stderr)
+  [ "${actual}" = "FOO" ]
+
+  local actual=$(echo $object |
+      yq -r '.[9].value' | tee /dev/stderr)
+  [ "${actual}" = "bar" ]
+
+  local actual=$(echo $object |
+      yq -r '.[10].name' | tee /dev/stderr)
+  [ "${actual}" = "FOOBAR" ]
+
+  local actual=$(echo $object |
+      yq -r '.[10].value' | tee /dev/stderr)
+  [ "${actual}" = "foobar" ]
+
+  local actual=$(echo $object |
+      yq -r '.[11].name' | tee /dev/stderr)
+  [ "${actual}" = "LOWER_CASE" ]
+
+  local actual=$(echo $object |
+      yq -r '.[11].value' | tee /dev/stderr)
+  [ "${actual}" = "sanitized" ]
+}

--- a/values.yaml
+++ b/values.yaml
@@ -81,6 +81,11 @@ injector:
   #     memory: 256Mi
   #     cpu: 250m
 
+  # extraEnvironmentVars is a list of extra enviroment variables to set in the
+  # injector deployment.
+  extraEnvironmentVars: {}
+    # KUBERNETES_SERVICE_HOST: kubernetes.default.svc
+
 server:
   # Resource requests, limits, etc. for the server cluster placement. This
   # should map directly to the value of the resources field for a PodSpec.


### PR DESCRIPTION
Allows user-specified environment variables to be set in the injector
deployment.
