### PR TITLE
Ability to provide imagePullSecrets also for injector image

### DIFF
--- a/templates/injector-deployment.yaml
+++ b/templates/injector-deployment.yaml
@@ -91,6 +91,10 @@ spec:
             periodSeconds: 2
             successThreshold: 1
             timeoutSeconds: 5
+      {{- if .Values.global.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml .Values.global.imagePullSecrets | nindent 8 }}
+      {{- end }}
 {{- if .Values.injector.certs.secretName }}
           volumeMounts:
             - name: webhook-certs


### PR DESCRIPTION
Global helm variable "ImagePullSecrets" is not taken into account for injector image "hashicorp/vault-k8". I added the missing template config.