### PR TITLE
Allow injection of TLS config for OpenShift routes

### DIFF
--- a/templates/server-route.yaml
+++ b/templates/server-route.yaml
@@ -27,7 +27,7 @@ spec:
   port:
     targetPort: 8200
   tls:
-    termination: passthrough
+    {{- toYaml .Values.server.route.tls | nindent  4 }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/values.yaml
+++ b/values.yaml
@@ -176,12 +176,17 @@ server:
     #      - chart-example.local
 
   # OpenShift only - create a route to expose the service
-  # The created route will be of type passthrough
+  # By default the created route will be of type passthrough
   route:
     enabled: false
     labels: {}
     annotations: {}
     host: chart-example.local
+    # tls will be passed directly to the route's TLS config, which
+    # can be used to configure other termination methods that terminate
+    # TLS at the router
+    tls:
+      termination: passthrough
 
   # authDelegator enables a cluster role binding to be attached to the service
   # account.  This cluster role binding can be used to setup Kubernetes auth


### PR DESCRIPTION
**Purpose of this PR:** On OpenShift it is common to let the cluster-wide router do the TLS termination, either through a wildcard certificate for its standard domain, or a per-route certificate. See https://docs.openshift.com/container-platform/4.5/networking/routes/secured-routes.html. These termination policies "edge" and "reencrypt" support additional configuration parameters on the route, specifically for the per-route certificate. The current chart version in master does not support to set these values or to even change the termination policy.

**Solution:** Add a `tls` block to `server.route` that is injected directly into the route config (`.spec.tls`) and set the default in values.yml to passthrough termination to not change default behavior.

**Alternative:** Include and document any values that are supported by `.spec.tls` in `server.route.tls` instead of injecting the whole YAML block.

**Outlook:** The default standalone config in the chart disables TLS at the vault listener, which is somewhat okay for in-cluster traffic, but a more production-ready default for OpenShift routes would be to assume termination policy "edge" instead of "passthrough", and to not set the route host. Not setting the route host generates a default hostname based on the OpenShift project name. Typical OpenShift clusters have a wildcard certificate set up for these default hostnames.

This would be a breaking change since it would change the chart's default behavior, which is why I left this part out of the PR for now.