### PR TITLE
Allow running pods in the host network

### DIFF
--- a/templates/server-psp.yaml
+++ b/templates/server-psp.yaml
@@ -22,7 +22,14 @@ spec:
     {{- if eq (.Values.server.dataStorage.enabled | toString) "true" }}
     - persistentVolumeClaim
     {{- end }}
+  {{- if .Values.server.hostNetwork }}
+  hostNetwork: {{ .Values.server.hostNetwork }}
+  hostPorts:
+    - min: 8200
+      max: 8202
+  {{- else }}
   hostNetwork: false
+  {{- end }}
   hostIPC: false
   hostPID: false
   runAsUser:

--- a/templates/server-statefulset.yaml
+++ b/templates/server-statefulset.yaml
@@ -41,6 +41,9 @@ spec:
       {{- if .Values.server.priorityClassName }}
       priorityClassName: {{ .Values.server.priorityClassName }}
       {{- end }}
+      {{- if .Values.server.hostNetwork }}
+      hostNetwork: {{ .Values.server.hostNetwork }}
+      {{- end }}
       terminationGracePeriodSeconds: 10
       serviceAccountName: {{ template "vault.serviceAccount.name" . }}
       {{ if  .Values.server.shareProcessNamespace }}

--- a/templates/server-statefulset.yaml
+++ b/templates/server-statefulset.yaml
@@ -105,7 +105,11 @@ spec:
                 fieldRef:
                   fieldPath: metadata.name
             - name: VAULT_CLUSTER_ADDR
+              {{- if .Values.server.ha.clusterAddr }}
+              value: {{ .Values.server.ha.clusterAddr }}
+              {{- else }}
               value: "https://$(HOSTNAME).{{ template "vault.fullname" . }}-internal:8201"
+              {{- end }}
             {{- if and (eq (.Values.server.ha.raft.enabled | toString) "true") (eq (.Values.server.ha.raft.setNodeId | toString) "true") }}
             - name: VAULT_RAFT_NODE_ID
               valueFrom:

--- a/values.yaml
+++ b/values.yaml
@@ -468,6 +468,7 @@ server:
     # See https://www.vaultproject.io/docs/configuration#api_addr
     # If set to null, this will be set to the Pod IP Address
     apiAddr: null
+    clusterAddr: null
 
     # Enables Vault's integrated Raft storage.  Unlike the typical HA modes where
     # Vault's persistence is external (such as Consul), enabling Raft mode will create

--- a/values.yaml
+++ b/values.yaml
@@ -541,6 +541,9 @@ server:
     # replicas. If you'd like a custom value, you can specify an override here.
       maxUnavailable: null
 
+  # hostNetwork defines whether to run the pods in the pod network or in the host network.
+  hostNetwork: false
+
   # Definition of the serviceAccount used to run Vault.
   serviceAccount:
     # Specifies whether a service account should be created


### PR DESCRIPTION
In our setup we have some vault instances running externally and new instances running in K8S using consul storage.
If one of the K8S instances get elected as active, all traffic is forwarded from the external instances to the active instance in K8S, so running it in the host network (where the existing instances are running as well) will make it easily reachable.

I'm not convinced this is the best way to make vault pods visible in the host network, I'm happy to try any other.

If this is a good approach, I will add the unit tests.