### PR TITLE
Fix bug with api server env

### DIFF
--- a/templates/server-statefulset.yaml
+++ b/templates/server-statefulset.yaml
@@ -71,7 +71,7 @@ spec:
             - name: VAULT_ADDR
               value: "{{ include "vault.scheme" . }}://127.0.0.1:8200"
             - name: VAULT_API_ADDR
-              value: "{{ include "vault.scheme" . }}-internal://$(POD_IP):8200"
+              value: "{{ include "vault.scheme" . }}://$(POD_IP):8200"
             - name: SKIP_CHOWN
               value: "true"
             - name: SKIP_SETCAP


### PR DESCRIPTION
`VAULT_API_ADDR` env is incorrect in the template.  This fixes that environment variable by removing `-internal`.