### PR TITLE
add ability to set pod annotations for injector

### DIFF
--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -283,6 +283,21 @@ Sets extra pod annotations
 {{- end -}}
 
 {{/*
+Sets extra injector pod annotations
+*/}}
+{{- define "injector.annotations" -}}
+  {{- if .Values.injector.annotations }}
+      annotations:
+        {{- $tp := typeOf .Values.injector.annotations }}
+        {{- if eq $tp "string" }}
+          {{- tpl .Values.injector.annotations . | nindent 8 }}
+        {{- else }}
+          {{- toYaml .Values.injector.annotations | nindent 8 }}
+        {{- end }}
+  {{- end }}
+{{- end -}}
+
+{{/*
 Sets extra ui service annotations
 */}}
 {{- define "vault.ui.annotations" -}}

--- a/templates/injector-deployment.yaml
+++ b/templates/injector-deployment.yaml
@@ -23,6 +23,7 @@ spec:
         app.kubernetes.io/name: {{ template "vault.name" . }}-agent-injector
         app.kubernetes.io/instance: {{ .Release.Name }}
         component: webhook
+      {{ template "injector.annotations" . }}
     spec:
       {{ template "injector.affinity" . }}
       {{ template "injector.tolerations" . }}

--- a/test/unit/injector-deployment.bats
+++ b/test/unit/injector-deployment.bats
@@ -391,6 +391,38 @@ load _helpers
 }
 
 #--------------------------------------------------------------------
+# extra annotations
+
+@test "injector/deployment: default annotations" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/injector-deployment.yaml \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.metadata.annotations' | tee /dev/stderr)
+  [ "${actual}" = "null" ]
+}
+
+@test "injector/deployment: specify annotations yaml" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/injector-deployment.yaml \
+      --set 'injector.annotations.foo=bar' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.metadata.annotations.foo' | tee /dev/stderr)
+  [ "${actual}" = "bar" ]
+}
+
+@test "injector/deployment: specify annotations yaml string" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/injector-deployment.yaml \
+      --set 'injector.annotations=foo: bar' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.metadata.annotations.foo' | tee /dev/stderr)
+  [ "${actual}" = "bar" ]
+}
+
+#--------------------------------------------------------------------
 # affinity
 
 @test "injector/deployment: affinity not set by default" {

--- a/values.yaml
+++ b/values.yaml
@@ -122,6 +122,11 @@ injector:
   # Priority class for injector pods
   priorityClassName: ""
 
+  # Extra annotations to attach to the injector pods
+  # This can either be YAML or a YAML-formatted multi-line templated string map
+  # of the annotations to apply to the injector pods
+  annotations: {}
+
 server:
   # Resource requests, limits, etc. for the server cluster placement. This
   # should map directly to the value of the resources field for a PodSpec.


### PR DESCRIPTION
this PR adds the ability to add pod annotations to the injector pod.  our use case for this is that we want to install Vault within an Istio enabled namespace and join Vault to the mesh, but we don't want to join the injector pod to the mesh.  so we need to specify pod annotations to exclude it.