### PR TITLE
Update ingress apiVersion in chart

### DIFF
--- a/templates/server-ingress.yaml
+++ b/templates/server-ingress.yaml
@@ -3,7 +3,11 @@
 {{- if .Values.server.ingress.enabled -}}
 {{- $serviceName := include "vault.fullname" . -}}
 {{- $servicePort := .Values.server.service.port -}}
+{{ if .Capabilities.APIVersions.Has "networking.k8s.io/v1beta1" }}
+apiVersion: networking.k8s.io/v1beta1
+{{ else }}
 apiVersion: extensions/v1beta1
+{{ end }}
 kind: Ingress
 metadata:
   name: {{ template "vault.fullname" . }}


### PR DESCRIPTION
The apiVersion `extensions/v1beta1` for ingresses has been removed in Kubernetes 1.16 and the new `networking.k8s.io/v1beta1` has to be used now. This conditional keeps compatibility with older Kubernetes versions while using the new apiVersion when available.