### PR TITLE
Add ability to provide extra Ingress backends (refs #361).

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: vault
-version: 0.8.1
+version: 0.8.0
 appVersion: 1.5.4
 description: Official HashiCorp Vault Chart
 home: https://www.vaultproject.io

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: vault
-version: 0.8.0
+version: 0.8.1
 appVersion: 1.5.4
 description: Official HashiCorp Vault Chart
 home: https://www.vaultproject.io

--- a/templates/server-ingress.yaml
+++ b/templates/server-ingress.yaml
@@ -41,6 +41,12 @@ spec:
     - host: {{ .host | quote }}
       http:
         paths:
+        {{- range .extraBackends }}
+          - path: {{ .path }}
+            backend:
+              serviceName: {{ .serviceName }}
+              servicePort: {{ .servicePort }}
+        {{- end }}
         {{- range (.paths | default (list "/")) }}
           - path: {{ . }}
             backend:

--- a/values.yaml
+++ b/values.yaml
@@ -175,6 +175,14 @@ server:
     hosts:
       - host: chart-example.local
         paths: []
+        # Allow adding extra backend sections. This allows us to make use of
+        # the annotations required to do https redirection using AWS
+        # Application Load Balancers.
+        # See <https://github.com/hashicorp/vault-helm/issues/361>.
+        # extraBackends:
+        #   - path: /*
+        #     serviceName: ssl-redirect
+        #     servicePort: use-annotation
 
     tls: []
     #  - secretName: chart-example-tls


### PR DESCRIPTION
A workaround to provide the ability to add extra backends, as required to get SSL redirection to work properly when using this chart with an AWS Application Load Balancer.