### PR TITLE
Add allowPrivilegeEscalation=false to pods

### DIFF
--- a/templates/injector-deployment.yaml
+++ b/templates/injector-deployment.yaml
@@ -46,8 +46,10 @@ spec:
           {{ template "injector.resources" . }}
           image: "{{ .Values.injector.image.repository }}:{{ .Values.injector.image.tag }}"
           imagePullPolicy: "{{ .Values.injector.image.pullPolicy }}"
+          {{- if not .Values.global.openshift }}
           securityContext:
             allowPrivilegeEscalation: false
+          {{- end }}
           env:
             - name: AGENT_INJECT_LISTEN
               value: ":8080"

--- a/templates/injector-deployment.yaml
+++ b/templates/injector-deployment.yaml
@@ -46,6 +46,8 @@ spec:
           {{ template "injector.resources" . }}
           image: "{{ .Values.injector.image.repository }}:{{ .Values.injector.image.tag }}"
           imagePullPolicy: "{{ .Values.injector.image.pullPolicy }}"
+          securityContext:
+            allowPrivilegeEscalation: false
           env:
             - name: AGENT_INJECT_LISTEN
               value: ":8080"

--- a/templates/server-statefulset.yaml
+++ b/templates/server-statefulset.yaml
@@ -70,6 +70,8 @@ spec:
           - "/bin/sh"
           - "-ec"
           args: {{ template "vault.args" . }}
+          securityContext:
+            allowPrivilegeEscalation: false
           env:
             - name: HOST_IP
               valueFrom:

--- a/templates/server-statefulset.yaml
+++ b/templates/server-statefulset.yaml
@@ -70,8 +70,10 @@ spec:
           - "/bin/sh"
           - "-ec"
           args: {{ template "vault.args" . }}
+          {{- if not .Values.global.openshift }}
           securityContext:
             allowPrivilegeEscalation: false
+          {{- end }}
           env:
             - name: HOST_IP
               valueFrom:


### PR DESCRIPTION
This adds `allowPrivilegeEscalation: false` to the Vault and Injector containers. I don't believe there's a need to make this configurable, so making this static. I'd like to test this on OpenShift before merging just to be sure, though.