### PR TITLE
Allow configurable egress for server network policy

### DIFF
--- a/templates/server-network-policy.yaml
+++ b/templates/server-network-policy.yaml
@@ -19,4 +19,8 @@ spec:
         protocol: TCP
       - port: 8201
         protocol: TCP
+  {{- if .Values.server.networkPolicy.egress }}
+  egress:
+    - {}
+  {{ end }}
 {{ end }}

--- a/templates/server-network-policy.yaml
+++ b/templates/server-network-policy.yaml
@@ -21,6 +21,6 @@ spec:
         protocol: TCP
   {{- if .Values.server.networkPolicy.egress }}
   egress:
-    - {}
+  {{- toYaml .Values.server.networkPolicy.egress | nindent 4 }}
   {{ end }}
 {{ end }}

--- a/test/unit/server-network-policy.bats
+++ b/test/unit/server-network-policy.bats
@@ -30,6 +30,6 @@ load _helpers
       --set 'server.networkPolicy.egress[0].ports[0].port=443' \
       --show-only templates/server-network-policy.yaml  \
       . | tee /dev/stderr |
-      yq -r '.spec.egress[0].to[0].ipBlock.cidr=10.0.0.0/24' | tee /dev/stderr)
+      yq -r '.spec.egress[0].to[0].ipBlock.cidr' | tee /dev/stderr)
   [ "${actual}" = "10.0.0.0/24" ]
 }

--- a/test/unit/server-network-policy.bats
+++ b/test/unit/server-network-policy.bats
@@ -25,9 +25,9 @@ load _helpers
   cd `chart_dir`
   local actual=$(helm template \
       --set 'server.networkPolicy.enabled=true' \
-      --set 'global.networkPolicy.egress[0].to[0].ipBlock.cidr=10.0.0.0/24' \
-      --set 'global.networkPolicy.egress[0].ports[0].protocol=TCP' \
-      --set 'global.networkPolicy.egress[0].ports[0].port=443' \
+      --set 'server.networkPolicy.egress[0].to[0].ipBlock.cidr=10.0.0.0/24' \
+      --set 'server.networkPolicy.egress[0].ports[0].protocol=TCP' \
+      --set 'server.networkPolicy.egress[0].ports[0].port=443' \
       --show-only templates/server-network-policy.yaml  \
       . | tee /dev/stderr |
       yq -r '.spec.egress[0].to[0].ipBlock.cidr=10.0.0.0/24' | tee /dev/stderr)

--- a/test/unit/server-network-policy.bats
+++ b/test/unit/server-network-policy.bats
@@ -30,6 +30,6 @@ load _helpers
       --set 'global.networkPolicy.egress[0].ports[0].port=443' \
       --show-only templates/server-network-policy.yaml  \
       . | tee /dev/stderr |
-      yq -r '.spec.egress[0]' | tee /dev/stderr)
-  [ "${actual}" = "{}" ]
+      yq -r '.spec.egress[0].to[0].ipBlock.cidr=10.0.0.0/24' | tee /dev/stderr)
+  [ "${actual}" = "10.0.0.0/24" ]
 }

--- a/test/unit/server-network-policy.bats
+++ b/test/unit/server-network-policy.bats
@@ -25,7 +25,9 @@ load _helpers
   cd `chart_dir`
   local actual=$(helm template \
       --set 'server.networkPolicy.enabled=true' \
-      --set 'server.networkPolicy.egress=true' \
+      --set 'global.networkPolicy.egress[0].to[0].ipBlock.cidr=10.0.0.0/24' \
+      --set 'global.networkPolicy.egress[0].ports[0].protocol=TCP' \
+      --set 'global.networkPolicy.egress[0].ports[0].port=443' \
       --show-only templates/server-network-policy.yaml  \
       . | tee /dev/stderr |
       yq -r '.spec.egress[0]' | tee /dev/stderr)

--- a/test/unit/server-network-policy.bats
+++ b/test/unit/server-network-policy.bats
@@ -20,3 +20,14 @@ load _helpers
       yq 'length > 0' | tee /dev/stderr)
   [ "${actual}" = "true" ]
 }
+
+@test "server/network-policy: egress enabled by server.networkPolicy.egress" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --set 'server.networkPolicy.enabled=true' \
+      --set 'server.networkPolicy.egress=true' \
+      --show-only templates/server-network-policy.yaml  \
+      . | tee /dev/stderr |
+      yq -r '.spec.egress[0]' | tee /dev/stderr)
+  [ "${actual}" = "{}" ]
+}

--- a/values.yaml
+++ b/values.yaml
@@ -321,6 +321,7 @@ server:
   # Enables network policy for server pods
   networkPolicy:
     enabled: false
+    egress: false
 
   # Priority class for server pods
   priorityClassName: ""

--- a/values.yaml
+++ b/values.yaml
@@ -321,7 +321,14 @@ server:
   # Enables network policy for server pods
   networkPolicy:
     enabled: false
-    egress: false
+    egress: []
+    # egress:
+    # - to:
+    #   - ipBlock:
+    #       cidr: 10.0.0.0/24
+    #   ports:
+    #   - protocol: TCP
+    #     port: 443
 
   # Priority class for server pods
   priorityClassName: ""


### PR DESCRIPTION
There are specific cases when the server pod needs to communicate with some external components.
E.g. when using various auth backends:
- kubernetes - server needs to talk with k8s api
- github - server needs to talk with github