### PR TITLE
Add note to config about sensitive configs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,8 @@
 # Vault Helm Chart
 
----
-**Please note**: We take Vault's security and our users' trust very seriously. If 
+> :warning: **Please note**: We take Vault's security and our users' trust very seriously. If 
 you believe you have found a security issue in Vault Helm, _please responsibly disclose_ 
 by contacting us at [security@hashicorp.com](mailto:security@hashicorp.com).
----
 
 This repository contains the official HashiCorp Helm chart for installing
 and configuring Vault on Kubernetes. This chart supports multiple use

--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 # Vault Helm Chart
 
+---
+**Please note**: We take Vault's security and our users' trust very seriously. If 
+you believe you have found a security issue in Vault Helm, _please responsibly disclose_ 
+by contacting us at [security@hashicorp.com](mailto:security@hashicorp.com).
+---
+
 This repository contains the official HashiCorp Helm chart for installing
 and configuring Vault on Kubernetes. This chart supports multiple use
 cases of Vault on Kubernetes depending on the values provided.

--- a/values.yaml
+++ b/values.yaml
@@ -341,6 +341,11 @@ server:
     # deployment. Default is to use a PersistentVolumeClaim mounted at /vault/data
     # and store data there. This is only used when using a Replica count of 1, and
     # using a stateful set. This should be HCL.
+
+    # Note: Configuration files are stored in ConfigMaps so sensitive data 
+    # such as passwords should be either mounted through extraSecretEnvironmentVars
+    # or through a Kube secret.  For more information see: 
+    # https://www.vaultproject.io/docs/platform/k8s/helm/run#protecting-sensitive-vault-configurations
     config: |
       ui = true
 
@@ -382,6 +387,11 @@ server:
       enabled: false
       # Set the Node Raft ID to the name of the pod
       setNodeId: false
+    
+      # Note: Configuration files are stored in ConfigMaps so sensitive data 
+      # such as passwords should be either mounted through extraSecretEnvironmentVars
+      # or through a Kube secret.  For more information see: 
+      # https://www.vaultproject.io/docs/platform/k8s/helm/run#protecting-sensitive-vault-configurations
       config: |
         ui = true
 
@@ -396,9 +406,15 @@ server:
         }
 
         service_registration "kubernetes" {}
+   
     # config is a raw string of default configuration when using a Stateful
     # deployment. Default is to use a Consul for its HA storage backend.
     # This should be HCL.
+    
+    # Note: Configuration files are stored in ConfigMaps so sensitive data 
+    # such as passwords should be either mounted through extraSecretEnvironmentVars
+    # or through a Kube secret.  For more information see: 
+    # https://www.vaultproject.io/docs/platform/k8s/helm/run#protecting-sensitive-vault-configurations
     config: |
       ui = true
 


### PR DESCRIPTION
Configs are stored in ConfigMaps due to limitations with Helm templating and Kube secrets requiring to be base64 encoded.  Vault Helm supports both `extraSecretEnvironmentVariables` and mounting secrets to be used as partial configuration files.  I added a note to `values.yaml` pointing to the documentation.

Additionally I added a warning header in the README about disclosing potential security flaws responsibly.