### PR TITLE
Fix raft acceptance test

### DIFF
--- a/test/acceptance/server-ha-raft.bats
+++ b/test/acceptance/server-ha-raft.bats
@@ -19,11 +19,6 @@ load _helpers
     jq -r '.initialized')
   [ "${init_status}" == "false" ]
 
-  # Security
-  local ipc=$(kubectl get statefulset "$(name_prefix)" --output json |
-    jq -r '.spec.template.spec.containers[0].securityContext.capabilities.add[0]')
-  [ "${ipc}" == "IPC_LOCK" ]
-
   # Replicas
   local replicas=$(kubectl get statefulset "$(name_prefix)" --output json |
     jq -r '.spec.replicas')


### PR DESCRIPTION
`IPC_LOCK` check was still present in the Raft acceptance tests.  This was removed in #197.