### PR TITLE
Added support for kubernetes ManagedCertificate resource

### DIFF
--- a/templates/managed-certificate.yaml
+++ b/templates/managed-certificate.yaml
@@ -1,0 +1,22 @@
+{{- if .Values.managedCertificate.enabled }}
+apiVersion: networking.gke.io/v1beta2
+kind: ManagedCertificate
+metadata:
+  name: {{ template "vault.fullname" . }}-cert
+  namespace: {{ .Release.Namespace }}
+  labels:
+    helm.sh/chart: {{ include "vault.chart" . }}
+    app.kubernetes.io/name: {{ include "vault.name" . }}-ui
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+  {{- template "vault.ui.annotations" . }}
+spec:
+  selector:
+    app.kubernetes.io/name: {{ include "vault.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    component: server
+  domains:
+      {{- range $domain := .Values.managedCertificate.domains }}
+      - {{ $domain }}
+      {{- end }}
+{{- end }}

--- a/values.yaml
+++ b/values.yaml
@@ -478,3 +478,14 @@ ui:
   # This can either be YAML or a YAML-formatted multi-line templated string map
   # of the annotations to apply to the ui service
   annotations: {}
+
+managedCertificate:
+  # True if you want to enabled ManagedCertificate
+  # In order to use the ManagedCertificate you will need to
+  #   annotate a service that supports it (gcp-ingress for example)
+  # Also, make sure the domains actually point to the exposed IP
+  #   otherwise the certificate won't be validated
+  enabled: false
+  # A list of domains the certificate will be generated for
+  domains: []
+  #   - my-domain.com


### PR DESCRIPTION
This is needed for the creation of a valid and managed SSL cert through a Kubernetes resource.
My use case is over GCP, I annotate it to the GCP ingress controller (as can see documented [here](https://cloud.google.com/kubernetes-engine/docs/how-to/managed-certs#config-connector))