### PR TITLE
Update mutating webhook API Version

### DIFF
--- a/templates/injector-mutating-webhook.yaml
+++ b/templates/injector-mutating-webhook.yaml
@@ -13,6 +13,10 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
 webhooks:
   - name: vault.hashicorp.com
+    sideEffects: None
+    admissionReviewVersions:
+    - "v1beta1"
+    - "v1"
     clientConfig:
       service:
         name: {{ template "vault.fullname" . }}-agent-injector-svc

--- a/templates/injector-mutating-webhook.yaml
+++ b/templates/injector-mutating-webhook.yaml
@@ -1,5 +1,5 @@
 {{- if and (eq (.Values.injector.enabled | toString) "true" ) (eq (.Values.global.enabled | toString) "true") }}
-{{- if .Capabilities.APIVersions.Has "admissionregistration.k8s.io/v1" -}}
+{{- if .Capabilities.APIVersions.Has "admissionregistration.k8s.io/v1" }}
 apiVersion: admissionregistration.k8s.io/v1
 {{- else }}
 apiVersion: admissionregistration.k8s.io/v1beta1

--- a/templates/injector-mutating-webhook.yaml
+++ b/templates/injector-mutating-webhook.yaml
@@ -1,5 +1,9 @@
 {{- if and (eq (.Values.injector.enabled | toString) "true" ) (eq (.Values.global.enabled | toString) "true") }}
+{{- if .Capabilities.APIVersions.Has "admissionregistration.k8s.io/v1" -}}
+apiVersion: admissionregistration.k8s.io/v1
+{{- else }}
 apiVersion: admissionregistration.k8s.io/v1beta1
+{{- end }}
 kind: MutatingWebhookConfiguration
 metadata:
   name: {{ template "vault.fullname" . }}-agent-injector-cfg

--- a/test/unit/injector-mutating-webhook.bats
+++ b/test/unit/injector-mutating-webhook.bats
@@ -76,7 +76,7 @@ load _helpers
   [ "${actual}" = "true" ]
 }
 
-@test "injector/MutatingWebhookConfiguration: failurePolicy empty by default" {
+@test "injector/MutatingWebhookConfiguration: failurePolicy 'Ignore' by default" {
   cd `chart_dir`
   local actual=$(helm template \
       --show-only templates/injector-mutating-webhook.yaml  \
@@ -84,7 +84,7 @@ load _helpers
       --namespace foo \
       . | tee /dev/stderr |
       yq '.webhooks[0].failurePolicy' | tee /dev/stderr)
-  [ "${actual}" = "null" ]
+  [ "${actual}" = "\"Ignore\"" ]
 }
 
 @test "injector/MutatingWebhookConfiguration: can set failurePolicy" {
@@ -97,4 +97,15 @@ load _helpers
       yq '.webhooks[0].failurePolicy' | tee /dev/stderr)
 
   [ "${actual}" = "\"Fail\"" ]
+}
+
+@test "injector/MutatingWebhookConfiguration: sets v1 APIVersion when supported" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/injector-mutating-webhook.yaml  \
+      --set 'injector.enabled=true' \
+      --namespace foo \
+      . | tee /dev/stderr |
+      yq '.webhooks[0].failurePolicy' | tee /dev/stderr)
+  [ "${actual}" = "\"Ignore\"" ]
 }

--- a/test/unit/injector-mutating-webhook.bats
+++ b/test/unit/injector-mutating-webhook.bats
@@ -98,14 +98,3 @@ load _helpers
 
   [ "${actual}" = "\"Fail\"" ]
 }
-
-@test "injector/MutatingWebhookConfiguration: sets v1 APIVersion when supported" {
-  cd `chart_dir`
-  local actual=$(helm template \
-      --show-only templates/injector-mutating-webhook.yaml  \
-      --set 'injector.enabled=true' \
-      --namespace foo \
-      . | tee /dev/stderr |
-      yq '.webhooks[0].failurePolicy' | tee /dev/stderr)
-  [ "${actual}" = "\"Ignore\"" ]
-}

--- a/values.yaml
+++ b/values.yaml
@@ -70,11 +70,12 @@ injector:
   #      sidecar-injector: enabled
   namespaceSelector: {}
 
-  # Configures failurePolicy of the webhook. By default webhook failures are ignored.
+  # Configures failurePolicy of the webhook. The "unspecified" default behaviour deoends on the
+  # API Version of the WebHook.
   # To block pod creation while webhook is unavailable, set the policy to `Fail` below.
   # See https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/#failure-policy
   #
-  # failurePolcy: Fail
+  failurePolicy: Ignore
 
   certs:
     # secretName is the name of the secret that has the TLS certificate and


### PR DESCRIPTION
`admissionregistration.k8s.io/v1beta1` is [deprecated](https://v1-16.docs.kubernetes.io/docs/setup/release/notes/#deprecations-and-removals) since 1.16 and will be removed in 1.19.

This PR will set the right API Version if it is supported.

**However**, there is a change in behaviour from `v1beta1` to `v1`. Specifically, the default (unspecified) [`failurePolicy`](https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/#failure-policy) changes from `Ignore` to `Fail`. Should we set the default in `values.yaml` to `Ignore` to preserve the previous behaviour? Or this can be labelled a breaking change?