### PR TITLE
Add more config variables for transit-unsealing and raft-joining

### DIFF
--- a/values.yaml
+++ b/values.yaml
@@ -171,6 +171,9 @@ server:
   # This is useful if Vault must be signaled, e.g. to send a SIGHUP for log rotation
   shareProcessNamespace: false
 
+  # extraCommands is a string containing additional commands before Vault server is started.
+  extraCommands: ""
+
   # extraArgs is a string containing additional Vault server arguments.
   extraArgs: ""
 


### PR DESCRIPTION
Currently, the Vault configuration (`/tmp/storageconfig.hcl`) only provides `HOST_IP` and `POD_IP` as variables that get replaced. Additionally, the used `sed` commands are not well written and can not support entering URLs (or anything that contains a `/`).

This two variables are not enough to set up Vault correctly in all scenarios (in HA you need `API_ADDR`). For unsealing with Vault Transit ([docs](https://www.vaultproject.io/docs/configuration/seal/transit)) you also need to configure the address of another Vault server (eg. `TRANSIT_ADDR`). And to set up Raft backend ([docs](https://www.vaultproject.io/docs/configuration/storage/raft)) as easy as possible it is beneficial, that all nodes attempt to automatically join the cluster (eg. `RAFT_ADDR`). With this PR these can all be set as environment variables under `extraEnvironmentVars:` and this enables you to utilize variables in Helmfile (or other wrappers on top of Helm).

Anyway, I have been successfully using and redeploying Vault with transit-unsealing and raft-joining for a couple of months now with this PR and such a configuration:

```
      config: |
        ui = true
        api_addr = "API_ADDR"
        cluster_addr = "https://POD_IP:8201"
        listener "tcp" {
          address         = "[::]:8200"
          cluster_address = "[::]:8201"
        }
        storage "raft" {
          path = "/vault/data"
        }
        seal "transit" {
          address         = "TRANSIT_ADDR"
          disable_renewal = "false"
          key_name        = "unseal_key"
          mount_path      = "transit/"
        }
```