### PR TITLE
Add configurable probe values

### DIFF
--- a/templates/server-statefulset.yaml
+++ b/templates/server-statefulset.yaml
@@ -141,11 +141,11 @@ spec:
             exec:
               command: ["/bin/sh", "-ec", "vault status -tls-skip-verify"]
             {{- end }}
-            failureThreshold: 2
-            initialDelaySeconds: 5
-            periodSeconds: 3
-            successThreshold: 1
-            timeoutSeconds: 5
+            failureThreshold: {{ .Values.server.readinessProbe.failureThreshold | default 2 }}
+            initialDelaySeconds: {{ .Values.server.readinessProbe.initialDelaySeconds | default 5 }}
+            periodSeconds: {{ .Values.server.readinessProbe.periodSeconds | default 3 }}
+            successThreshold: {{ .Values.server.readinessProbe.successThreshold | default 1 }}
+            timeoutSeconds: {{ .Values.server.readinessProbe.timeoutSeconds | default 5 }}
           {{- end }}
           {{- if .Values.server.livenessProbe.enabled }}
           livenessProbe:
@@ -153,10 +153,11 @@ spec:
               path: {{ .Values.server.livenessProbe.path | quote }}
               port: 8200
               scheme: {{ include "vault.scheme" . | upper }}
-            initialDelaySeconds: {{ .Values.server.livenessProbe.initialDelaySeconds }}
-            periodSeconds: 3
-            successThreshold: 1
-            timeoutSeconds: 5
+            failureThreshold: {{ .Values.server.livenessProbe.failureThreshold | default 2 }}
+            initialDelaySeconds: {{ .Values.server.livenessProbe.initialDelaySeconds | default 60 }}
+            periodSeconds: {{ .Values.server.livenessProbe.periodSeconds | default 3 }}
+            successThreshold: {{ .Values.server.livenessProbe.successThreshold | default 1 }}
+            timeoutSeconds: {{ .Values.server.livenessProbe.timeoutSeconds | default 5 }}
           {{- end }}
           lifecycle:
             # Vault container doesn't receive SIGTERM from Kubernetes

--- a/templates/server-statefulset.yaml
+++ b/templates/server-statefulset.yaml
@@ -141,11 +141,11 @@ spec:
             exec:
               command: ["/bin/sh", "-ec", "vault status -tls-skip-verify"]
             {{- end }}
-            failureThreshold: {{ .Values.server.readinessProbe.failureThreshold | default 2 }}
-            initialDelaySeconds: {{ .Values.server.readinessProbe.initialDelaySeconds | default 5 }}
-            periodSeconds: {{ .Values.server.readinessProbe.periodSeconds | default 3 }}
-            successThreshold: {{ .Values.server.readinessProbe.successThreshold | default 1 }}
-            timeoutSeconds: {{ .Values.server.readinessProbe.timeoutSeconds | default 5 }}
+            failureThreshold: {{ .Values.server.readinessProbe.failureThreshold }}
+            initialDelaySeconds: {{ .Values.server.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.server.readinessProbe.periodSeconds }}
+            successThreshold: {{ .Values.server.readinessProbe.successThreshold }}
+            timeoutSeconds: {{ .Values.server.readinessProbe.timeoutSeconds }}
           {{- end }}
           {{- if .Values.server.livenessProbe.enabled }}
           livenessProbe:
@@ -153,11 +153,11 @@ spec:
               path: {{ .Values.server.livenessProbe.path | quote }}
               port: 8200
               scheme: {{ include "vault.scheme" . | upper }}
-            failureThreshold: {{ .Values.server.livenessProbe.failureThreshold | default 2 }}
-            initialDelaySeconds: {{ .Values.server.livenessProbe.initialDelaySeconds | default 60 }}
-            periodSeconds: {{ .Values.server.livenessProbe.periodSeconds | default 3 }}
-            successThreshold: {{ .Values.server.livenessProbe.successThreshold | default 1 }}
-            timeoutSeconds: {{ .Values.server.livenessProbe.timeoutSeconds | default 5 }}
+            failureThreshold: {{ .Values.server.livenessProbe.failureThreshold }}
+            initialDelaySeconds: {{ .Values.server.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.server.livenessProbe.periodSeconds }}
+            successThreshold: {{ .Values.server.livenessProbe.successThreshold }}
+            timeoutSeconds: {{ .Values.server.livenessProbe.timeoutSeconds }}
           {{- end }}
           lifecycle:
             # Vault container doesn't receive SIGTERM from Kubernetes

