### PR TITLE
don't set VAULT_DEV_ROOT_TOKEN_ID by default in dev mode

### DIFF
--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -140,7 +140,7 @@ Set's additional environment variables based on the mode.
 {{- define "vault.envs" -}}
   {{ if eq .mode "dev" }}
             - name: VAULT_DEV_ROOT_TOKEN_ID
-              value: {{ .Values.server.dev.devRootToken | default "root" }}
+              value: {{ .Values.server.dev.devRootToken }}
   {{ end }}
 {{- end -}}
 

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -135,6 +135,14 @@ for users looking to use this chart with Consul Helm.
 {{- end -}}
 
 {{/*
+Set's additional environment variables based on the mode.
+*/}}
+{{- define "vault.envs" -}}
+  {{ if eq .mode "dev" }}
+            - name: VAULT_DEV_ROOT_TOKEN_ID
+              value: {{ .Values.server.dev.devRootToken | default "root" }}
+  {{ end }}
+{{- end -}}
 
 {{/*
 Set's which additional volumes should be mounted to the container

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -135,14 +135,6 @@ for users looking to use this chart with Consul Helm.
 {{- end -}}
 
 {{/*
-Set's additional environment variables based on the mode.
-*/}}
-{{- define "vault.envs" -}}
-  {{ if eq .mode "dev" }}
-            - name: VAULT_DEV_ROOT_TOKEN_ID
-              value: "root"
-  {{ end }}
-{{- end -}}
 
 {{/*
 Set's which additional volumes should be mounted to the container

--- a/templates/server-statefulset.yaml
+++ b/templates/server-statefulset.yaml
@@ -111,6 +111,7 @@ spec:
             {{- end }}
             - name: HOME
               value: "/home/vault"
+            {{ template "vault.envs" . }}
             {{- include "vault.extraEnvironmentVars" .Values.server | nindent 12 }}
             {{- include "vault.extraSecretEnvironmentVars" .Values.server | nindent 12 }}
           volumeMounts:

--- a/templates/server-statefulset.yaml
+++ b/templates/server-statefulset.yaml
@@ -111,7 +111,6 @@ spec:
             {{- end }}
             - name: HOME
               value: "/home/vault"
-            {{ template "vault.envs" . }}
             {{- include "vault.extraEnvironmentVars" .Values.server | nindent 12 }}
             {{- include "vault.extraSecretEnvironmentVars" .Values.server | nindent 12 }}
           volumeMounts:

--- a/test/unit/server-dev-statefulset.bats
+++ b/test/unit/server-dev-statefulset.bats
@@ -236,6 +236,44 @@ load _helpers
 }
 
 #--------------------------------------------------------------------
+# devRootToken
+
+@test "server/dev-StatefulSet: set default devRootToken" {
+  cd `chart_dir`
+  local object=$(helm template \
+      --show-only templates/server-statefulset.yaml  \
+      --set 'server.dev.enabled=true' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.containers[0].env' | tee /dev/stderr)
+
+  local actual=$(echo $object |
+      yq -r '.[11].name' | tee /dev/stderr)
+  [ "${actual}" = "VAULT_DEV_ROOT_TOKEN_ID" ]
+
+  local actual=$(echo $object |
+      yq -r '.[11].value' | tee /dev/stderr)
+  [ "${actual}" = "root" ]
+}
+
+@test "server/dev-StatefulSet: set custom devRootToken" {
+  cd `chart_dir`
+  local object=$(helm template \
+      --show-only templates/server-statefulset.yaml  \
+      --set 'server.dev.enabled=true' \
+      --set 'server.dev.devRootToken=customtoken' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.containers[0].env' | tee /dev/stderr)
+
+  local actual=$(echo $object |
+      yq -r '.[11].name' | tee /dev/stderr)
+  [ "${actual}" = "VAULT_DEV_ROOT_TOKEN_ID" ]
+
+  local actual=$(echo $object |
+      yq -r '.[11].value' | tee /dev/stderr)
+  [ "${actual}" = "customtoken" ]
+}
+
+#--------------------------------------------------------------------
 # extraEnvironmentVars
 
 @test "server/dev-StatefulSet: set extraEnvironmentVars" {

--- a/test/unit/server-dev-statefulset.bats
+++ b/test/unit/server-dev-statefulset.bats
@@ -249,19 +249,19 @@ load _helpers
       yq -r '.spec.template.spec.containers[0].env' | tee /dev/stderr)
 
   local actual=$(echo $object |
-    yq -r '.[12].name' | tee /dev/stderr)
+r   yq -r '.[11].name' | tee /dev/stderr)
   [ "${actual}" = "FOO" ]
 
   local actual=$(echo $object |
-      yq -r '.[12].value' | tee /dev/stderr)
+      yq -r '.[11].value' | tee /dev/stderr)
   [ "${actual}" = "bar" ]
 
   local actual=$(echo $object |
-      yq -r '.[13].name' | tee /dev/stderr)
+      yq -r '.[12].name' | tee /dev/stderr)
   [ "${actual}" = "FOOBAR" ]
 
   local actual=$(echo $object |
-      yq -r '.[13].value' | tee /dev/stderr)
+      yq -r '.[12].value' | tee /dev/stderr)
   [ "${actual}" = "foobar" ]
 }
 

--- a/test/unit/server-dev-statefulset.bats
+++ b/test/unit/server-dev-statefulset.bats
@@ -249,19 +249,19 @@ load _helpers
       yq -r '.spec.template.spec.containers[0].env' | tee /dev/stderr)
 
   local actual=$(echo $object |
-      yq -r '.[11].name' | tee /dev/stderr)
+      yq -r '.[12].name' | tee /dev/stderr)
   [ "${actual}" = "FOO" ]
 
   local actual=$(echo $object |
-      yq -r '.[11].value' | tee /dev/stderr)
+      yq -r '.[12].value' | tee /dev/stderr)
   [ "${actual}" = "bar" ]
 
   local actual=$(echo $object |
-      yq -r '.[12].name' | tee /dev/stderr)
+      yq -r '.[13].name' | tee /dev/stderr)
   [ "${actual}" = "FOOBAR" ]
 
   local actual=$(echo $object |
-      yq -r '.[12].value' | tee /dev/stderr)
+      yq -r '.[13].value' | tee /dev/stderr)
   [ "${actual}" = "foobar" ]
 }
 

--- a/test/unit/server-dev-statefulset.bats
+++ b/test/unit/server-dev-statefulset.bats
@@ -249,7 +249,7 @@ load _helpers
       yq -r '.spec.template.spec.containers[0].env' | tee /dev/stderr)
 
   local actual=$(echo $object |
-r   yq -r '.[11].name' | tee /dev/stderr)
+      yq -r '.[11].name' | tee /dev/stderr)
   [ "${actual}" = "FOO" ]
 
   local actual=$(echo $object |

--- a/values.yaml
+++ b/values.yaml
@@ -417,7 +417,7 @@ server:
   dev:
     enabled: false
 
-    # Overrides dev root token value which by default is set to "root"
+    # Set VAULT_DEV_ROOT_TOKEN_ID value
     devRootToken: "root"
 
   # Run Vault in "standalone" mode. This is the default mode that will deploy if

--- a/values.yaml
+++ b/values.yaml
@@ -418,7 +418,7 @@ server:
     enabled: false
 
     # Overrides dev root token value which by default is set to "root"
-    #devRootToken: "root"
+    devRootToken: "root"
 
   # Run Vault in "standalone" mode. This is the default mode that will deploy if
   # no arguments are given to helm. This requires a PVC for data storage to use

--- a/values.yaml
+++ b/values.yaml
@@ -417,7 +417,7 @@ server:
   dev:
     enabled: false
 
-    # Overrides default root token which is by default set to "root"
+    # Overrides dev root token value which by default is set to "root"
     #devRootToken: "root"
 
   # Run Vault in "standalone" mode. This is the default mode that will deploy if

--- a/values.yaml
+++ b/values.yaml
@@ -417,6 +417,9 @@ server:
   dev:
     enabled: false
 
+    # Overrides default root token which is by default set to "root"
+    #devRootToken: "root"
+
   # Run Vault in "standalone" mode. This is the default mode that will deploy if
   # no arguments are given to helm. This requires a PVC for data storage to use
   # the "file" backend.  This mode is not highly available and should not be scaled


### PR DESCRIPTION
Do not set VAULT_DEV_ROOT_TOKEN_ID environment variable by default when running in dev mode as it can already be set using `extraSecretEnvironmentVars` or `extraEnvironmentVars`. 
At the moment it is impossible to set VAULT_DEV_ROOT_TOKEN_ID to a custome value as variable will be duplicated in a resulting yaml file.
