### PR TITLE
allow to set extra volume mode

### DIFF
--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -96,6 +96,7 @@ extra volumes the user may have specified (such as a secret with TLS).
           {{- else if (eq .type "secret") }}
             secretName: {{ .name }}
           {{- end }}
+            defaultMode: {{ .defaultMode | default 420 }}
   {{- end }}
 {{- end -}}
 


### PR DESCRIPTION
Currently there is no way to mount start up script that can be used for post start - the file permission are set to the default, 420, which is not executable. This PR allows to set the file permission.