### PR TITLE
Adding vault poststart hook/configs

### DIFF
--- a/files/vault-config.sh
+++ b/files/vault-config.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+set +x
+while ! nslookup vault </dev/null || ! nc -w1 vault 8200 </dev/null; do
+    echo "Waiting for Vault to Come up!"
+    sleep 0.1
+done
+sleep 10
+
+echo "Vault Up, Will be initlising the it"
+
+export VAULT_ADDR=http://$VAULT_SERVICE_HOST:$VAULT_SERVICE_PORT_HTTP
+echo "vault address is: $VAULT_ADDR"
+
+echo "Initialising the vault"
+vault operator init -n 1 -t 1 > /tmp/stdout
+cat /tmp/stdout | head -n 1 | awk '{print $4}' > /tmp/key
+cat /tmp/stdout | grep -i "Root" |awk '{print $4}' > /tmp/token
+export KEY=$(cat /tmp/key)
+export VAULT_TOKEN=$(cat /tmp/token)
+
+echo "vault key is : $KEY"
+echo "vault token is : $VAULT_TOKEN"
+
+echo "Unsealing the vault"
+vault operator unseal $KEY
+vault status
+
+if [ "{{.Values.initvault.ldapauth.enabled}}" == "true" ]; then
+    echo "Enabling the LDAP auth"
+    export ldap_url="{{.Values.initvault.ldapauth.ldap_url}}"
+    export userattr="{{.Values.initvault.ldapauth.userattr}}"
+    export userdn="{{.Values.initvault.ldapauth.userdn}}"
+    export groupdn="{{.Values.initvault.ldapauth.groupdn}}"
+    export upndomain="{{.Values.initvault.ldapauth.upndomain}}"
+    vault auth enable ldap
+    vault login $VAULT_TOKEN
+    vault write auth/ldap/config \
+        url="${ldap_url}" \
+        userattr="${userattr}" \
+        userdn="${userdn}" \
+        groupdn="${groupdn}" \
+        upndomain="${upndomain}" \
+        insecure_tls=true starttls=true \
+        tls_min_version=tls10
+fi

--- a/templates/hooks/vault-config-cm.yaml
+++ b/templates/hooks/vault-config-cm.yaml
@@ -1,0 +1,8 @@
+{{- if .Values.initvault.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: vault-config-sh
+data:
+{{ (tpl (.Files.Glob "files/vault-config.sh").AsConfig . ) | indent 4 }}
+{{- end }}

--- a/templates/hooks/vault-config-job.yaml
+++ b/templates/hooks/vault-config-job.yaml
@@ -1,0 +1,30 @@
+{{- if .Values.initvault.enabled }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: vault-config-job
+  annotations:
+    "helm.sh/hook": "post-install"
+spec:
+  template:
+    spec:
+      containers:
+      - name: vault-config-install
+        image: {{ .Values.server.image.repository }}:{{ .Values.server.image.tag | default "latest" }}
+        imagePullPolicy: IfNotPresent
+        command: ["sh", "/tmp/vault-config.sh"]
+        volumeMounts:
+        - name: vault-config-sh
+          mountPath: /tmp/vault-config.sh
+          subPath: vault-config.sh
+      restartPolicy: OnFailure
+      terminationGracePeriodSeconds: 0
+      volumes:
+      - name: vault-config-sh
+        configMap:
+          name: vault-config-sh
+          defaultMode: 0777
+  backoffLimit: 5
+  completions: 1
+  parallelism: 1
+  {{- end }}

--- a/values.yaml
+++ b/values.yaml
@@ -426,3 +426,30 @@ ui:
   # This should be a multi-line string mapping directly to the a map of
   # the annotations to apply to the ui service
   annotations: {}
+
+# This will run helm post-install hook to init the vault
+initvault:
+  enabled: false
+
+# The ldap auth related params
+  ldapauth:
+    enabled: false
+    ldap_url: "ldap://"
+    userattr: ""
+    userdn: ""
+    groupdn: ""
+    upndomain: ""
+
+# The GitHub auth related params
+  githubauth:
+    enabled: false
+    organization: ""
+
+# The Kubernetes auth related params
+  k8sauth:
+    enabled: false
+    token_reviewer_jwt: ""
+    kubernetes_host: ""
+    kubernetes_ca_cert: ""
+
+# More Auth can be added here as per reqiurement


### PR DESCRIPTION
@jasonodonnell as discussed in https://github.com/hashicorp/vault-helm/issues/251 adding PR. This performs following tasks.

- Check vault status before execution
- Vault init and unseal it - It can be enabled/disables using `values.yaml`
- Enable ldap auth - This is also can be enabled/disabled using `values.yaml`

More auth modes can be control and added using `vault-config.sh` currently it supports `ldap` only.