### PR TITLE
Fixes active and standby service annotations

### DIFF
--- a/templates/server-ha-active-service.yaml
+++ b/templates/server-ha-active-service.yaml
@@ -14,7 +14,7 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
   annotations:
 {{- if .Values.server.service.annotations }}
-{{ toYaml .Values.server.service.annotations | indent 4 }}
+{{ tpl .Values.server.service.annotations . | indent 4 }}
 {{- end }}
 spec:
   type: ClusterIP

--- a/templates/server-ha-standby-service.yaml
+++ b/templates/server-ha-standby-service.yaml
@@ -14,7 +14,7 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
   annotations:
 {{- if .Values.server.service.annotations }}
-{{ toYaml .Values.server.service.annotations | indent 4 }}
+{{ tpl .Values.server.service.annotations . | indent 4 }}
 {{- end }}
 spec:
   type: ClusterIP


### PR DESCRIPTION
It has been decided in #227 to move annotations to multi-line
string for consistency. Thoses definitions were not following thoses
rules. This commit fixes it.