### PR TITLE
Allow explicit network policy enablement

### DIFF
--- a/templates/server-network-policy.yaml
+++ b/templates/server-network-policy.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.global.openshift }}
+{{- if or (.Values.global.openshift) (eq (.Values.server.networkPolicy.enabled | toString) "true" ) }}
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:

--- a/templates/server-network-policy.yaml
+++ b/templates/server-network-policy.yaml
@@ -1,4 +1,4 @@
-{{- if or (.Values.global.openshift) (eq (.Values.server.networkPolicy.enabled | toString) "true" ) }}
+{{- if eq (.Values.server.networkPolicy.enabled | toString) "true"  }}
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:

--- a/test/unit/server-network-policy.bats
+++ b/test/unit/server-network-policy.bats
@@ -2,7 +2,7 @@
 
 load _helpers
 
-@test "server/network-policy: OpenShift - disabled by default" {
+@test "server/network-policy: disabled by default" {
   cd `chart_dir`
   local actual=$( (helm template \
       --show-only templates/server-network-policy.yaml  \
@@ -11,10 +11,10 @@ load _helpers
   [ "${actual}" = "false" ]
 }
 
-@test "server/network-policy: OpenShift - enabled if OpenShift" {
+@test "server/network-policy: enabled by server.networkPolicy.enabled" {
   cd `chart_dir`
   local actual=$( (helm template \
-      --set 'global.openshift=true' \
+      --set 'server.networkPolicy.enabled=true' \
       --show-only templates/server-network-policy.yaml  \
       . || echo "---") | tee /dev/stderr |
       yq 'length > 0' | tee /dev/stderr)

--- a/values.yaml
+++ b/values.yaml
@@ -298,6 +298,10 @@ server:
   #   beta.kubernetes.io/arch: amd64
   nodeSelector: null
 
+  # Enables network policy for server pods
+  networkPolicy:
+    enabled: true
+
   # Priority class for server pods
   priorityClassName: ""
 

--- a/values.yaml
+++ b/values.yaml
@@ -300,7 +300,7 @@ server:
 
   # Enables network policy for server pods
   networkPolicy:
-    enabled: true
+    enabled: false
 
   # Priority class for server pods
   priorityClassName: ""


### PR DESCRIPTION
For now, the only way to create a network policy - is to enable `openshift`. 
I don't need all the resources enabled by `openshift` configuration.
But I still need network policy.
This PR allows configuring network policy creation without enabling `openshift`