### PR TITLE
Use docker mirror

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,14 +6,14 @@ jobs:
   bats-unit-test:
     docker:
       # This image is built from test/docker/Test.dockerfile
-      - image: hashicorpdev/vault-helm-test:0.1.0
+      - image: docker.mirror.hashicorp.services/hashicorpdev/vault-helm-test:0.1.0
     steps:
       - checkout
       - run: bats ./test/unit -t
   acceptance:
     docker:
       # This image is build from test/docker/Test.dockerfile
-      - image: hashicorpdev/vault-helm-test:0.1.0
+      - image: docker.mirror.hashicorp.services/hashicorpdev/vault-helm-test:0.1.0
 
     steps:
       - checkout
@@ -35,7 +35,7 @@ jobs:
           when: always
   update-helm-charts-index:
     docker:
-      - image: circleci/golang:latest
+      - image: docker.mirror.hashicorp.services/circleci/golang:1.15.3
     steps:
       - checkout
       - run:

--- a/test/docker/Test.dockerfile
+++ b/test/docker/Test.dockerfile
@@ -6,7 +6,7 @@
 # a script to configure kubectl, potentially install Helm, and run the tests
 # manually. This image only has the dependencies pre-installed.
 
-FROM alpine:latest
+FROM docker.mirror.hashicorp.services/alpine:latest
 WORKDIR /root
 
 ENV BATS_VERSION "1.1.0"


### PR DESCRIPTION
Instead of using dockerhub (which will enforce rate limiting on anonymous image pulls starting Nov 1st), we're moving projects to our mirror at `docker.mirror.hashicorp.services`. LMK if you have any q's, otherwise feel free to approve and merge on your own! 