### PR TITLE
Fix python dependency in test image (#336)

### DIFF
--- a/test/docker/Test.dockerfile
+++ b/test/docker/Test.dockerfile
@@ -19,7 +19,6 @@ RUN apk update && apk add --no-cache --virtual .build-deps \
     tar \
     bash \
     openssl \
-    python \
     py-pip \
     git \
     make \


### PR DESCRIPTION
In latest alpine release (3.12) there was an intentional change
to drop python support without specify required version: python2
or python3.

Signed-off-by: Octavian Ionescu <itavyg@gmail.com>