### PR TITLE
allow server annotations with dev mode

### DIFF
--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -269,7 +269,7 @@ Sets the injector node selector for pod placement
 Sets extra pod annotations
 */}}
 {{- define "vault.annotations" -}}
-  {{- if and (ne .mode "dev") .Values.server.annotations }}
+  {{- if .Values.server.annotations }}
       annotations:
         {{- $tp := typeOf .Values.server.annotations }}
         {{- if eq $tp "string" }}


### PR DESCRIPTION
Reconciles issues seen in #301

As a developer I would like to be able to use dev mode in conjunction with pod annotations.