### PR TITLE
Allow both yaml and multi-line string annotations

### DIFF
--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -264,7 +264,12 @@ Sets extra pod annotations
 {{- define "vault.annotations" -}}
   {{- if and (ne .mode "dev") .Values.server.annotations }}
       annotations:
-        {{- tpl .Values.server.annotations . | nindent 8 }}
+        {{- $tp := typeOf .Values.server.annotations }}
+        {{- if eq $tp "string" }}
+          {{- tpl .Values.server.annotations . | nindent 8 }}
+        {{- else }}
+          {{- toYaml .Values.server.annotations | nindent 8 }}
+        {{- end }}
   {{- end }}
 {{- end -}}
 
@@ -274,7 +279,12 @@ Sets extra ui service annotations
 {{- define "vault.ui.annotations" -}}
   {{- if .Values.ui.annotations }}
   annotations:
-    {{- tpl .Values.ui.annotations . | nindent 4 }}
+    {{- $tp := typeOf .Values.ui.annotations }}
+    {{- if eq $tp "string" }}
+      {{- tpl .Values.ui.annotations . | nindent 4 }}
+    {{- else }}
+      {{- toYaml .Values.ui.annotations | nindent 4 }}
+    {{- end }}
   {{- end }}
 {{- end -}}
 
@@ -284,7 +294,12 @@ Sets extra service account annotations
 {{- define "vault.serviceAccount.annotations" -}}
   {{- if and (ne .mode "dev") .Values.server.serviceAccount.annotations }}
   annotations:
-    {{- tpl .Values.server.serviceAccount.annotations . | nindent 4 }}
+    {{- $tp := typeOf .Values.server.serviceAccount.annotations }}
+    {{- if eq $tp "string" }}
+      {{- tpl .Values.server.serviceAccount.annotations . | nindent 4 }}
+    {{- else }}
+      {{- toYaml .Values.server.serviceAccount.annotations | nindent 4 }}
+    {{- end }}
   {{- end }}
 {{- end -}}
 
@@ -294,7 +309,26 @@ Sets extra ingress annotations
 {{- define "vault.ingress.annotations" -}}
   {{- if .Values.server.ingress.annotations }}
   annotations:
-    {{- tpl .Values.server.ingress.annotations . | nindent 4 }}
+    {{- $tp := typeOf .Values.server.ingress.annotations }}
+    {{- if eq $tp "string" }}
+      {{- tpl .Values.server.ingress.annotations . | nindent 4 }}
+    {{- else }}
+      {{- toYaml .Values.server.ingress.annotations | nindent 4 }}
+    {{- end }}
+  {{- end }}
+{{- end -}}
+
+{{/*
+Sets extra vault server Service annotations
+*/}}
+{{- define "vault.service.annotations" -}}
+  {{- if .Values.server.service.annotations }}
+    {{- $tp := typeOf .Values.server.service.annotations }}
+    {{- if eq $tp "string" }}
+      {{- tpl .Values.server.service.annotations . | nindent 4 }}
+    {{- else }}
+      {{- toYaml .Values.server.service.annotations | nindent 4 }}
+    {{- end }}
   {{- end }}
 {{- end -}}
 

--- a/templates/server-ha-active-service.yaml
+++ b/templates/server-ha-active-service.yaml
@@ -13,9 +13,7 @@ metadata:
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
   annotations:
-{{- if .Values.server.service.annotations }}
-{{ tpl .Values.server.service.annotations . | indent 4 }}
-{{- end }}
+{{ template "vault.service.annotations" .}}
 spec:
   type: ClusterIP
   publishNotReadyAddresses: true

--- a/templates/server-ha-standby-service.yaml
+++ b/templates/server-ha-standby-service.yaml
@@ -13,9 +13,7 @@ metadata:
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
   annotations:
-{{- if .Values.server.service.annotations }}
-{{ tpl .Values.server.service.annotations . | indent 4 }}
-{{- end }}
+{{ template "vault.service.annotations" .}}
 spec:
   type: ClusterIP
   publishNotReadyAddresses: true

--- a/templates/server-headless-service.yaml
+++ b/templates/server-headless-service.yaml
@@ -14,9 +14,7 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
   annotations:
     service.alpha.kubernetes.io/tolerate-unready-endpoints: "true"
-{{- if .Values.server.service.annotations }}
-{{ tpl .Values.server.service.annotations . | indent 4 }}
-{{- end }}
+{{ template "vault.service.annotations" .}}
 spec:
   clusterIP: None
   publishNotReadyAddresses: true

--- a/templates/server-service.yaml
+++ b/templates/server-service.yaml
@@ -17,9 +17,7 @@ metadata:
     # to an open issue where it may not work:
     # https://github.com/kubernetes/kubernetes/issues/58662
     service.alpha.kubernetes.io/tolerate-unready-endpoints: "true"
