### PR TITLE
check that git tag == chart tag on tagged releases

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,39 +1,53 @@
-version: 2
+version: 2.1
+orbs:
+  slack: circleci/slack@3.4.2
+
 jobs:
   bats-unit-test:
     docker:
-        # This image is built from test/docker/Test.dockerfile
-        - image: hashicorpdev/vault-helm-test:0.1.0
+      # This image is built from test/docker/Test.dockerfile
+      - image: hashicorpdev/vault-helm-test:0.1.0
     steps:
       - checkout
       - run: bats ./test/unit -t
   acceptance:
     docker:
-        # This image is build from test/docker/Test.dockerfile
-        - image: hashicorpdev/vault-helm-test:0.1.0
+      # This image is build from test/docker/Test.dockerfile
+      - image: hashicorpdev/vault-helm-test:0.1.0
 
     steps:
-        - checkout
-        - run:
-            name: terraform init & apply
-            command: |
-                echo -e "${GOOGLE_APP_CREDS}" | base64 -d > vault-helm-test.json
-                export GOOGLE_CREDENTIALS=vault-helm-test.json
-                make provision-cluster
-        - run:
-            name: Run acceptance tests
-            command: bats ./test/acceptance -t
+      - checkout
+      - run:
+          name: terraform init & apply
+          command: |
+            echo -e "${GOOGLE_APP_CREDS}" | base64 -d > vault-helm-test.json
+            export GOOGLE_CREDENTIALS=vault-helm-test.json
+            make provision-cluster
+      - run:
+          name: Run acceptance tests
+          command: bats ./test/acceptance -t
 
-        - run:
-            name: terraform destroy
-            command: |
-                export GOOGLE_CREDENTIALS=vault-helm-test.json
-                make destroy-cluster
-            when: always
+      - run:
+          name: terraform destroy
+          command: |
+            export GOOGLE_CREDENTIALS=vault-helm-test.json
+            make destroy-cluster
+          when: always
   update-helm-charts-index:
     docker:
       - image: circleci/golang:latest
     steps:
+      - checkout
+      - run:
+          name: verify Chart version matches tag version
+          command: |
+            GO111MODULE=on go get github.com/mikefarah/yq/v2
+            git_tag=$(echo "${CIRCLE_TAG#v}")
+            chart_tag=$(yq r Chart.yaml version)
+            if [ "${git_tag}" != "${chart_tag}" ]; then
+              echo "chart version (${chart_tag}) did not match git version (${git_tag})"
+              exit 1
+            fi
       - run:
           name: update helm-charts index
           command: |
@@ -43,17 +57,21 @@ jobs:
                 -H 'Accept: application/json' \
                 -d "{\"branch\": \"master\",\"parameters\":{\"SOURCE_REPO\": \"${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}\",\"SOURCE_TAG\": \"${CIRCLE_TAG}\"}}" \
                 "${CIRCLE_ENDPOINT}/${CIRCLE_PROJECT}/pipeline"
+      - slack/status:
+          fail_only: true
+          failure_message: "Failed to trigger an update to the helm charts index. Check the logs at: ${CIRCLE_BUILD_URL}"
+
 workflows:
   version: 2
   build_and_test:
     jobs:
       - bats-unit-test
       - acceptance:
-            requires:
-                - bats-unit-test
-            filters:
-                branches:
-                    only: master
+          requires:
+            - bats-unit-test
+          filters:
+            branches:
+              only: master
   update-helm-charts-index:
     jobs:
       - update-helm-charts-index:


### PR DESCRIPTION
It is easy to miss updating the version number in `Chart.yaml` when tagging a release so this is a sanity check to make sure the git tag version matches the version in the `Chart.yaml` file. I have also added a slack notification to send something when there is a failure in the tagged build workflow.