--- a/test/unit/server-statefulset.bats
+++ b/test/unit/server-statefulset.bats
@@ -962,6 +962,110 @@ load _helpers
   [ "${actual}" = "null" ]
 }
 
+@test "server/standalone-StatefulSet: readiness failureThreshold default" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/server-statefulset.yaml \
+      --set 'server.readinessProbe.enabled=true' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.containers[0].readinessProbe.failureThreshold' | tee /dev/stderr)
+  [ "${actual}" = "2" ]
+}
+
+@test "server/standalone-StatefulSet: readiness failureThreshold configurable" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/server-statefulset.yaml \
+      --set 'server.readinessProbe.enabled=true' \
+      --set 'server.readinessProbe.failureThreshold=100' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.containers[0].readinessProbe.failureThreshold' | tee /dev/stderr)
+  [ "${actual}" = "100" ]
+}
+
+@test "server/standalone-StatefulSet: readiness initialDelaySeconds default" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/server-statefulset.yaml \
+      --set 'server.readinessProbe.enabled=true' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.containers[0].readinessProbe.initialDelaySeconds' | tee /dev/stderr)
+  [ "${actual}" = "5" ]
+}
+
+@test "server/standalone-StatefulSet: readiness initialDelaySeconds configurable" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/server-statefulset.yaml \
+      --set 'server.readinessProbe.enabled=true' \
+      --set 'server.readinessProbe.initialDelaySeconds=100' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.containers[0].readinessProbe.initialDelaySeconds' | tee /dev/stderr)
+  [ "${actual}" = "100" ]
+}
+
+@test "server/standalone-StatefulSet: readiness periodSeconds default" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/server-statefulset.yaml \
+      --set 'server.readinessProbe.enabled=true' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.containers[0].readinessProbe.periodSeconds' | tee /dev/stderr)
+  [ "${actual}" = "3" ]
+}
+
+@test "server/standalone-StatefulSet: readiness periodSeconds configurable" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/server-statefulset.yaml \
+      --set 'server.readinessProbe.enabled=true' \
+      --set 'server.readinessProbe.periodSeconds=100' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.containers[0].readinessProbe.periodSeconds' | tee /dev/stderr)
+  [ "${actual}" = "100" ]
+}
+
+@test "server/standalone-StatefulSet: readiness successThreshold default" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/server-statefulset.yaml \
+      --set 'server.readinessProbe.enabled=true' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.containers[0].readinessProbe.successThreshold' | tee /dev/stderr)
+  [ "${actual}" = "1" ]
+}
+
+@test "server/standalone-StatefulSet: readiness successThreshold configurable" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/server-statefulset.yaml \
+      --set 'server.readinessProbe.enabled=true' \
+      --set 'server.readinessProbe.successThreshold=100' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.containers[0].readinessProbe.successThreshold' | tee /dev/stderr)
+  [ "${actual}" = "100" ]
+}
+
+@test "server/standalone-StatefulSet: readiness timeoutSeconds default" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/server-statefulset.yaml \
+      --set 'server.readinessProbe.enabled=true' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.containers[0].readinessProbe.timeoutSeconds' | tee /dev/stderr)
+  [ "${actual}" = "5" ]
+}
+
+@test "server/standalone-StatefulSet: readiness timeoutSeconds configurable" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/server-statefulset.yaml \
+      --set 'server.readinessProbe.enabled=true' \
+      --set 'server.readinessProbe.timeoutSeconds=100' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.containers[0].readinessProbe.timeoutSeconds' | tee /dev/stderr)
+  [ "${actual}" = "100" ]
+}
 
 @test "server/standalone-StatefulSet: livenessProbe default" {
   cd `chart_dir`
@@ -982,7 +1086,28 @@ load _helpers
   [ "${actual}" = "/v1/sys/health?standbyok=true" ]
 }
 