-{{- if .Values.server.service.annotations }}
-{{ tpl .Values.server.service.annotations . | indent 4 }}
-{{- end }}
+{{ template "vault.service.annotations" .}}
 spec:
   {{- if .Values.server.service.type}}
   type: {{ .Values.server.service.type }}

--- a/test/acceptance/server-annotations.bats
+++ b/test/acceptance/server-annotations.bats
@@ -1,0 +1,46 @@
+#!/usr/bin/env bats
+
+load _helpers
+
+@test "server/annotations: testing yaml and yaml-formatted string formats" {
+  cd `chart_dir`
+  kubectl delete namespace acceptance --ignore-not-found=true
+  kubectl create namespace acceptance
+  kubectl config set-context --current --namespace=acceptance
+
+  helm install "$(name_prefix)" -f ./test/acceptance/server-test/annotations-overrides.yaml .
+  wait_for_running $(name_prefix)-0
+
+  # service annotations
+  local awesome=$(kubectl get service "$(name_prefix)" --output json |
+    jq -r '.metadata.annotations.active')
+  [ "${awesome}" == "sometimes" ]
+
+  local pickMe=$(kubectl get service "$(name_prefix)" --output json |
+    jq -r '.metadata.annotations.pickMe')
+  [ "${pickMe}" == "please" ]
+
+  local environment=$(kubectl get statefulset "$(name_prefix)" --output json |
+    jq -r '.spec.template.metadata.annotations.environment')
+  [ "${environment}" == "production" ]
+
+  local milk=$(kubectl get statefulset "$(name_prefix)" --output json |
+    jq -r '.spec.template.metadata.annotations.milk')
+  [ "${milk}" == "oat" ]
+
+  local myName=$(kubectl get statefulset "$(name_prefix)" --output json |
+    jq -r '.spec.template.metadata.annotations.myName')
+  [ "${myName}" == "$(name_prefix)" ]
+
+}
+
+# Clean up
+teardown() {
+  if [[ ${CLEANUP:-true} == "true" ]]
+  then
+      echo "helm/pvc teardown"
+      helm delete $(name_prefix)
+      kubectl delete --all pvc
+      kubectl delete namespace acceptance --ignore-not-found=true
+  fi
+}

--- a/test/acceptance/server-test/annotations-overrides.yaml
+++ b/test/acceptance/server-test/annotations-overrides.yaml
@@ -1,0 +1,9 @@
+server:
+  annotations: |
+    environment: production
+    milk: oat
+    myName: "{{ .Release.Name }}"
+  service:
+    annotations:
+      active: sometimes
+      pickMe: please

--- a/test/unit/server-ha-standby-service.bats
+++ b/test/unit/server-ha-standby-service.bats
@@ -2,12 +2,23 @@
 
 load _helpers
 
-@test "server/ha-standby-Service: generic annotations" {
+@test "server/ha-standby-Service: generic annotations string" {
   cd `chart_dir`
   local actual=$(helm template \
       --show-only templates/server-ha-standby-service.yaml \
       --set 'server.ha.enabled=true' \
       --set 'server.service.annotations=vaultIsAwesome: true' \
+      . | tee /dev/stderr |
+      yq -r '.metadata.annotations["vaultIsAwesome"]' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}
+
+@test "server/ha-standby-Service: generic annotations yaml" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/server-ha-standby-service.yaml \
+      --set 'server.ha.enabled=true' \
+      --set 'server.service.annotations.vaultIsAwesome=true' \
       . | tee /dev/stderr |
       yq -r '.metadata.annotations["vaultIsAwesome"]' | tee /dev/stderr)
   [ "${actual}" = "true" ]

--- a/test/unit/server-ingress.bats
+++ b/test/unit/server-ingress.bats
@@ -70,13 +70,25 @@ load _helpers
   [ "${actual}" = "external" ]
 }
 
-@test "server/ingress: annotations added to object" {
+@test "server/ingress: annotations added to object - string" {
   cd `chart_dir`
 
   local actual=$(helm template \
       --show-only templates/server-ingress.yaml \
       --set 'server.ingress.enabled=true' \
       --set 'server.ingress.annotations=kubernetes.io/ingress.class: nginx' \
+      . | tee /dev/stderr |
+      yq -r '.metadata.annotations["kubernetes.io/ingress.class"]' | tee /dev/stderr)
+  [ "${actual}" = "nginx" ]
+}
+
+@test "server/ingress: annotations added to object - yaml" {
+  cd `chart_dir`
+
+  local actual=$(helm template \
+      --show-only templates/server-ingress.yaml \
+      --set 'server.ingress.enabled=true' \
+      --set server.ingress.annotations."kubernetes\.io/ingress\.class"=nginx \
       . | tee /dev/stderr |
       yq -r '.metadata.annotations["kubernetes.io/ingress.class"]' | tee /dev/stderr)
   [ "${actual}" = "nginx" ]

--- a/test/unit/server-serviceaccount.bats
+++ b/test/unit/server-serviceaccount.bats
@@ -23,6 +23,14 @@ load _helpers
   local actual=$(helm template \
       --show-only templates/server-serviceaccount.yaml  \
       --set 'server.ha.enabled=true' \
+      --set 'server.serviceAccount.annotations.foo=bar' \
+      . | tee /dev/stderr |
+      yq -r '.metadata.annotations["foo"]' | tee /dev/stderr)
+  [ "${actual}" = "bar" ]
+
+  local actual=$(helm template \
+      --show-only templates/server-serviceaccount.yaml  \
+      --set 'server.ha.enabled=true' \
       . | tee /dev/stderr |
       yq -r '.metadata.annotations["foo"]' | tee /dev/stderr)
   [ "${actual}" = "null" ]

--- a/test/unit/server-statefulset.bats
+++ b/test/unit/server-statefulset.bats
@@ -936,3 +936,25 @@ load _helpers
       yq -r '.spec.template.spec.containers[0].ports | map(select(.containerPort==8202)) | .[] .name' | tee /dev/stderr)
   [ "${actual}" = "https-rep" ]
 }
