### PR TITLE
Fix hardcoded service name in raft env

### DIFF
--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -135,7 +135,7 @@ Set's additional environment variables based on the mode.
   {{ end }}
   {{ if and (eq .mode "ha") (eq (.Values.server.ha.raft.enabled | toString) "true") }}
             - name: VAULT_CLUSTER_ADDR
-              value: "https://$(HOSTNAME).vault-internal:8201"
+              value: "https://$(HOSTNAME).{{ template "vault.fullname" . }}-internal:8201"
   {{ end }}
 {{- end -}}
 

--- a/test/unit/server-ha-statefulset.bats
+++ b/test/unit/server-ha-statefulset.bats
@@ -403,6 +403,28 @@ load _helpers
   [ "${actual}" = "secret_key_1" ]
 }
 
+
+#--------------------------------------------------------------------
+# VAULT_CLUSTER_ADDR renders
+
+@test "server/ha-StatefulSet: cluster addr renders" {
+  cd `chart_dir`
+  local object=$(helm template \
+      --show-only templates/server-statefulset.yaml  \
+      --set 'server.ha.enabled=true' \
+      --set 'server.ha.raft.enabled=true' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.containers[0].env' | tee /dev/stderr)
+  
+  local actual=$(echo $object |
+     yq -r '.[7].name' | tee /dev/stderr)
+  [ "${actual}" = "VAULT_CLUSTER_ADDR" ]
+
+  local actual=$(echo $object |
+     yq -r '.[7].value' | tee /dev/stderr)
+  [ "${actual}" = 'https://$(HOSTNAME).RELEASE-NAME-vault-internal:8201' ]
+}
+
 #--------------------------------------------------------------------
 # storage class
 


### PR DESCRIPTION
Small bug fix where the name of the cluster wasn't being prepended to the service name when deploying Raft clusters.