-@test "server/standalone-StatefulSet: livenessProbe initialDelaySeconds default" {
+@test "server/standalone-StatefulSet: liveness failureThreshold default" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/server-statefulset.yaml \
+      --set 'server.livenessProbe.enabled=true' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.containers[0].livenessProbe.failureThreshold' | tee /dev/stderr)
+  [ "${actual}" = "2" ]
+}
+
+@test "server/standalone-StatefulSet: liveness failureThreshold configurable" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/server-statefulset.yaml \
+      --set 'server.livenessProbe.enabled=true' \
+      --set 'server.livenessProbe.failureThreshold=100' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.containers[0].livenessProbe.failureThreshold' | tee /dev/stderr)
+  [ "${actual}" = "100" ]
+}
+
+@test "server/standalone-StatefulSet: liveness initialDelaySeconds default" {
   cd `chart_dir`
   local actual=$(helm template \
       --show-only templates/server-statefulset.yaml \
@@ -992,17 +1117,82 @@ load _helpers
   [ "${actual}" = "60" ]
 }
 
-@test "server/standalone-StatefulSet: livenessProbe initialDelaySeconds configurable" {
+@test "server/standalone-StatefulSet: liveness initialDelaySeconds configurable" {
   cd `chart_dir`
   local actual=$(helm template \
       --show-only templates/server-statefulset.yaml \
       --set 'server.livenessProbe.enabled=true' \
-      --set 'server.livenessProbe.initialDelaySeconds=30' \
+      --set 'server.livenessProbe.initialDelaySeconds=100' \
       . | tee /dev/stderr |
       yq -r '.spec.template.spec.containers[0].livenessProbe.initialDelaySeconds' | tee /dev/stderr)
-  [ "${actual}" = "30" ]
+  [ "${actual}" = "100" ]
 }
 
+@test "server/standalone-StatefulSet: liveness periodSeconds default" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/server-statefulset.yaml \
+      --set 'server.livenessProbe.enabled=true' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.containers[0].livenessProbe.periodSeconds' | tee /dev/stderr)
+  [ "${actual}" = "3" ]
+}
+
+@test "server/standalone-StatefulSet: liveness periodSeconds configurable" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/server-statefulset.yaml \
+      --set 'server.livenessProbe.enabled=true' \
+      --set 'server.livenessProbe.periodSeconds=100' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.containers[0].livenessProbe.periodSeconds' | tee /dev/stderr)
+  [ "${actual}" = "100" ]
+}
+
+@test "server/standalone-StatefulSet: liveness successThreshold default" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/server-statefulset.yaml \
+      --set 'server.livenessProbe.enabled=true' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.containers[0].livenessProbe.successThreshold' | tee /dev/stderr)
+  [ "${actual}" = "1" ]
+}
+
+@test "server/standalone-StatefulSet: liveness successThreshold configurable" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/server-statefulset.yaml \
+      --set 'server.livenessProbe.enabled=true' \
+      --set 'server.livenessProbe.successThreshold=100' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.containers[0].livenessProbe.successThreshold' | tee /dev/stderr)
+  [ "${actual}" = "100" ]
+}
+
+@test "server/standalone-StatefulSet: liveness timeoutSeconds default" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/server-statefulset.yaml \
+      --set 'server.livenessProbe.enabled=true' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.containers[0].livenessProbe.timeoutSeconds' | tee /dev/stderr)
+  [ "${actual}" = "5" ]
+}
+
+@test "server/standalone-StatefulSet: liveness timeoutSeconds configurable" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/server-statefulset.yaml \
+      --set 'server.livenessProbe.enabled=true' \
+      --set 'server.livenessProbe.timeoutSeconds=100' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.containers[0].livenessProbe.timeoutSeconds' | tee /dev/stderr)
+  [ "${actual}" = "100" ]
+}
+
+#--------------------------------------------------------------------
+# args
 @test "server/standalone-StatefulSet: add extraArgs" {
   cd `chart_dir`
   local actual=$(helm template \

--- a/test/unit/server-statefulset.bats
+++ b/test/unit/server-statefulset.bats
@@ -1011,7 +1011,7 @@ load _helpers
       --set 'server.readinessProbe.enabled=true' \
       . | tee /dev/stderr |
       yq -r '.spec.template.spec.containers[0].readinessProbe.periodSeconds' | tee /dev/stderr)
-  [ "${actual}" = "3" ]
+  [ "${actual}" = "5" ]
 }
 
 @test "server/standalone-StatefulSet: readiness periodSeconds configurable" {
@@ -1053,7 +1053,7 @@ load _helpers
       --set 'server.readinessProbe.enabled=true' \
       . | tee /dev/stderr |
       yq -r '.spec.template.spec.containers[0].readinessProbe.timeoutSeconds' | tee /dev/stderr)
-  [ "${actual}" = "5" ]
+  [ "${actual}" = "3" ]
 }
 
 @test "server/standalone-StatefulSet: readiness timeoutSeconds configurable" {
@@ -1135,7 +1135,7 @@ load _helpers
       --set 'server.livenessProbe.enabled=true' \
       . | tee /dev/stderr |
       yq -r '.spec.template.spec.containers[0].livenessProbe.periodSeconds' | tee /dev/stderr)
