### PR TITLE
add support for more flexible volume mounts e.g. for use with init containers

### DIFF
--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -97,6 +97,9 @@ extra volumes the user may have specified (such as a secret with TLS).
             secretName: {{ .name }}
           {{- end }}
   {{- end }}
+  {{- if .Values.server.volumes }}
+    {{- toYaml .Values.server.volumes | nindent 8}}
+  {{- end }}
 {{- end -}}
 
 {{/*
@@ -158,6 +161,9 @@ based on the mode configured.
             - name: userconfig-{{ .name }}
               readOnly: true
               mountPath: {{ .path | default "/vault/userconfig" }}/{{ .name }}
+  {{- end }}
+  {{- if .Values.server.volumeMounts }}
+    {{- toYaml .Values.server.volumeMounts | nindent 12}}
   {{- end }}
 {{- end -}}
 

--- a/values.yaml
+++ b/values.yaml
@@ -163,6 +163,20 @@ server:
   # This is useful if you need to run a script to provision TLS certificates or
   # write out configuration files in a dynamic way.
   extraInitContainers: null
+    # # This example installs a plugin pulled from github into the /usr/local/libexec/vault/oauthapp folder,
+    # # which is defined in the volumes value.
+    # - name: oauthapp
+    #   image: "alpine"
+    #   command: [sh, -c]
+    #   args:
+    #     - cd /tmp &&
+    #       wget https://github.com/puppetlabs/vault-plugin-secrets-oauthapp/releases/download/v1.2.0/vault-plugin-secrets-oauthapp-v1.2.0-linux-amd64.tar.xz -O oauthapp.xz &&
+    #       tar -xf oauthapp.xz &&
+    #       mv vault-plugin-secrets-oauthapp-v1.2.0-linux-amd64 /usr/local/libexec/vault/oauthapp &&
+    #       chmod +x /usr/local/libexec/vault/oauthapp
+    #   volumeMounts:
+    #     - name: plugins
+    #       mountPath: /usr/local/libexec/vault
 
   # extraContainers is a list of sidecar containers. Specified as a YAML list.
   extraContainers: null
@@ -209,6 +223,22 @@ server:
     # - type: secret (or "configMap")
     #   name: my-secret
     #   path: null # default is `/vault/userconfig`
+
+  # volumes is a list of volumes made available to all containers. These are rendered
+  # via toYaml rather than pre-processed like the extraVolumes value.
+  # The purpose is to make it easy to share volumes between containers.
+  volumes: null
+  #   - name: plugins
+  #     emptyDir: {}
+
+  # volumeMounts is a list of volumeMounts for the main server container. These are rendered
+  # via toYaml rather than pre-processed like the extraVolumes value.
+  # The purpose is to make it easy to share volumes between containers.
+  volumeMounts: null
+  #   - mountPath: /usr/local/libexec/vault
+  #     name: plugins
+  #     readOnly: true
+
 
   # Affinity Settings
   # Commenting out or setting as empty the affinity variable, will allow


### PR DESCRIPTION
The existing volume mounts implementation via extraVolumes is too opinionated to allow mounting volumes for custom purposes, such as installing a plugin via an init container. Personally I don't like it and would remove it completely, but for backwards compatibility I've left it and added additional server.volumes and server.volumeMounts. Examples in the values files show how this can be used.

Please consider this as it's an easy way to customise your Vault installation.