### PR TITLE
Fix Raft config provided in YAML

### DIFF
--- a/templates/server-config-configmap.yaml
+++ b/templates/server-config-configmap.yaml
@@ -15,7 +15,11 @@ metadata:
 data:
   extraconfig-from-values.hcl: |-
   {{- if or (eq .mode "ha") (eq .mode "standalone") }}
+  {{- if eq (.Values.server.ha.raft.enabled | toString) "true" }}
+  {{- $type := typeOf .Values.server.ha.raft.config }}
+  {{- else }}
   {{- $type := typeOf (index .Values.server .mode).config }}
+  {{- endif }}
   {{- if eq $type "string" }}
     disable_mlock = true
   {{- if eq .mode "standalone" }}


### PR DESCRIPTION
According to the improvement in #213 I attempted to use YAML config in Raft mode. It turns out, that the type check in this situation does not work correctly.

```
  ha:
    enabled: true
    #config: {}  # uncomment as a workaround for this bug to provide the correct type
    raft:
      enabled: true
      config:
        ...(yaml config)...
```

Results in:

```
Error: template: vault/templates/server-config-configmap.yaml:26:18: executing "vault/templates/server-config-configmap.yaml" at <.Values.server.ha.raft.config>: wrong type for value; expected string; got map[string]interface {}
```