### PR TITLE
Update notes template to be helm v3 compatible

### DIFF
--- a/templates/NOTES.txt
+++ b/templates/NOTES.txt
@@ -10,5 +10,5 @@ https://www.vaultproject.io/docs/
 Your release is named {{ .Release.Name }}. To learn more about the release, try:
 
   $ helm status {{ .Release.Name }}
-  $ helm get {{ .Release.Name }}
+  $ helm get manifest {{ .Release.Name }}
 


### PR DESCRIPTION
`helm get {{ .Release.Name }}` is replaced by `helm get all {{ .Release.Name }}` in helm v3, but `all` doesn't exist in v2. In v3, running `helm get vault` returns the help text.

In this PR I've proposed changing to `vault get manifest` because that's an example that works on both versions without having to write a caveat with two versions of the command, and contains the additional information that I think most new users would be immediately interested in. But I'm not opposed to giving two versions of the command either.

v2 docs: https://v2.helm.sh/docs/helm/#helm-get
v3 docs: https://helm.sh/docs/helm/helm_get/