### PR TITLE
fix annotation bug. Use active service on ingress when ha

### DIFF
--- a/templates/server-ingress.yaml
+++ b/templates/server-ingress.yaml
@@ -3,7 +3,7 @@
 {{- if .Values.server.ingress.enabled -}}
 {{- $serviceName := include "vault.fullname" . -}}
 {{- if and (eq .mode "ha" ) (and (eq (.Values.server.service.enabled | toString) "true" ) (eq (.Values.global.enabled | toString) "true")) }}
-{{- $serviceName := printf "%s-%s" $serviceName "active" -}}
+{{- $serviceName = printf "%s-%s" $serviceName "active" -}}
 {{- end }}
 {{- $servicePort := .Values.server.service.port -}}
 {{ if .Capabilities.APIVersions.Has "networking.k8s.io/v1beta1" }}

--- a/templates/server-ingress.yaml
+++ b/templates/server-ingress.yaml
@@ -2,6 +2,9 @@
 {{- if ne .mode "external" }}
 {{- if .Values.server.ingress.enabled -}}
 {{- $serviceName := include "vault.fullname" . -}}
+{{- if and (eq .mode "ha" ) (and (eq (.Values.server.service.enabled | toString) "true" ) (eq (.Values.global.enabled | toString) "true")) }}
+{{- $serviceName := printf "%s-%s" $serviceName "active" -}}
+{{- end }}
 {{- $servicePort := .Values.server.service.port -}}
 {{ if .Capabilities.APIVersions.Has "networking.k8s.io/v1beta1" }}
 apiVersion: networking.k8s.io/v1beta1

--- a/test/unit/server-ingress.bats
+++ b/test/unit/server-ingress.bats
@@ -93,3 +93,31 @@ load _helpers
       yq -r '.metadata.annotations["kubernetes.io/ingress.class"]' | tee /dev/stderr)
   [ "${actual}" = "nginx" ]
 }
+
+@test "server/ingress: uses active service when ha - yaml" {
+  cd `chart_dir`
+
+  local actual=$(helm template \
+      --show-only templates/server-ingress.yaml \
+      --set 'server.ingress.enabled=true' \
+      --set 'server.dev.enabled=false' \
+      --set 'server.ha.enabled=true' \
+      --set 'server.service.enabled=true' \
+      . | tee /dev/stderr |
+      yq -r '.spec.rules[0].http.paths[0].backend.serviceName' | tee /dev/stderr)
+  [ "${actual}" = "RELEASE-NAME-vault-active" ]
+}
+
+@test "server/ingress: uses regular service when not ha - yaml" {
+  cd `chart_dir`
+
+  local actual=$(helm template \
+      --show-only templates/server-ingress.yaml \
+      --set 'server.ingress.enabled=true' \
+      --set 'server.dev.enabled=false' \
+      --set 'server.ha.enabled=false' \
+      --set 'server.service.enabled=true' \
+      . | tee /dev/stderr |
+      yq -r '.spec.rules[0].http.paths[0].backend.serviceName' | tee /dev/stderr)
+  [ "${actual}" = "RELEASE-NAME-vault" ]
+}


### PR DESCRIPTION
Annotations currently give a warning because they are not actually rendering as yaml like normal charts do.
"Warning: Merging destination map for chart 'vault'. Cannot overwrite table item 'annotations', with non table value: map[]"

changing from annotations: {} to annotations: [] removes this warning.

Additionally I've added some logic that points the ingress at the active server when in ha mode. There are times that pointing at the standby pods causes problems. 