### PR TITLE
security: refactor gid and uid

### DIFF
--- a/templates/server-statefulset.yaml
+++ b/templates/server-statefulset.yaml
@@ -44,9 +44,9 @@ spec:
       {{ end }}
       securityContext:
         runAsNonRoot: true
-        runAsGroup: {{ .Values.server.gid | default 1000 }}
-        runAsUser: {{ .Values.server.uid | default 100 }}
-        fsGroup: {{ .Values.server.gid | default 1000 }}
+        runAsGroup: {{ .Values.server.gid }}
+        runAsUser: {{ .Values.server.uid }}
+        fsGroup: {{ .Values.server.gid }}
       volumes:
         {{ template "vault.volumes" . }}
       containers:

--- a/test/unit/server-statefulset.bats
+++ b/test/unit/server-statefulset.bats
@@ -761,6 +761,16 @@ load _helpers
   [ "${actual}" = "2000" ]
 }
 
+@test "server/standalone-StatefulSet: uid nullable" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/server-statefulset.yaml \
+      --set 'server.uid=null' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.securityContext.runAsUser' | tee /dev/stderr)
+  [ "${actual}" = "null" ]
+}
+
 @test "server/standalone-StatefulSet: gid default" {
   cd `chart_dir`
   local actual=$(helm template \
@@ -778,6 +788,16 @@ load _helpers
       . | tee /dev/stderr |
       yq -r '.spec.template.spec.securityContext.runAsGroup' | tee /dev/stderr)
   [ "${actual}" = "2000" ]
+}
+
+@test "server/standalone-StatefulSet: gid nullable" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/server-statefulset.yaml \
+      --set 'server.gid=null' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.securityContext.runAsGroup' | tee /dev/stderr)
+  [ "${actual}" = "null" ]
 }
 
 @test "server/standalone-StatefulSet: fsgroup default" {
@@ -798,6 +818,17 @@ load _helpers
       yq -r '.spec.template.spec.securityContext.fsGroup' | tee /dev/stderr)
   [ "${actual}" = "2000" ]
 }
+
+@test "server/standalone-StatefulSet: fsgroup nullable" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/server-statefulset.yaml \
+      --set 'server.gid=null' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.securityContext.fsGroup' | tee /dev/stderr)
+  [ "${actual}" = "null" ]
+}
+
 
 #--------------------------------------------------------------------
 # health checks

--- a/values.yaml
+++ b/values.yaml
@@ -127,6 +127,11 @@ server:
   #     memory: 256Mi
   #     cpu: 250m
 
+  # Pod's group id.
+  gid: 1000
+  # Pod's user id.
+  uid: 100
+
   # Ingress allows ingress services to be created to allow external access
   # from Kubernetes to access Vault pods.
   ingress:


### PR DESCRIPTION
- Moves defaults for `server.gid` and `server.uid` to `values.yaml`.
- Adds missing documentation for the fields.

Motivation:

Currently, it's not possible to have an "empty" group or user id in pods. Overriding `server.gid` or `server.uid` to `null` doesn't work because of the `default` clause. However, on Openshift the pods will be assigned a proper group and user depending on security context constraints that applies to it. 

From [Managing Security Context Constraints](https://docs.openshift.com/container-platform/4.3/authentication/managing-security-context-constraints.html):
> When a container or pod does not request a user ID under which it should be run, the effective UID depends on the SCC that emits this pod. Because restricted SCC is granted to all authenticated users by default, it will be available to all users and service accounts and used in most cases.