### PR TITLE
fix: variable declaration serviceName

### DIFF
--- a/templates/server-route.yaml
+++ b/templates/server-route.yaml
@@ -3,7 +3,7 @@
 {{- if .Values.server.route.enabled -}}
 {{- $serviceName := include "vault.fullname" . -}}
 {{- if eq .mode "ha" }}
-{{- $serviceName = printf "%s-%s" $serviceName "active" -}}
+{{- $serviceName := printf "%s-%s" $serviceName "active" -}}
 {{- end }}
 kind: Route
 apiVersion: route.openshift.io/v1


### PR DESCRIPTION
# Probleam

Error parse template install Vault:

Wait helm template failed. Error: parse error in "vault/templates/server-route.yaml": template: vault/templates/server-route.yaml:6: unexpected "=" in operand : exit status 1

# Solution

Fix service name variable

```yaml
{{- $serviceName := printf "%s-%s" $serviceName "active" -}}]
```