### PR TITLE
Add volume claim annotations

### DIFF
--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -179,7 +179,7 @@ storage might be desired by the user.
       {{- if and (eq (.Values.server.dataStorage.enabled | toString) "true") (or (eq .mode "standalone") (eq (.Values.server.ha.raft.enabled | toString ) "true" )) }}
     - metadata:
         name: data
-      {{- template "vault.dataVolumeClaim.annotations" . }}
+        {{- include "vault.dataVolumeClaim.annotations" . | nindent 6 }}
       spec:
         accessModes:
           - {{ .Values.server.dataStorage.accessMode | default "ReadWriteOnce" }}
@@ -193,7 +193,7 @@ storage might be desired by the user.
       {{- if eq (.Values.server.auditStorage.enabled | toString) "true" }}
     - metadata:
         name: audit
-      {{- template "vault.auditVolumeClaim.annotations" . }}
+        {{- include "vault.auditVolumeClaim.annotations" . | nindent 6 }}
       spec:
         accessModes:
           - {{ .Values.server.auditStorage.accessMode | default "ReadWriteOnce" }}

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -179,6 +179,7 @@ storage might be desired by the user.
       {{- if and (eq (.Values.server.dataStorage.enabled | toString) "true") (or (eq .mode "standalone") (eq (.Values.server.ha.raft.enabled | toString ) "true" )) }}
     - metadata:
         name: data
+  {{- template "vault.dataVolumeClaim.annotations" . }}
       spec:
         accessModes:
           - {{ .Values.server.dataStorage.accessMode | default "ReadWriteOnce" }}
@@ -192,6 +193,7 @@ storage might be desired by the user.
       {{- if eq (.Values.server.auditStorage.enabled | toString) "true" }}
     - metadata:
         name: audit
+  {{- template "vault.auditVolumeClaim.annotations" . }}
       spec:
         accessModes:
           - {{ .Values.server.auditStorage.accessMode | default "ReadWriteOnce" }}
@@ -391,6 +393,36 @@ Sets extra statefulset annotations
       {{- tpl .Values.server.statefulSet.annotations . | nindent 4 }}
     {{- else }}
       {{- toYaml .Values.server.statefulSet.annotations | nindent 4 }}
+    {{- end }}
+  {{- end }}
+{{- end -}}
+
+{{/*
+Sets VolumeClaim annotations for data volume
+*/}}
+{{- define "vault.dataVolumeClaim.annotations" -}}
+  {{- if and (ne .mode "dev") (.Values.server.dataStorage.enabled) (.Values.server.dataStorage.annotations) }}
+  annotations:
+    {{- $tp := typeOf .Values.server.dataStorage.annotations }}
+    {{- if eq $tp "string" }}
+      {{- tpl .Values.server.dataStorage.annotations . | nindent 4 }}
+    {{- else }}
+      {{- toYaml .Values.server.dataStorage.annotations | nindent 4 }}
+    {{- end }}
+  {{- end }}
+{{- end -}}
+
+{{/*
+Sets VolumeClaim annotations for audit volume
+*/}}
+{{- define "vault.auditVolumeClaim.annotations" -}}
+  {{- if and (ne .mode "dev") (.Values.server.auditStorage.enabled) (.Values.server.auditStorage.annotations) }}
+  annotations:
+    {{- $tp := typeOf .Values.server.auditStorage.annotations }}
+    {{- if eq $tp "string" }}
+      {{- tpl .Values.server.auditStorage.annotations . | nindent 4 }}
+    {{- else }}
+      {{- toYaml .Values.server.auditStorage.annotations | nindent 4 }}
     {{- end }}
   {{- end }}
 {{- end -}}

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -179,7 +179,7 @@ storage might be desired by the user.
       {{- if and (eq (.Values.server.dataStorage.enabled | toString) "true") (or (eq .mode "standalone") (eq (.Values.server.ha.raft.enabled | toString ) "true" )) }}
     - metadata:
         name: data