+
+#--------------------------------------------------------------------
+# annotations
+@test "server/standalone-StatefulSet: generic annotations string" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/server-statefulset.yaml \
+      --set 'server.annotations=vaultIsAwesome: true' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.metadata.annotations["vaultIsAwesome"]' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}
+
+@test "server/ha-standby-Service: generic annotations yaml" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/server-statefulset.yaml \
+      --set 'server.annotations.vaultIsAwesome=true' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.metadata.annotations["vaultIsAwesome"]' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}

--- a/test/unit/ui-service.bats
+++ b/test/unit/ui-service.bats
@@ -210,6 +210,16 @@ load _helpers
       --set 'server.ha.enabled=true' \
       --set 'ui.serviceType=LoadBalancer' \
       --set 'ui.enabled=true' \
+      --set 'ui.annotations.foo=bar' \
+      . | tee /dev/stderr |
+      yq -r '.metadata.annotations["foo"]' | tee /dev/stderr)
+  [ "${actual}" = "bar" ]
+
+  local actual=$(helm template \
+      --show-only templates/ui-service.yaml  \
+      --set 'server.ha.enabled=true' \
+      --set 'ui.serviceType=LoadBalancer' \
+      --set 'ui.enabled=true' \
       . | tee /dev/stderr |
       yq -r '.metadata.annotations["foo"]' | tee /dev/stderr)
   [ "${actual}" = "null" ]

--- a/values.yaml
+++ b/values.yaml
@@ -137,6 +137,9 @@ server:
       # |
       # kubernetes.io/ingress.class: nginx
       # kubernetes.io/tls-acme: "true"
+      #   or
+      # kubernetes.io/ingress.class: nginx
+      # kubernetes.io/tls-acme: "true"
     hosts:
       - host: chart-example.local
         paths: []
@@ -230,8 +233,8 @@ server:
   extraLabels: {}
 
   # Extra annotations to attach to the server pods
-  # This should be a multi-line string mapping directly to the a map of
-  # the annotations to apply to the server pods
+  # This can either be YAML or a YAML-formatted multi-line templated string map
+  # of the annotations to apply to the server pods
   annotations: {}
 
   # Enables a headless service to be used by the Vault Statefulset
@@ -257,8 +260,9 @@ server:
     port: 8200
     # Target port to which the service should be mapped to
     targetPort: 8200
-    # Extra annotations for the service definition. This should be a multi-line
-    # string formatted as a map of the annotations to apply to the service.
+    # Extra annotations for the service definition. This can either be YAML or a
+    # YAML-formatted multi-line templated string map of the annotations to apply
+    # to the service.
     annotations: {}
 
   # This configures the Vault Statefulset to create a PVC for data
@@ -400,9 +404,9 @@ server:
 
   # Definition of the serviceAccount used to run Vault.
   serviceAccount:
-    # Extra annotations for the serviceAccount definition. This should be a
-    # multi-line string formatted as a map of the annotations to apply to the
-    # serviceAccount.
+    # Extra annotations for the serviceAccount definition. This can either be
+    # YAML or a YAML-formatted multi-line templated string map of the
+    # annotations to apply to the serviceAccount.
     annotations: {}
 
 # Vault UI
@@ -424,6 +428,6 @@ ui:
   # loadBalancerIP:
 
   # Extra annotations to attach to the ui service
-  # This should be a multi-line string mapping directly to the a map of
-  # the annotations to apply to the ui service
+  # This can either be YAML or a YAML-formatted multi-line templated string map
+  # of the annotations to apply to the ui service
   annotations: {}


### PR DESCRIPTION
Changed/added helper functions to detect if the annotations value is a string or yaml, and apply `tpl` or `toYaml` accordingly. Defaults are left as `{}` since yaml is more likely to be used with helm on the command line. This means a warning will be shown when setting an annotation to a multi-line string (which has been the existing behavior).