### PR TITLE
Update to 0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
-##  0.8.0 (October 20th, 2020)
+
+## 0.8.0 (October 20th, 2020)
 
 Improvements:
 * Make server NetworkPolicy independent of OpenShift [GH-381](https://github.com/hashicorp/vault-helm/pull/381)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## Unreleased
+##  0.8.0 (October 20th, 2020)
 
 Improvements:
 * Make server NetworkPolicy independent of OpenShift [GH-381](https://github.com/hashicorp/vault-helm/pull/381)
@@ -114,7 +115,7 @@ Features:
 
 * Extra containers can now be added to the Vault pods
 * Added configurability of pod probes
-* Added Vault Agent Injector 
+* Added Vault Agent Injector
 
 Improvements:
 
@@ -168,21 +169,21 @@ Features:
 
 * Added `extraSecretEnvironmentVars` to allow users to mount secrets as
   environment variables
-* Added `tlsDisable` configurable to change HTTP protocols from HTTP/HTTPS 
+* Added `tlsDisable` configurable to change HTTP protocols from HTTP/HTTPS
   depending on the value
-* Added `serviceNodePort` to configure a NodePort value when setting `serviceType` 
+* Added `serviceNodePort` to configure a NodePort value when setting `serviceType`
   to "NodePort"
 
 Improvements:
 
 * Changed UI port to 8200 for better HTTP protocol support
-* Added `path` to `extraVolumes` to define where the volume should be 
+* Added `path` to `extraVolumes` to define where the volume should be
   mounted.  Defaults to `/vault/userconfig`
 * Upgraded Vault to 1.2.2
 
 Bugs:
 
-* Fixed bug where upgrade would fail because immutable labels were being 
+* Fixed bug where upgrade would fail because immutable labels were being
   changed (Helm Version label)
 * Fixed bug where UI service used wrong selector after updating helm labels
 * Added `VAULT_API_ADDR` env to Vault pod to fixed bug where Vault thinks

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: vault
-version: 0.7.0
-appVersion: 1.5.2
+version: 0.8.0
+appVersion: 1.5.4
 description: Official HashiCorp Vault Chart
 home: https://www.vaultproject.io
 icon: https://github.com/hashicorp/vault/raw/f22d202cde2018f9455dec755118a9b84586e082/Vault_PrimaryLogo_Black.png

--- a/test/acceptance/server-ha-enterprise-dr.bats
+++ b/test/acceptance/server-ha-enterprise-dr.bats
@@ -7,7 +7,7 @@ load _helpers
 
   helm install "$(name_prefix)-east" \
     --set='server.image.repository=hashicorp/vault-enterprise' \
-    --set='server.image.tag=1.5.2_ent' \
+    --set='server.image.tag=1.5.4_ent' \
     --set='injector.enabled=false' \
     --set='server.ha.enabled=true' \
     --set='server.ha.raft.enabled=true' .
@@ -28,7 +28,7 @@ load _helpers
 
   local primary_token=$(echo ${init} | jq -r '.unseal_keys_b64[0]')
   [ "${primary_token}" != "" ]
-  
+
   local primary_root=$(echo ${init} | jq -r '.root_token')
   [ "${primary_root}" != "" ]
 
@@ -60,7 +60,7 @@ load _helpers
 
   kubectl exec "$(name_prefix)-east-0" -- vault login ${primary_root}
 
-  local raft_status=$(kubectl exec "$(name_prefix)-east-0" -- vault operator raft list-peers -format=json | 
+  local raft_status=$(kubectl exec "$(name_prefix)-east-0" -- vault operator raft list-peers -format=json |
     jq -r '.data.config.servers | length')
   [ "${raft_status}" == "3" ]
 
@@ -76,7 +76,7 @@ load _helpers
   helm install "$(name_prefix)-west" \
     --set='injector.enabled=false' \
     --set='server.image.repository=hashicorp/vault-enterprise' \
-    --set='server.image.tag=1.5.2_ent' \
+    --set='server.image.tag=1.5.4_ent' \
     --set='server.ha.enabled=true' \
     --set='server.ha.raft.enabled=true' .
   wait_for_running "$(name_prefix)-west-0"

--- a/test/acceptance/server-ha-enterprise-perf.bats
+++ b/test/acceptance/server-ha-enterprise-perf.bats
@@ -8,7 +8,7 @@ load _helpers
   helm install "$(name_prefix)-east" \
     --set='injector.enabled=false' \
     --set='server.image.repository=hashicorp/vault-enterprise' \
-    --set='server.image.tag=1.5.2_ent' \
+    --set='server.image.tag=1.5.4_ent' \
     --set='server.ha.enabled=true' \
     --set='server.ha.raft.enabled=true' .
   wait_for_running "$(name_prefix)-east-0"
@@ -28,7 +28,7 @@ load _helpers
 
   local primary_token=$(echo ${init} | jq -r '.unseal_keys_b64[0]')
   [ "${primary_token}" != "" ]
-  
+
   local primary_root=$(echo ${init} | jq -r '.root_token')
   [ "${primary_root}" != "" ]
 
@@ -60,7 +60,7 @@ load _helpers
 
   kubectl exec "$(name_prefix)-east-0" -- vault login ${primary_root}
 
-  local raft_status=$(kubectl exec "$(name_prefix)-east-0" -- vault operator raft list-peers -format=json | 
+  local raft_status=$(kubectl exec "$(name_prefix)-east-0" -- vault operator raft list-peers -format=json |
     jq -r '.data.config.servers | length')
   [ "${raft_status}" == "3" ]
 
@@ -76,7 +76,7 @@ load _helpers
   helm install "$(name_prefix)-west" \
     --set='injector.enabled=false' \
     --set='server.image.repository=hashicorp/vault-enterprise' \
-    --set='server.image.tag=1.5.2_ent' \
+    --set='server.image.tag=1.5.4_ent' \
     --set='server.ha.enabled=true' \
     --set='server.ha.raft.enabled=true' .
   wait_for_running "$(name_prefix)-west-0"

--- a/values.yaml
+++ b/values.yaml
@@ -38,7 +38,7 @@ injector:
   # image sets the repo and tag of the vault-k8s image to use for the injector.
   image:
     repository: "hashicorp/vault-k8s"
-    tag: "0.5.0"
+    tag: "0.6.0"
     pullPolicy: IfNotPresent
 
   # agentImage sets the repo and tag of the Vault image to use for the Vault Agent
@@ -46,7 +46,7 @@ injector:
   # required.
   agentImage:
     repository: "vault"
-    tag: "1.5.2"
+    tag: "1.5.4"
 
   # Mount Path of the Vault Kubernetes Auth Method.
   authPath: "auth/kubernetes"
@@ -140,7 +140,7 @@ server:
 
   image:
     repository: "vault"
-    tag: "1.5.2"
+    tag: "1.5.4"
     # Overrides the default Image Pull Policy
     pullPolicy: IfNotPresent
 


### PR DESCRIPTION
## Improvements
* Make server NetworkPolicy independent of OpenShift [GH-381](https://github.com/hashicorp/vault-helm/pull/381)
* Added configurables for all probe values [GH-387](https://github.com/hashicorp/vault-helm/pull/387)
* MountPath for audit and data storage is now configurable [GH-393](https://github.com/hashicorp/vault-helm/pull/393)
* Annotations can now be added to the Injector pods [GH-394](https://github.com/hashicorp/vault-helm/pull/394)
* The injector can now be configured with a failurePolicy [GH-400](https://github.com/hashicorp/vault-helm/pull/400)
* Added additional environment variables for rendering within Vault config [GH-398](https://github.com/hashicorp/vault-helm/pull/398)
* Service account for Vault K8s auth is automatically created when `injector.externalVaultAddr` is set [GH-392](https://github.com/hashicorp/vault-helm/pull/392)

## Bugs
* Fixed install output using Helm V2 command [GH-378](https://github.com/hashicorp/vault-helm/pull/378)