### PR TITLE
Fix server-headless-service annotations

### DIFF
--- a/templates/server-headless-service.yaml
+++ b/templates/server-headless-service.yaml
@@ -15,7 +15,7 @@ metadata:
   annotations:
     service.alpha.kubernetes.io/tolerate-unready-endpoints: "true"
 {{- if .Values.server.service.annotations }}
-{{ toYaml .Values.server.service.annotations | indent 4 }}
+{{ tpl .Values.server.service.annotations . | indent 4 }}
 {{- end }}
 spec:
   clusterIP: None


### PR DESCRIPTION
`Values.server.service.annotations` are now being treated as multi-line
strings, to match the other annotations in the chart, and to support
templating within the annotations.
