### PR TITLE
Removing namespace from yaml of non-namespaced objects

### DIFF
--- a/templates/injector-clusterrolebinding.yaml
+++ b/templates/injector-clusterrolebinding.yaml
@@ -3,7 +3,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: {{ template "vault.fullname" . }}-agent-injector-binding
-  namespace: {{ .Release.Namespace }}
   labels:
     app.kubernetes.io/name: {{ include "vault.name" . }}-agent-injector
     app.kubernetes.io/instance: {{ .Release.Name }}

--- a/templates/server-clusterrolebinding.yaml
+++ b/templates/server-clusterrolebinding.yaml
@@ -5,7 +5,6 @@ apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
 metadata:
   name: {{ template "vault.fullname" . }}-server-binding
-  namespace: {{ .Release.Namespace }}
   labels:
     helm.sh/chart: {{ include "vault.chart" . }}
     app.kubernetes.io/name: {{ include "vault.name" . }}


### PR DESCRIPTION
`ClusterRoleBinding`s are non-namespaced objects, so the `namespace` field is meaningless.

Other non-namespaced objects like `ClusterRole` and `MutatingWebhookConfiguration` already did not have the field so did not need to be updated.