### PR TITLE
Add vault-k8s metrics configurable

### DIFF
--- a/templates/injector-deployment.yaml
+++ b/templates/injector-deployment.yaml
@@ -76,6 +76,10 @@ spec:
             - name: AGENT_INJECT_SET_SECURITY_CONTEXT
               value: "false"
             {{- end }}
+            {{- if .Values.injector.metrics.enabled }}
+            - name: AGENT_INJECT_TELEMETRY_PATH
+              value: "/metrics"
+            {{- end }}
             {{- include "vault.extraEnvironmentVars" .Values.injector | nindent 12 }}
           args:
             - agent-inject

--- a/test/unit/injector-deployment.bats
+++ b/test/unit/injector-deployment.bats
@@ -106,6 +106,23 @@ load _helpers
   [ "${actual}" = "250m" ]
 }
 
+@test "injector/deployment: enable metrics" {
+  cd `chart_dir`
+  local object=$(helm template \
+      --show-only templates/injector-deployment.yaml  \
+      --set 'injector.metrics.enabled=true' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.containers[0].env' | tee /dev/stderr)
+
+  local actual=$(echo $object |
+     yq -r '.[9].name' | tee /dev/stderr)
+  [ "${actual}" = "AGENT_INJECT_TELEMETRY_PATH" ]
+
+  local actual=$(echo $object |
+      yq -r '.[9].value' | tee /dev/stderr)
+  [ "${actual}" = "/metrics" ]
+}
+
 @test "injector/deployment: manual TLS environment vars" {
   cd `chart_dir`
   local object=$(helm template \

--- a/values.yaml
+++ b/values.yaml
@@ -27,6 +27,10 @@ injector:
   # True if you want to enable vault agent injection.
   enabled: true
 
+  # If true, will enable a node exporter metrics endpoint at /metrics.
+  metrics:
+    enabled: false
+
   # External vault server address for the injector to use. Setting this will
   # disable deployment of a vault server along with the injector.
   externalVaultAddr: ""


### PR DESCRIPTION
This adds a configurable to toggle Vault K8s new exported metrics endpoint (https://github.com/hashicorp/vault-k8s/pull/145).  This is currently an unreleased feature in Vault K8s, but will be in the new release coming.  For now this will have no effect. 