### PR TITLE
Make serviceAccount name a configuration option

### DIFF
--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -292,11 +292,11 @@ Sets extra ui service annotations
 {{/*
 Create the name of the service account to use
 */}}
-{{- define "vault.serviceAccountName" -}}
-{{- if .Values.serviceAccount.enabled -}}
-    {{ default (include "vault.fullname" .) .Values.serviceAccount.name }}
+{{- define "vault.serviceAccount.name" -}}
+{{- if .Values.server.serviceAccount.enabled -}}
+    {{ default (include "vault.fullname" .) .Values.server.serviceAccount.name }}
 {{- else -}}
-    {{ default "default" .Values.serviceAccount.name }}
+    {{ default "default" .Values.server.serviceAccount.name }}
 {{- end -}}
 {{- end -}}
 

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -290,6 +290,17 @@ Sets extra ui service annotations
 {{- end -}}
 
 {{/*
+Create the name of the service account to use
+*/}}
+{{- define "vault.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+    {{ default (include "vault.fullname" .) .Values.serviceAccount.name }}
+{{- else -}}
+    {{ default "default" .Values.serviceAccount.name }}
+{{- end -}}
+{{- end -}}
+
+{{/*
 Sets extra service account annotations
 */}}
 {{- define "vault.serviceAccount.annotations" -}}

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -293,7 +293,7 @@ Sets extra ui service annotations
 Create the name of the service account to use
 */}}
 {{- define "vault.serviceAccountName" -}}
-{{- if .Values.serviceAccount.create -}}
+{{- if .Values.serviceAccount.enabled -}}
     {{ default (include "vault.fullname" .) .Values.serviceAccount.name }}
 {{- else -}}
     {{ default "default" .Values.serviceAccount.name }}

--- a/templates/server-clusterrolebinding.yaml
+++ b/templates/server-clusterrolebinding.yaml
@@ -16,7 +16,7 @@ roleRef:
   name: system:auth-delegator
 subjects:
 - kind: ServiceAccount
-  name: {{ template "vault.fullname" . }}
+  name: {{ template "vault.serviceAccount.name" . }}
   namespace: {{ .Release.Namespace }}
 {{ end }}
 {{ end }}

--- a/templates/server-discovery-rolebinding.yaml
+++ b/templates/server-discovery-rolebinding.yaml
@@ -17,7 +17,7 @@ roleRef:
   name: {{ template "vault.fullname" . }}-discovery-role
 subjects:
 - kind: ServiceAccount
-  name: {{ template "vault.fullname" . }}
+  name: {{ template "vault.serviceAccount.name" . }}
   namespace: {{ .Release.Namespace }}
 {{ end }}
 {{ end }}

--- a/templates/server-serviceaccount.yaml
+++ b/templates/server-serviceaccount.yaml
@@ -1,6 +1,7 @@
 {{ template "vault.mode" . }}
 {{- if ne .mode "external" }}
 {{- if and (ne .mode "") (eq (.Values.global.enabled | toString) "true") }}
+{{- if (eq (.Values.server.serviceAccount.enabled | toString) "true" ) }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -12,5 +13,6 @@ metadata:
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
   {{ template "vault.serviceAccount.annotations" . }}
+{{ end }}
 {{ end }}
 {{ end }}

--- a/templates/server-serviceaccount.yaml
+++ b/templates/server-serviceaccount.yaml
@@ -5,7 +5,7 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ template "vault.serviceAccountName" . }}
+  name: {{ template "vault.serviceAccount.name" . }}
   namespace: {{ .Release.Namespace }}
   labels:
     helm.sh/chart: {{ include "vault.chart" . }}

--- a/templates/server-serviceaccount.yaml
+++ b/templates/server-serviceaccount.yaml
@@ -4,7 +4,7 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ template "vault.fullname" . }}
+  name: {{ template "vault.serviceAccountName" . }}
   namespace: {{ .Release.Namespace }}
   labels:
     helm.sh/chart: {{ include "vault.chart" . }}

--- a/templates/server-statefulset.yaml
+++ b/templates/server-statefulset.yaml
@@ -41,7 +41,7 @@ spec:
       priorityClassName: {{ .Values.server.priorityClassName }}
       {{- end }}
       terminationGracePeriodSeconds: 10
-      serviceAccountName: {{ template "vault.fullname" . }}
+      serviceAccountName: {{ template "vault.serviceAccountName" . }}
       {{ if  .Values.server.shareProcessNamespace }}
       shareProcessNamespace: true
       {{ end }}

--- a/templates/server-statefulset.yaml
+++ b/templates/server-statefulset.yaml
@@ -41,7 +41,7 @@ spec:
       priorityClassName: {{ .Values.server.priorityClassName }}
       {{- end }}
       terminationGracePeriodSeconds: 10
-      serviceAccountName: {{ template "vault.serviceAccountName" . }}
+      serviceAccountName: {{ template "vault.serviceAccount.name" . }}
       {{ if  .Values.server.shareProcessNamespace }}
       shareProcessNamespace: true
       {{ end }}

