### PR TITLE
Add configurable mountPath for audit/data storage

### DIFF
--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -146,12 +146,12 @@ based on the mode configured.
 {{- define "vault.mounts" -}}
   {{ if eq (.Values.server.auditStorage.enabled | toString) "true" }}
             - name: audit
-              mountPath: /vault/audit
+              mountPath: {{ .Values.server.auditStorage.mountPath }}
   {{ end }}
   {{ if or (eq .mode "standalone") (and (eq .mode "ha") (eq (.Values.server.ha.raft.enabled | toString) "true"))  }}
     {{ if eq (.Values.server.dataStorage.enabled | toString) "true" }}
             - name: data
-              mountPath: /vault/data
+              mountPath: {{ .Values.server.dataStorage.mountPath }}
     {{ end }}
   {{ end }}
   {{ if and (ne .mode "dev") (or (.Values.server.standalone.config)  (.Values.server.ha.config)) }}

--- a/test/unit/server-statefulset.bats
+++ b/test/unit/server-statefulset.bats
@@ -604,6 +604,56 @@ load _helpers
   [ "${actual}" = "0" ]
 }
 
+@test "server/standalone-StatefulSet: default audit storage mount path" {
+  cd `chart_dir`
+  local object=$(helm template \
+      --show-only templates/server-statefulset.yaml  \
+      --set 'server.auditStorage.enabled=true' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.containers[0].volumeMounts[] | select(.name == "audit")' | tee /dev/stderr)
+
+  local actual=$(echo $object | yq -r '.mountPath' | tee /dev/stderr)
+  [ "${actual}" = "/vault/audit" ]
+}
+
+@test "server/standalone-StatefulSet: can configure audit storage mount path" {
+  cd `chart_dir`
+  local object=$(helm template \
+      --show-only templates/server-statefulset.yaml  \
+      --set 'server.auditStorage.enabled=true' \
+      --set 'server.auditStorage.mountPath=/var/log/vault' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.containers[0].volumeMounts[] | select(.name == "audit")' | tee /dev/stderr)
+
+  local actual=$(echo $object | yq -r '.mountPath' | tee /dev/stderr)
+  [ "${actual}" = "/var/log/vault" ]
+}
+
+@test "server/standalone-StatefulSet: default data storage mount path" {
+  cd `chart_dir`
+  local object=$(helm template \
+      --show-only templates/server-statefulset.yaml  \
+      --set 'server.dataStorage.enabled=true' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.containers[0].volumeMounts[] | select(.name == "data")' | tee /dev/stderr)
+
+  local actual=$(echo $object | yq -r '.mountPath' | tee /dev/stderr)
+  [ "${actual}" = "/vault/data" ]
+}
+
+@test "server/standalone-StatefulSet: can configure data storage mount path" {
+  cd `chart_dir`
+  local object=$(helm template \
+      --show-only templates/server-statefulset.yaml  \
+      --set 'server.dataStorage.enabled=true' \
+      --set 'server.dataStorage.mountPath=/opt/vault' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.containers[0].volumeMounts[] | select(.name == "data")' | tee /dev/stderr)
+
+  local actual=$(echo $object | yq -r '.mountPath' | tee /dev/stderr)
+  [ "${actual}" = "/opt/vault" ]
+}
+
 @test "server/standalone-StatefulSet: affinity is set by default" {
   cd `chart_dir`
   local actual=$(helm template \

--- a/values.yaml
+++ b/values.yaml
@@ -369,6 +369,8 @@ server:
     enabled: true
     # Size of the PVC created
     size: 10Gi
+    # Location where the PVC will be mounted.
+    mountPath: "/vault/data"
     # Name of the storage class to use.  If null it will use the
     # configured default Storage Class.
     storageClass: null
@@ -386,6 +388,8 @@ server:
     enabled: false
     # Size of the PVC created
     size: 10Gi
+    # Location where the PVC will be mounted.
+    mountPath: "/vault/audit"
     # Name of the storage class to use.  If null it will use the
     # configured default Storage Class.
     storageClass: null


### PR DESCRIPTION
This PR makes the mountPath for data and audit persistent volumes configurable when users prefer different mounts in the filesystem. The defaults are the same as they've always been but are now configurable via values.