### PR TITLE
Setting Ingress to use the active Vault Pod

### DIFF
--- a/templates/server-ingress.yaml
+++ b/templates/server-ingress.yaml
@@ -36,9 +36,9 @@ spec:
         {{- range (.paths | default (list "/")) }}
           - path: {{ . }}
             backend:
-              serviceName: {{ $serviceName }}
+              serviceName: {{ $serviceName }}-active
               servicePort: {{ $servicePort }}
-        {{- end }}
+  {{- end }}
   {{- end }}
 {{- end }}
 {{- end }}


### PR DESCRIPTION
The Ingress service defaults to the `vault` service which contains all the running Pods. For some operations, this can cause a error when a `standby` Pod happens to be connected to with the following message:`Error [action description]: redirect would cause protocol downgrade`.

Since the chart creates a `vault-active` service that points to the currently active Pod, this PR adds the `-acvive` suffix to the service used by the Ingress so the active Pod is always being talked to by clients, which alleviates the above error. 

