### PR TITLE
imagePullSecrets in injector-deployment

### DIFF
--- a/templates/injector-deployment.yaml
+++ b/templates/injector-deployment.yaml
@@ -104,4 +104,8 @@ spec:
           secret:
             secretName: "{{ .Values.injector.certs.secretName }}"
 {{- end }}
+      {{- if .Values.global.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml .Values.global.imagePullSecrets | nindent 8 }}
+      {{- end }}
 {{ end }}


### PR DESCRIPTION
vault-agent-injector does not respect the global imagePullSecrets at the moment