### PR TITLE
Enable Vault to review kube tokens when using external Vault

### DIFF
--- a/templates/server-clusterrolebinding.yaml
+++ b/templates/server-clusterrolebinding.yaml
@@ -1,5 +1,4 @@
 {{ template "vault.mode" . }}
-{{- if ne .mode "external" }}
 {{- if and (ne .mode "") (and (eq (.Values.global.enabled | toString) "true") (eq (.Values.server.authDelegator.enabled | toString) "true")) }}
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
@@ -18,5 +17,4 @@ subjects:
 - kind: ServiceAccount
   name: {{ template "vault.serviceAccount.name" . }}
   namespace: {{ .Release.Namespace }}
-{{ end }}
 {{ end }}

--- a/templates/server-serviceaccount.yaml
+++ b/templates/server-serviceaccount.yaml
@@ -1,5 +1,4 @@
 {{ template "vault.mode" . }}
-{{- if ne .mode "external" }}
 {{- if and (ne .mode "") (eq (.Values.global.enabled | toString) "true") }}
 {{- if (eq (.Values.server.serviceAccount.create | toString) "true" ) }}
 apiVersion: v1
@@ -13,6 +12,5 @@ metadata:
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
   {{ template "vault.serviceAccount.annotations" . }}
-{{ end }}
 {{ end }}
 {{ end }}

--- a/test/unit/server-clusterrolebinding.bats
+++ b/test/unit/server-clusterrolebinding.bats
@@ -61,12 +61,12 @@ load _helpers
   [ "${actual}" = "false" ]
 }
 
-@test "server/ClusterRoleBinding: disable with injector.externalVaultAddr" {
+@test "server/ClusterRoleBinding: also deploy with injector.externalVaultAddr" {
   cd `chart_dir`
   local actual=$( (helm template \
       --show-only templates/server-clusterrolebinding.yaml  \
       --set 'injector.externalVaultAddr=http://vault-outside' \
       . || echo "---") | tee /dev/stderr |
       yq 'length > 0' | tee /dev/stderr)
-  [ "${actual}" = "false" ]
+  [ "${actual}" = "true" ]
 }

--- a/values.yaml
+++ b/values.yaml
@@ -70,7 +70,7 @@ injector:
   #      sidecar-injector: enabled
   namespaceSelector: {}
 
-  # Configures failurePolicy of the webhook. By default webhook failures are ignored. 
+  # Configures failurePolicy of the webhook. By default webhook failures are ignored.
   # To block pod creation while webhook is unavailable, set the policy to `Fail` below.
   # See https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/#failure-policy
   #
@@ -229,7 +229,7 @@ server:
     enabled: true
     # If you need to use a http path instead of the default exec
     # path: /v1/sys/health?standbyok=true
-    
+
     # When a probe fails, Kubernetes will try failureThreshold times before giving up
     failureThreshold: 2
     # Number of seconds after the container has started before probe initiates
@@ -429,9 +429,9 @@ server:
     # and store data there. This is only used when using a Replica count of 1, and
     # using a stateful set. This should be HCL.
 
-    # Note: Configuration files are stored in ConfigMaps so sensitive data 
+    # Note: Configuration files are stored in ConfigMaps so sensitive data
     # such as passwords should be either mounted through extraSecretEnvironmentVars
-    # or through a Kube secret.  For more information see: 
+    # or through a Kube secret.  For more information see:
     # https://www.vaultproject.io/docs/platform/k8s/helm/run#protecting-sensitive-vault-configurations
     config: |
       ui = true
@@ -479,10 +479,10 @@ server:
       enabled: false
       # Set the Node Raft ID to the name of the pod
       setNodeId: false
-    
-      # Note: Configuration files are stored in ConfigMaps so sensitive data 
+
+      # Note: Configuration files are stored in ConfigMaps so sensitive data
       # such as passwords should be either mounted through extraSecretEnvironmentVars
-      # or through a Kube secret.  For more information see: 
+      # or through a Kube secret.  For more information see:
       # https://www.vaultproject.io/docs/platform/k8s/helm/run#protecting-sensitive-vault-configurations
       config: |
         ui = true
@@ -498,14 +498,14 @@ server:
         }
 
         service_registration "kubernetes" {}
-   
+
     # config is a raw string of default configuration when using a Stateful
     # deployment. Default is to use a Consul for its HA storage backend.
     # This should be HCL.
-    
-    # Note: Configuration files are stored in ConfigMaps so sensitive data 
+
+    # Note: Configuration files are stored in ConfigMaps so sensitive data
     # such as passwords should be either mounted through extraSecretEnvironmentVars
-    # or through a Kube secret.  For more information see: 
+    # or through a Kube secret.  For more information see:
     # https://www.vaultproject.io/docs/platform/k8s/helm/run#protecting-sensitive-vault-configurations
     config: |
       ui = true
@@ -542,6 +542,8 @@ server:
       maxUnavailable: null
 
   # Definition of the serviceAccount used to run Vault.
+  # These options are also used when using an external Vault server to validate
+  # Kubernetes tokens.
   serviceAccount:
     # Specifies whether a service account should be created
     create: true


### PR DESCRIPTION
We want Vault to perform token reviews with Kubernetes even if we are
using an external Vault.

We need to create the ServiceAccount, Secret and ClusterRoleBinding with
the system:auth-delegator role to enable delegated authentication and
authorization checks [1].

These SA and RBAC objects are created when we deploy the Vault server.
In order to enable the creation of these objects when using an external
Vault, we remove the condition on external mode.

User might want to provide a sensible name (in global.serviceAccount.name) to the service
account such as: vault-auth.

refs #376

[1] https://www.vaultproject.io/docs/auth/kubernetes#configuring-kubernetes