### PR TITLE
Missing enabled checks for injector-network-policy

### DIFF
--- a/templates/injector-network-policy.yaml
+++ b/templates/injector-network-policy.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.global.openshift }}
+{{- if and (eq (.Values.injector.enabled | toString) "true" ) (and (eq (.Values.global.enabled | toString) "true") (eq (.Values.global.openshift | toString) "true") ) }}
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:


### PR DESCRIPTION
Looks like the `templates/injector-network-policy.yaml` is missing the checks to disable the template if injector isn't enabled.