### PR TITLE
Allow overriding VAULT_API_ADDR

### DIFF
--- a/templates/server-statefulset.yaml
+++ b/templates/server-statefulset.yaml
@@ -79,7 +79,11 @@ spec:
             - name: VAULT_ADDR
               value: "{{ include "vault.scheme" . }}://127.0.0.1:8200"
             - name: VAULT_API_ADDR
+              {{- if .Values.server.ha.apiAddr }}
+              value: {{ .Values.server.ha.apiAddr }}
+              {{- else }}
               value: "{{ include "vault.scheme" . }}://$(POD_IP):8200"
+              {{- end }}
             - name: SKIP_CHOWN
               value: "true"
             - name: SKIP_SETCAP

--- a/values.yaml
+++ b/values.yaml
@@ -349,6 +349,11 @@ server:
     enabled: false
     replicas: 3
 
+    # Set the api_addr configuration for Vault HA
+    # See https://www.vaultproject.io/docs/configuration#api_addr
+    # If set to null, this will be set to the Pod IP Address
+    apiAddr: null
+
     # Enables Vault's integrated Raft storage.  Unlike the typical HA modes where
     # Vault's persistence is external (such as Consul), enabling Raft mode will create
     # persistent volumes for Vault to store data according to the configuration under server.dataStorage.


### PR DESCRIPTION
According to the [documentation](https://www.vaultproject.io/docs/configuration#api_addr), this setting is used for client redirection, and also the default issuer for the [Identity OIDC token](https://www.vaultproject.io/api-docs/secret/identity/tokens).

I am guessing that this address should thus be accessible via all clients, including those not inside the Kubernetes Cluster. 

- The TLS certificate issued for Vault will probably not include the pod IP address since the pod IP addresses cannot be chosen.
- Pod IP addresses might not be accessible to clients outside the cluster.

This PR proposes allowing the user to override the setting if they desire.

I have previously set this to something that is not the Pod IP and I have not experienced problems. The setting is not very well explained and so I am not sure if this affects anything.