### PR TITLE
Add support for setting VAULT_RAFT_NODE_ID environment variable

### DIFF
--- a/templates/server-statefulset.yaml
+++ b/templates/server-statefulset.yaml
@@ -87,6 +87,12 @@ spec:
                   fieldPath: metadata.name
             - name: VAULT_CLUSTER_ADDR
               value: "https://$(HOSTNAME).{{ template "vault.fullname" . }}-internal:8201"
+            {{- if and (eq (.Values.server.ha.raft.enabled | toString) "true") (eq (.Values.server.ha.raft.setNodeId | toString) "true") }}
+            - name: VAULT_RAFT_NODE_ID
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            {{- end }}
             {{ template "vault.envs" . }}
             {{- include "vault.extraEnvironmentVars" .Values.server | nindent 12 }}
             {{- include "vault.extraSecretEnvironmentVars" .Values.server | nindent 12 }}

--- a/templates/server-statefulset.yaml
+++ b/templates/server-statefulset.yaml
@@ -91,7 +91,7 @@ spec:
             - name: VAULT_RAFT_NODE_ID
               valueFrom:
                 fieldRef:
-                  fieldPath: metadata.namespace
+                  fieldPath: metadata.name
             {{- end }}
             {{ template "vault.envs" . }}
             {{- include "vault.extraEnvironmentVars" .Values.server | nindent 12 }}

--- a/test/unit/server-ha-statefulset.bats
+++ b/test/unit/server-ha-statefulset.bats
@@ -403,7 +403,6 @@ load _helpers
   [ "${actual}" = "secret_key_1" ]
 }
 
-
 #--------------------------------------------------------------------
 # VAULT_CLUSTER_ADDR renders
 
@@ -415,7 +414,7 @@ load _helpers
       --set 'server.ha.raft.enabled=true' \
       . | tee /dev/stderr |
       yq -r '.spec.template.spec.containers[0].env' | tee /dev/stderr)
-  
+
   local actual=$(echo $object |
      yq -r '.[9].name' | tee /dev/stderr)
   [ "${actual}" = "VAULT_CLUSTER_ADDR" ]
@@ -423,6 +422,28 @@ load _helpers
   local actual=$(echo $object |
      yq -r '.[9].value' | tee /dev/stderr)
   [ "${actual}" = 'https://$(HOSTNAME).RELEASE-NAME-vault-internal:8201' ]
+}
+
+#--------------------------------------------------------------------
+# VAULT_RAFT_NODE_ID renders
+
+@test "server/ha-StatefulSet: raft node ID renders" {
+  cd `chart_dir`
+  local object=$(helm template \
+      --show-only templates/server-statefulset.yaml  \
+      --set 'server.ha.enabled=true' \
+      --set 'server.ha.raft.enabled=true' \
+      --set 'server.ha.raft.setNodeId=true' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.containers[0].env' | tee /dev/stderr)
+
+  local actual=$(echo $object |
+     yq -r '.[10].name' | tee /dev/stderr)
+  [ "${actual}" = "VAULT_RAFT_NODE_ID" ]
+
+  local actual=$(echo $object |
+     yq -r '.[10].valueFrom.fieldRef.fieldPath' | tee /dev/stderr)
+  [ "${actual}" = 'metadata.namespace' ]
 }
 
 #--------------------------------------------------------------------

--- a/test/unit/server-ha-statefulset.bats
+++ b/test/unit/server-ha-statefulset.bats
@@ -443,7 +443,7 @@ load _helpers
 
   local actual=$(echo $object |
      yq -r '.[10].valueFrom.fieldRef.fieldPath' | tee /dev/stderr)
-  [ "${actual}" = 'metadata.namespace' ]
+  [ "${actual}" = 'metadata.name' ]
 }
 
 #--------------------------------------------------------------------

--- a/values.yaml
+++ b/values.yaml
@@ -40,7 +40,7 @@ injector:
 
   # Configures the log format of the injector. Supported log formats: "standard", "json".
   logFormat: "standard"
-  
+
   # Configures all Vault Agent sidecars to revoke their token when shutting down
   revokeOnShutdown: false
 
@@ -338,15 +338,17 @@ server:
   ha:
     enabled: false
     replicas: 3
-    
-    # Enables Vault's integrated Raft storage.  Unlike the typical HA modes where 
-    # Vault's persistence is external (such as Consul), enabling Raft mode will create 
+
+    # Enables Vault's integrated Raft storage.  Unlike the typical HA modes where
+    # Vault's persistence is external (such as Consul), enabling Raft mode will create
     # persistent volumes for Vault to store data according to the configuration under server.dataStorage.
     # The Vault cluster will coordinate leader elections and failovers internally.
     raft:
-      
+
       # Enables Raft integrated storage
       enabled: false
+      # Set the Node Raft ID to the name of the pod
+      setNodeId: false
       config: |
         ui = true
 


### PR DESCRIPTION
Gives raft nodes more meaningful names than some randomly generated UUID.