-  [ "${actual}" = "3" ]
+  [ "${actual}" = "5" ]
 }
 
 @test "server/standalone-StatefulSet: liveness periodSeconds configurable" {
@@ -1177,7 +1177,7 @@ load _helpers
       --set 'server.livenessProbe.enabled=true' \
       . | tee /dev/stderr |
       yq -r '.spec.template.spec.containers[0].livenessProbe.timeoutSeconds' | tee /dev/stderr)
-  [ "${actual}" = "5" ]
+  [ "${actual}" = "3" ]
 }
 
 @test "server/standalone-StatefulSet: liveness timeoutSeconds configurable" {

--- a/values.yaml
+++ b/values.yaml
@@ -237,7 +237,7 @@ server:
     path: "/v1/sys/health?standbyok=true"
     # When a probe fails, Kubernetes will try failureThreshold times before giving up
     failureThreshold: 2
-    # Number of seconds after the container has started before probbe initiates
+    # Number of seconds after the container has started before probe initiates
     initialDelaySeconds: 60
     # How often (in seconds) to perform the probe
     periodSeconds: 3

--- a/values.yaml
+++ b/values.yaml
@@ -218,11 +218,33 @@ server:
     enabled: true
     # If you need to use a http path instead of the default exec
     # path: /v1/sys/health?standbyok=true
+    
+    # When a probe fails, Kubernetes will try failureThreshold times before giving up
+    failureThreshold: 2
+    # Number of seconds after the container has started before probbe initiates
+    initialDelaySeconds: 5
+    # How often (in seconds) to perform the probe
+    periodSeconds: 3
+    # Minimum consecutive successes for the probe to be considered successful after having failed
+    successThreshold: 1
+    # Number of seconds after which the probe times out.
+    timeoutSeconds: 5
+    # If you need to use a http path instead of the default exec
+    # path: /v1/sys/health?standbyok=true
   # Used to enable a livenessProbe for the pods
   livenessProbe:
     enabled: false
     path: "/v1/sys/health?standbyok=true"
+    # When a probe fails, Kubernetes will try failureThreshold times before giving up
+    failureThreshold: 2
+    # Number of seconds after the container has started before probbe initiates
     initialDelaySeconds: 60
+    # How often (in seconds) to perform the probe
+    periodSeconds: 3
+    # Minimum consecutive successes for the probe to be considered successful after having failed
+    successThreshold: 1
+    # Number of seconds after which the probe times out.
+    timeoutSeconds: 5
 
   # Used to set the sleep time during the preStop step
   preStopSleepSeconds: 5

--- a/values.yaml
+++ b/values.yaml
@@ -221,7 +221,7 @@ server:
     
     # When a probe fails, Kubernetes will try failureThreshold times before giving up
     failureThreshold: 2
-    # Number of seconds after the container has started before probbe initiates
+    # Number of seconds after the container has started before probe initiates
     initialDelaySeconds: 5
     # How often (in seconds) to perform the probe
     periodSeconds: 3

--- a/values.yaml
+++ b/values.yaml
@@ -229,8 +229,6 @@ server:
     successThreshold: 1
     # Number of seconds after which the probe times out.
     timeoutSeconds: 5
-    # If you need to use a http path instead of the default exec
-    # path: /v1/sys/health?standbyok=true
   # Used to enable a livenessProbe for the pods
   livenessProbe:
     enabled: false

--- a/values.yaml
+++ b/values.yaml
@@ -224,11 +224,11 @@ server:
     # Number of seconds after the container has started before probe initiates
     initialDelaySeconds: 5
     # How often (in seconds) to perform the probe
-    periodSeconds: 3
+    periodSeconds: 5
     # Minimum consecutive successes for the probe to be considered successful after having failed
     successThreshold: 1
     # Number of seconds after which the probe times out.
-    timeoutSeconds: 5
+    timeoutSeconds: 3
   # Used to enable a livenessProbe for the pods
   livenessProbe:
     enabled: false
@@ -238,11 +238,11 @@ server:
     # Number of seconds after the container has started before probe initiates
     initialDelaySeconds: 60
     # How often (in seconds) to perform the probe
-    periodSeconds: 3
+    periodSeconds: 5
     # Minimum consecutive successes for the probe to be considered successful after having failed
     successThreshold: 1
     # Number of seconds after which the probe times out.
-    timeoutSeconds: 5
+    timeoutSeconds: 3
 
   # Used to set the sleep time during the preStop step
   preStopSleepSeconds: 5


### PR DESCRIPTION
This makes hardcoded probe values configurable with some defaults out of the box so users can configure readiness/liveness probes for their environment.