### PR TITLE
Add postStart lifecycle hook

### DIFF
--- a/templates/server-statefulset.yaml
+++ b/templates/server-statefulset.yaml
@@ -159,6 +159,14 @@ spec:
                   # to this pod while it's terminating
                   "sleep {{ .Values.server.preStopSleepSeconds }} && kill -SIGTERM $(pidof vault)",
                 ]
+            {{- if .Values.server.postStart }}
+            postStart:
+              exec:
+                command:
+                {{- range (.Values.server.postStart) }}
+                - {{ . | quote }}
+                {{- end }}
+            {{- end }}
         {{- if .Values.server.extraContainers }}
           {{ toYaml .Values.server.extraContainers | nindent 8}}
         {{- end }}

--- a/test/unit/server-statefulset.bats
+++ b/test/unit/server-statefulset.bats
@@ -1048,3 +1048,24 @@ load _helpers
       yq '.spec.template.spec | .priorityClassName == "armaggeddon"' | tee /dev/stderr)
   [ "${actual}" = "true" ]
 }
+
+#--------------------------------------------------------------------
+# postStart
+@test "server/standalone-StatefulSet: postStart disabled by default" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/server-statefulset.yaml  \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.containers[0].lifecycle.postStart' | tee /dev/stderr)
+  [ "${actual}" = "null" ]
+}
+
+@test "server/standalone-StatefulSet: postStart can be set" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/server-statefulset.yaml  \
+      --set='server.postStart={/bin/sh,-c,sleep}' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.containers[0].lifecycle.postStart.exec.command[0]' | tee /dev/stderr)
+  [ "${actual}" = "/bin/sh" ]
+}

--- a/values.yaml
+++ b/values.yaml
@@ -191,7 +191,7 @@ server:
   # Used to define commands to run after the pod is ready.
   # This can be used to automate processes such as initialization
   # or boostrapping auth methods.
-  postStart: |
+  postStart: []
   # - /bin/sh
   # - -c
   # - /vault/userconfig/myscript/run.sh

--- a/values.yaml
+++ b/values.yaml
@@ -188,6 +188,14 @@ server:
   # Used to set the sleep time during the preStop step
   preStopSleepSeconds: 5
 
+  # Used to define commands to run after the pod is ready.
+  # This can be used to automate processes such as initialization
+  # or boostrapping auth methods.
+  postStart: |
+  # - /bin/sh
+  # - -c
+  # - /vault/userconfig/myscript/run.sh
+
   # extraEnvironmentVars is a list of extra enviroment variables to set with the stateful set. These could be
   # used to include variables required for auto-unseal.
   extraEnvironmentVars: {}


### PR DESCRIPTION
This adds a configurable `postStart` lifecycle hook to Vault Helm.  Using this hook, in conjunction with readiness probe configurations, it's possible to run scripts on the Vault pods after they start.  This would allow users to create custom scripts to do things like initialize Vault and bootstrap auth methods/policies.

```yaml
server:
  # Mount a secret containing some custom script
  extraVolumes:
  - type: secret
    name: demo-vault

  # Configure readiness probe to report "ready" even if Vault is uninitialized and sealed.
  # Useful when bootstrapping Vault for the first time.
  readinessProbe:
    path: "/v1/sys/health?standbyok=true&sealedcode=204&uninitcode=204"

  postStart:
  - "/bin/sh"
  - "-c"
  - "/vault/userconfig/demo-vault/bootstrap.sh"
```

These can also be configured via `--set`:

```bash
helm install vault \
  --set='server.postStart={/bin/sh,-c,/vault/userconfig/demo-vault/bootstrap.sh}' \
  .
```