### PR TITLE
fix: default value types don't match real type

### DIFF
--- a/values.yaml
+++ b/values.yaml
@@ -133,7 +133,7 @@ server:
     enabled: false
     labels: {}
       # traffic: external
-    annotations: {}
+    annotations: ""
       # |
       # kubernetes.io/ingress.class: nginx
       # kubernetes.io/tls-acme: "true"
@@ -222,7 +222,7 @@ server:
   # Example:
   # nodeSelector: |
   #   beta.kubernetes.io/arch: amd64
-  nodeSelector: {}
+  nodeSelector: ""
 
   # Extra labels to attach to the server pods
   # This should be a multi-line string mapping directly to the a map of
@@ -232,7 +232,7 @@ server:
   # Extra annotations to attach to the server pods
   # This should be a multi-line string mapping directly to the a map of
   # the annotations to apply to the server pods
-  annotations: {}
+  annotations: ""
 
   # Enables a headless service to be used by the Vault Statefulset
   service:


### PR DESCRIPTION
This fixes the default values for several of the fields. There may be other cases, but these are the ones I know of.

The default values were the wrong type, so helm would complain about overriding them with a different type.

This should be fully and properly resolved with another PR for #55, but this will resolve peoples errors immediately.