### PR TITLE
Remove tolerate-unready-endpoints annotation

### DIFF
--- a/templates/server-headless-service.yaml
+++ b/templates/server-headless-service.yaml
@@ -13,7 +13,6 @@ metadata:
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
   annotations:
-    service.alpha.kubernetes.io/tolerate-unready-endpoints: "true"
 {{ template "vault.service.annotations" .}}
 spec:
   clusterIP: None

--- a/templates/server-service.yaml
+++ b/templates/server-service.yaml
@@ -13,10 +13,6 @@ metadata:
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
   annotations:
-    # This must be set in addition to publishNotReadyAddresses due
-    # to an open issue where it may not work:
-    # https://github.com/kubernetes/kubernetes/issues/58662
-    service.alpha.kubernetes.io/tolerate-unready-endpoints: "true"
 {{ template "vault.service.annotations" .}}
 spec:
   {{- if .Values.server.service.type}}

--- a/test/unit/server-service.bats
+++ b/test/unit/server-service.bats
@@ -143,32 +143,6 @@ load _helpers
   [ "${actual}" = "false" ]
 }
 
-# This can be seen as testing just what we put into the YAML raw, but
-# this is such an important part of making everything work we verify it here.
-@test "server/Service: tolerates unready endpoints" {
-  cd `chart_dir`
-  local actual=$(helm template \
-      --show-only templates/server-service.yaml \
-      --set 'server.dev.enabled=true' \
-      . | tee /dev/stderr |
-      yq -r '.metadata.annotations["service.alpha.kubernetes.io/tolerate-unready-endpoints"]' | tee /dev/stderr)
-  [ "${actual}" = "true" ]
-
-  local actual=$(helm template \
-      --show-only templates/server-service.yaml \
-      --set 'server.ha.enabled=true' \
-      . | tee /dev/stderr |
-      yq -r '.metadata.annotations["service.alpha.kubernetes.io/tolerate-unready-endpoints"]' | tee /dev/stderr)
-  [ "${actual}" = "true" ]
-
-  local actual=$(helm template \
-      --show-only templates/server-service.yaml \
-      --set 'server.standalone.enabled=true' \
-      . | tee /dev/stderr |
-      yq -r '.metadata.annotations["service.alpha.kubernetes.io/tolerate-unready-endpoints"]' | tee /dev/stderr)
-  [ "${actual}" = "true" ]
-}
-
 @test "server/Service: generic annotations" {
   cd `chart_dir`
   local actual=$(helm template \


### PR DESCRIPTION
This annotation has been deprecated since Kuberneets 1.8 and the publishNotReadyAddresses parameter replacing it has been correctly implemented in Kubernetes 1.11 (see https://github.com/kubernetes/kubernetes/pull/63742)