--- a/test/unit/server-serviceaccount.bats
+++ b/test/unit/server-serviceaccount.bats
@@ -2,6 +2,41 @@
 
 load _helpers
 
+@test "server/ServiceAccount: specify service account name" {
+  cd `chart_dir`
+
+  local actual=$(helm template \
+      -x templates/server-serviceaccount.yaml  \
+      --set 'server.dev.enabled=true' \
+      --set 'server.serviceAccount.enabled=false' \
+      . | tee /dev/stderr |
+      yq 'length == 0' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+
+  local actual=$(helm template \
+      -x templates/server-serviceaccount.yaml  \
+      --set 'server.dev.enabled=true' \
+      --set 'server.serviceAccount.name=user-defined-ksa' \
+      . | tee /dev/stderr |
+      yq -r '.metadata.name' | tee /dev/stderr)
+  [ "${actual}" = "user-defined-ksa" ]
+
+  local actual=$(helm template \
+      -x templates/server-serviceaccount.yaml  \
+      --set 'server.dev.enabled=true' \
+      . | tee /dev/stderr |
+      yq -r '.metadata.name' | tee /dev/stderr)
+  [ "${actual}" = "release-name-vault" ]
+
+  local actual=$(helm template \
+      -x templates/server-serviceaccount.yaml  \
+      --set 'server.ha.enabled=true' \
+      --set 'server.serviceAccount.annotations.iam\.gke\.io/gcp-service-account=user-defined-gsa@my-project.iam.gserviceaccount.com' \
+      . | tee /dev/stderr |
+      yq -r '.metadata.annotations["iam.gke.io/gcp-service-account"]' | tee /dev/stderr)
+  [ "${actual}" = "user-defined-gsa@my-project.iam.gserviceaccount.com" ]
+}
+
 @test "server/ServiceAccount: specify annotations" {
   cd `chart_dir`
   local actual=$(helm template \

--- a/test/unit/server-serviceaccount.bats
+++ b/test/unit/server-serviceaccount.bats
@@ -6,7 +6,7 @@ load _helpers
   cd `chart_dir`
 
   local actual=$(helm template \
-      -x templates/server-serviceaccount.yaml  \
+      --show-only templates/server-serviceaccount.yaml  \
       --set 'server.dev.enabled=true' \
       --set 'server.serviceAccount.enabled=false' \
       . | tee /dev/stderr |
@@ -14,7 +14,7 @@ load _helpers
   [ "${actual}" = "true" ]
 
   local actual=$(helm template \
-      -x templates/server-serviceaccount.yaml  \
+      --show-only templates/server-serviceaccount.yaml  \
       --set 'server.dev.enabled=true' \
       --set 'server.serviceAccount.name=user-defined-ksa' \
       . | tee /dev/stderr |
@@ -22,14 +22,14 @@ load _helpers
   [ "${actual}" = "user-defined-ksa" ]
 
   local actual=$(helm template \
-      -x templates/server-serviceaccount.yaml  \
+      --show-only templates/server-serviceaccount.yaml  \
       --set 'server.dev.enabled=true' \
       . | tee /dev/stderr |
       yq -r '.metadata.name' | tee /dev/stderr)
   [ "${actual}" = "release-name-vault" ]
 
   local actual=$(helm template \
-      -x templates/server-serviceaccount.yaml  \
+      --show-only templates/server-serviceaccount.yaml  \
       --set 'server.ha.enabled=true' \
       --set 'server.serviceAccount.annotations.iam\.gke\.io/gcp-service-account=user-defined-gsa@my-project.iam.gserviceaccount.com' \
       . | tee /dev/stderr |

--- a/values.yaml
+++ b/values.yaml
@@ -451,6 +451,11 @@ server:
 
   # Definition of the serviceAccount used to run Vault.
   serviceAccount:
+    # Specifies whether a service account should be created
+    enabled: true
+    # The name of the service account to use.
+    # If not set and create is true, a name is generated using the fullname template
+    name: ""
     # Extra annotations for the serviceAccount definition. This can either be
     # YAML or a YAML-formatted multi-line templated string map of the
     # annotations to apply to the serviceAccount.


### PR DESCRIPTION
**_Note this PR is a clone of original https://github.com/hashicorp/vault-helm/pull/56 authored by @satterly to change the source branch to recently rebased fork. Original PR description is;_**

Allow user to set the Kubernetes serviceAccount name used by vault.

Currently the serviceAccount name is based on the chart release name
which is non-deterministic and so makes using GCloud Workload Identity
service account mapping very difficult.

And according to Google, "Workload Identity is the recommended way to access Google Cloud services from within GKE due to its improved security properties and manageability."
https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity

This also follows Helm Best Practices when defining serviceAccount names
https://helm.sh/docs/chart_best_practices/#using-rbac-resources

Example values.yaml

server:
  serviceaccount:
    name: vault-ksa
    annotations:
      iam.gke.io/gcp-service-account: vault-gsa@my-project.iam.gserviceaccount.com

where

    "vault-ksa" is the Kubernetes Service Account
    "vault-gsa" is the GCP Service Account
    "my-project" is the GCP Project name