-  {{- template "vault.dataVolumeClaim.annotations" . }}
+      {{- template "vault.dataVolumeClaim.annotations" . }}
       spec:
         accessModes:
           - {{ .Values.server.dataStorage.accessMode | default "ReadWriteOnce" }}
@@ -193,7 +193,7 @@ storage might be desired by the user.
       {{- if eq (.Values.server.auditStorage.enabled | toString) "true" }}
     - metadata:
         name: audit
-  {{- template "vault.auditVolumeClaim.annotations" . }}
+      {{- template "vault.auditVolumeClaim.annotations" . }}
       spec:
         accessModes:
           - {{ .Values.server.auditStorage.accessMode | default "ReadWriteOnce" }}

--- a/test/unit/server-statefulset.bats
+++ b/test/unit/server-statefulset.bats
@@ -1090,6 +1090,50 @@ load _helpers
   [ "${actual}" = "true" ]
 }
 
+@test "server/standalone-StatefulSet: auditStorage volumeClaim annotations string" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/server-statefulset.yaml \
+      --set 'server.auditStorage.enabled=true' \
+      --set 'server.auditStorage.annotations=vaultIsAwesome: true' \
+      . | tee /dev/stderr |
+      yq -r '.spec.volumeClaimTemplates[1].metadata.annotations["vaultIsAwesome"]' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}
+
+@test "server/standalone-StatefulSet: dataStorage volumeClaim annotations string" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/server-statefulset.yaml \
+      --set 'server.dataStorage.enabled=true' \
+      --set 'server.dataStorage.annotations=vaultIsAwesome: true' \
+      . | tee /dev/stderr |
+      yq -r '.spec.volumeClaimTemplates[0].metadata.annotations["vaultIsAwesome"]' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}
+
+@test "server/standalone-StatefulSet: auditStorage volumeClaim annotations yaml" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/server-statefulset.yaml \
+      --set 'server.auditStorage.enabled=true' \
+      --set 'server.auditStorage.annotations.vaultIsAwesome=true' \
+      . | tee /dev/stderr |
+      yq -r '.spec.volumeClaimTemplates[1].metadata.annotations["vaultIsAwesome"]' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}
+
+@test "server/standalone-StatefulSet: dataStorage volumeClaim annotations yaml" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/server-statefulset.yaml \
+      --set 'server.dataStorage.enabled=true' \
+      --set 'server.dataStorage.annotations.vaultIsAwesome=true' \
+      . | tee /dev/stderr |
+      yq -r '.spec.volumeClaimTemplates[0].metadata.annotations["vaultIsAwesome"]' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}
+
 @test "server/ha-standby-Service: generic annotations yaml" {
   cd `chart_dir`
   local actual=$(helm template \

--- a/values.yaml
+++ b/values.yaml
@@ -346,6 +346,8 @@ server:
     storageClass: null
     # Access Mode of the storage device being used for the PVC
     accessMode: ReadWriteOnce
+    # Annotations to apply to the PVC
+    annotations: {}
 
   # This configures the Vault Statefulset to create a PVC for audit
   # logs.  Once Vault is deployed, initialized and unseal, Vault must
@@ -361,6 +363,8 @@ server:
     storageClass: null
     # Access Mode of the storage device being used for the PVC
     accessMode: ReadWriteOnce
+    # Annotations to apply to the PVC
+    annotations: {}
 
   # Run Vault in "dev" mode. This requires no further setup, no state management,
   # and no initialization. This is useful for experimenting with Vault without


### PR DESCRIPTION
Context: When using a tool like ArgoCD, `PersistentVolumeClaim` resources show up as "needs pruning" since they are generated via templating instead of factored in at build time. Despite the use of values that indicate the creation of these claims is a desirable outcome, they simply show up as "out of sync."

Adding the ability to pass annotations into these objects would allow the use of annotations to tell ArgoCD to simply ignore them. This is admittedly a fringe use case, but could provide useful either way. These were created separately to allow turning either of them on or off, but the initial approach was to just put them under `global`, but that seemed wrong.

Unit tests pass: `303 tests, 0 failures`, however no net new unit tests have been added as part of this PR. I'm happy to write one if it's necessary for this addition.

Thanks for your time!