### PR TITLE
return VAULT_API_ADDR as FQDN

### DIFF
--- a/templates/server-statefulset.yaml
+++ b/templates/server-statefulset.yaml
@@ -73,18 +73,18 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
-            - name: VAULT_ADDR
-              value: "{{ include "vault.scheme" . }}://127.0.0.1:8200"
-            - name: VAULT_API_ADDR
-              value: "{{ include "vault.scheme" . }}://$(POD_IP):8200"
-            - name: SKIP_CHOWN
-              value: "true"
-            - name: SKIP_SETCAP
-              value: "true"
             - name: HOSTNAME
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.name
+            - name: VAULT_ADDR
+              value: "{{ include "vault.scheme" . }}://127.0.0.1:8200"
+            - name: VAULT_API_ADDR
+              value: "{{ include "vault.scheme" . }}://$(HOSTNAME).{{ template "vault.fullname" . }}-internal:8200"
+            - name: SKIP_CHOWN
+              value: "true"
+            - name: SKIP_SETCAP
+              value: "true"
             - name: VAULT_CLUSTER_ADDR
               value: "https://$(HOSTNAME).{{ template "vault.fullname" . }}-internal:8201"
             {{ template "vault.envs" . }}


### PR DESCRIPTION
It is better in my opinion if VAULT_API_ADDR was returned as FQDN instead of ip address. Safer to use FQDN in k8s environment :)

As discussed here https://discuss.hashicorp.com/t/req-return-api-addr-as-fqdn-instead-of-ip/7896