### PR TITLE
Add extraArgs support to dev mode

### DIFF
--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -104,18 +104,6 @@ extra volumes the user may have specified (such as a secret with TLS).
 {{- end -}}
 
 {{/*
-Set's a command to override the entrypoint defined in the image
-so we can make the user experience nicer.  This works in with
-"vault.args" to specify what commands /bin/sh should run.
-*/}}
-{{- define "vault.command" -}}
-  {{ if or (eq .mode "standalone") (eq .mode "ha") }}
-          - "/bin/sh"
-          - "-ec"
-  {{ end }}
-{{- end -}}
-
-{{/*
 Set's the args for custom command to render the Vault configuration
 file with IP addresses to make the out of box experience easier
 for users looking to use this chart with Consul Helm.
@@ -131,6 +119,9 @@ for users looking to use this chart with Consul Helm.
             [ -n "${TRANSIT_ADDR}" ] && sed -Ei "s|TRANSIT_ADDR|${TRANSIT_ADDR?}|g" /tmp/storageconfig.hcl;
             [ -n "${RAFT_ADDR}" ] && sed -Ei "s|RAFT_ADDR|${RAFT_ADDR?}|g" /tmp/storageconfig.hcl;
             /usr/local/bin/docker-entrypoint.sh vault server -config=/tmp/storageconfig.hcl {{ .Values.server.extraArgs }}
+   {{ else if eq .mode "dev" }}
+          - |
+            /usr/local/bin/docker-entrypoint.sh vault server -dev {{ .Values.server.extraArgs }}
   {{ end }}
 {{- end -}}
 

--- a/templates/server-statefulset.yaml
+++ b/templates/server-statefulset.yaml
@@ -66,7 +66,9 @@ spec:
           {{ template "vault.resources" . }}
           image: {{ .Values.server.image.repository }}:{{ .Values.server.image.tag | default "latest" }}
           imagePullPolicy: {{ .Values.server.image.pullPolicy }}
-          command: {{ template "vault.command" . }}
+          command:
+          - "/bin/sh"
+          - "-ec"
           args: {{ template "vault.args" . }}
           env:
             - name: HOST_IP

--- a/test/unit/server-dev-statefulset.bats
+++ b/test/unit/server-dev-statefulset.bats
@@ -403,3 +403,14 @@ load _helpers
       yq -r '.spec.template.spec.securityContext.fsGroup' | tee /dev/stderr)
   [ "${actual}" = "2000" ]
 }
+
+@test "server/dev-StatefulSet: add extraArgs" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/server-statefulset.yaml \
+      --set 'server.dev.enabled=true' \
+      --set 'server.extraArgs=foobar' \
+      . | tee /dev/stderr |
+       yq -r '.spec.template.spec.containers[0].args[0]' | tee /dev/stderr)
+  [[ "${actual}" = *"foobar"* ]]
+}


### PR DESCRIPTION
There are some use cases for `dev` mode where extra flags may be desired, such as the `-dev-kv-v1` flag. This lifts restrictions on commands/args for dev mode.

I removed `vault.command` helper function all together because it was no longer needed since it's always true.

Closes #417.