### PR TITLE
Force caBundle to always be quoted

### DIFF
--- a/templates/injector-mutating-webhook.yaml
+++ b/templates/injector-mutating-webhook.yaml
@@ -14,7 +14,7 @@ webhooks:
         name: {{ template "vault.fullname" . }}-agent-injector-svc
         namespace: {{ .Release.Namespace }}
         path: "/mutate"
-      caBundle: {{ .Values.injector.certs.caBundle }}
+      caBundle: {{ .Values.injector.certs.caBundle | quote }}
     rules:
       - operations: ["CREATE", "UPDATE"]
         apiGroups: [""]

--- a/test/unit/injector-mutating-webhook.bats
+++ b/test/unit/injector-mutating-webhook.bats
@@ -42,7 +42,7 @@ load _helpers
   [ "${actual}" = "\"foo\"" ]
 }
 
-@test "injector/MutatingWebhookConfiguration: caBundle is empty" {
+@test "injector/MutatingWebhookConfiguration: caBundle is empty string" {
   cd `chart_dir`
   local actual=$(helm template \
       --show-only templates/injector-mutating-webhook.yaml  \
@@ -50,7 +50,7 @@ load _helpers
       --namespace foo \
       . | tee /dev/stderr |
       yq '.webhooks[0].clientConfig.caBundle' | tee /dev/stderr)
-  [ "${actual}" = "null" ]
+  [ "${actual}" = "\"\"" ]
 }
 
 @test "injector/MutatingWebhookConfiguration: namespaceSelector empty by default" {


### PR DESCRIPTION
This fixes issues when you use Helm 3 and do not provide a value for `caBundle` that causes validation issues, since the value of `caBundle` must be a string, even if empty.

(The issues are similar to https://github.com/jetstack/cert-manager/issues/1143, and you cannot turn validation off when using Helm 3.)
