### PR TITLE
Add optional LoadBalancer service for HA mode

### DIFF
--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -394,6 +394,20 @@ Sets extra vault server Service annotations
 {{- end -}}
 
 {{/*
+Sets extra vault server LoadBalancer annotations
+*/}}
+{{- define "vault.lb.annotations" -}}
+  {{- if .Values.server.ha.lb.annotations }}
+    {{- $tp := typeOf .Values.server.ha.lb.annotations }}
+    {{- if eq $tp "string" }}
+      {{- tpl .Values.server.ha.lb.annotations . | nindent 4 }}
+    {{- else }}
+      {{- toYaml .Values.server.ha.lb.annotations | nindent 4 }}
+    {{- end }}
+  {{- end }}
+{{- end -}}
+
+{{/*
 Sets PodSecurityPolicy annotations
 */}}
 {{- define "vault.psp.annotations" -}}

--- a/templates/server-ha-active-service.yaml
+++ b/templates/server-ha-active-service.yaml
@@ -1,4 +1,5 @@
 {{ template "vault.mode" . }}
+{{- if ne .mode "external" }}
 {{- if and (eq .mode "ha" ) (eq (.Values.server.service.enabled | toString) "true" ) (eq (.Values.global.enabled | toString) "true") }}
 # Service for active Vault pod
 apiVersion: v1
@@ -36,4 +37,5 @@ spec:
     app.kubernetes.io/instance: {{ .Release.Name }}
     component: server
     vault-active: "true"
+{{- end }}
 {{- end }}

--- a/templates/server-ha-active-service.yaml
+++ b/templates/server-ha-active-service.yaml
@@ -1,6 +1,5 @@
 {{ template "vault.mode" . }}
-{{- if ne .mode "external" }}
-{{- if and (eq .mode "ha" ) (and (eq (.Values.server.service.enabled | toString) "true" ) (eq (.Values.global.enabled | toString) "true")) }}
+{{- if and (eq .mode "ha" ) (eq (.Values.server.service.enabled | toString) "true" ) (eq (.Values.global.enabled | toString) "true") }}
 # Service for active Vault pod
 apiVersion: v1
 kind: Service
@@ -37,5 +36,4 @@ spec:
     app.kubernetes.io/instance: {{ .Release.Name }}
     component: server
     vault-active: "true"
-{{- end }}
 {{- end }}

--- a/templates/server-ha-lb.yaml
+++ b/templates/server-ha-lb.yaml
@@ -1,10 +1,10 @@
 {{ template "vault.mode" . }}
-{{- if and (eq .mode "ha" ) (eq (.Values.server.service.enabled | toString) "true" ) (eq (.Values.global.enabled | toString) "true") }}
-# Service for standby Vault pod
+{{- if and (eq .mode "ha" ) (eq (.Values.server.service.enabled | toString) "true" ) (eq (.Values.global.enabled | toString) "true") (eq (.Values.server.ha.lb.enabled | toString) "true") }}
+# LoadBalancer for active Vault pod
 apiVersion: v1
-kind: Service
+kind: LoadBalancer
 metadata:
-  name: {{ template "vault.fullname" . }}-standby
+  name: {{ template "vault.fullname" . }}-lb
   namespace: {{ .Release.Namespace }}
   labels:
     helm.sh/chart: {{ include "vault.chart" . }}
@@ -19,6 +19,11 @@ spec:
   {{- end}}
   {{- if .Values.server.service.clusterIP }}
   clusterIP: {{ .Values.server.service.clusterIP }}
+  {{- end }}
+  {{- if .Values.server.ha.local }}
+  externalTrafficPolicy: Local
+  {{- else }}
+  externalTrafficPolicy: Cluster
   {{- end }}
   publishNotReadyAddresses: true
   ports:
@@ -35,5 +40,5 @@ spec:
     app.kubernetes.io/name: {{ include "vault.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     component: server
-    vault-active: "false"
+    vault-active: "true"
 {{- end }}

--- a/templates/server-ha-lb.yaml
+++ b/templates/server-ha-lb.yaml
@@ -12,20 +12,11 @@ metadata:
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
   annotations:
-{{ template "vault.service.annotations" .}}
+{{ template "vault.lb.annotations" .}}
 spec:
-  {{- if .Values.server.service.type}}
-  type: {{ .Values.server.service.type }}
-  {{- end}}
-  {{- if .Values.server.service.clusterIP }}
-  clusterIP: {{ .Values.server.service.clusterIP }}
-  {{- end }}
-  {{- if .Values.server.ha.local }}
-  externalTrafficPolicy: Local
-  {{- else }}
-  externalTrafficPolicy: Cluster
-  {{- end }}
-  publishNotReadyAddresses: true
+  type: LoadBalancer
+  externalTrafficPolicy: {{ .Values.server.ha.lb.externalTrafficPolicy }}
+  publishNotReadyAddresses: {{ .Values.server.ha.lb.publishNotReadyAddresses }}
   ports:
     - name: {{ include "vault.scheme" . }}
       port: {{ .Values.server.service.port }}

--- a/templates/server-ha-standby-service.yaml
+++ b/templates/server-ha-standby-service.yaml
@@ -1,4 +1,5 @@
 {{ template "vault.mode" . }}
+{{- if ne .mode "external" }}
 {{- if and (eq .mode "ha" ) (eq (.Values.server.service.enabled | toString) "true" ) (eq (.Values.global.enabled | toString) "true") }}
 # Service for standby Vault pod
 apiVersion: v1
@@ -36,4 +37,5 @@ spec:
     app.kubernetes.io/instance: {{ .Release.Name }}
     component: server
     vault-active: "false"
+{{- end }}
 {{- end }}

--- a/test/unit/server-ha-lb.bats
+++ b/test/unit/server-ha-lb.bats
@@ -1,0 +1,203 @@
+#!/usr/bin/env bats
+
+load _helpers
+
+@test "server/ha-lb-Service: generic annotations" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/server-ha-lb.yaml \
+      --set 'server.ha.enabled=true' \
+      --set 'server.ha.lb.enabled=true' \
+      --set 'server.ha.lb.annotations=vaultIsAwesome: true' \
+      . | tee /dev/stderr |
+      yq -r '.metadata.annotations["vaultIsAwesome"]' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}
+
+@test "server/ha-lb-Service: disable with ha.enabled false" {
+  cd `chart_dir`
+  local actual=$( (helm template \
+      --show-only templates/server-ha-lb.yaml  \
+      --set 'server.ha.enabled=false' \
+      --set 'server.ha.lb.enabled=true' \
+      . || echo "---") | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+}
+
+@test "server/ha-lb-Service: disable with ha.lb.enabled false" {
+  cd `chart_dir`
+  local actual=$( (helm template \
+      --show-only templates/server-ha-lb.yaml  \
+      --set 'server.ha.enabled=true' \
+      --set 'server.ha.lb.enabled=false' \
+      . || echo "---") | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+}
+
+@test "server/ha-lb-Service: disable with server.service.enabled false" {
+  cd `chart_dir`
+  local actual=$( (helm template \
+      --show-only templates/server-ha-lb.yaml  \
+      --set 'server.ha.enabled=true' \
+      --set 'server.ha.lb.enabled=true' \
+      --set 'server.service.enabled=false' \
+      . || echo "---") | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+}
+
+@test "server/ha-lb-Service: type LoadBalancer" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/server-ha-lb.yaml \
+      --set 'server.ha.enabled=true' \
+      --set 'server.ha.lb.enabled=true' \
+      . | tee /dev/stderr |
+      yq -r '.spec.type' | tee /dev/stderr)
+  [ "${actual}" = "LoadBalancer" ]
+}
+
+@test "server/ha-lb-Service: clusterIP empty by default" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/server-ha-lb.yaml \
+      --set 'server.ha.enabled=true' \
+      --set 'server.ha.lb.enabled=true' \
+      . | tee /dev/stderr |
+      yq -r '.spec.clusterIP' | tee /dev/stderr)
+  [ "${actual}" = "null" ]
+}
+
+@test "server/ha-lb-Service: externalTrafficPolicy Local and publishNotReadyAddresses false as defaults" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/server-ha-lb.yaml \
+      --set 'server.ha.enabled=true' \
+      --set 'server.ha.lb.enabled=true' \
+      . | tee /dev/stderr |
+      yq -r '.spec.externalTrafficPolicy' | tee /dev/stderr)
+  [ "${actual}" = "Local" ]
+
+  local actual=$(helm template \
+      --show-only templates/server-ha-lb.yaml \
+      --set 'server.ha.enabled=true' \
+      --set 'server.ha.lb.enabled=true' \
+      . | tee /dev/stderr |
+      yq -r '.spec.publishNotReadyAddresses' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+}
+
+@test "server/ha-lb-Service: externalTrafficPolicy can be set" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/server-ha-lb.yaml \
+      --set 'server.ha.enabled=true' \
+      --set 'server.ha.lb.enabled=true' \
+      --set 'server.ha.lb.externalTrafficPolicy=Cluster' \
+      . | tee /dev/stderr |
+      yq -r '.spec.externalTrafficPolicy' | tee /dev/stderr)
+  [ "${actual}" = "Cluster" ]
+}
+
+@test "server/ha-lb-Service: publishNotReadyAddresses can be set" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/server-ha-lb.yaml \
+      --set 'server.ha.enabled=true' \
+      --set 'server.ha.lb.enabled=true' \
+      --set 'server.ha.lb.publishNotReadyAddresses=true' \
+      . | tee /dev/stderr |
+      yq -r '.spec.publishNotReadyAddresses' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}
+
+@test "server/ha-lb-Service: port and targetPort will be 8200 by default" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/server-ha-lb.yaml \
+      --set 'server.ha.enabled=true' \
+      --set 'server.ha.lb.enabled=true' \
+      . | tee /dev/stderr |
+      yq -r '.spec.ports[0].port' | tee /dev/stderr)
+  [ "${actual}" = "8200" ]
+
+  local actual=$(helm template \
+      --show-only templates/server-ha-lb.yaml \
+      --set 'server.ha.enabled=true' \
+      --set 'server.ha.lb.enabled=true' \
+      . | tee /dev/stderr |
+      yq -r '.spec.ports[0].targetPort' | tee /dev/stderr)
+  [ "${actual}" = "8200" ]
+}
+
+@test "server/ha-lb-Service: port and targetPort can be set" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/server-ha-lb.yaml \
+      --set 'server.ha.enabled=true' \
+      --set 'server.ha.lb.enabled=true' \
+      --set 'server.service.port=8000' \
+      . | tee /dev/stderr |
+      yq -r '.spec.ports[0].port' | tee /dev/stderr)
+  [ "${actual}" = "8000" ]
+
+  local actual=$(helm template \
+      --show-only templates/server-ha-lb.yaml \
+      --set 'server.ha.enabled=true' \
+      --set 'server.ha.lb.enabled=true' \
+      --set 'server.service.targetPort=80' \
+      . | tee /dev/stderr |
+      yq -r '.spec.ports[0].targetPort' | tee /dev/stderr)
+  [ "${actual}" = "80" ]
+}
+
+@test "server/ha-lb-Service: nodeport can be set" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/server-ha-lb.yaml \
+      --set 'server.ha.enabled=true' \
+      --set 'server.ha.lb.enabled=true' \
+      --set 'server.service.type=NodePort' \
+      --set 'server.service.nodePort=30009' \
+      . | tee /dev/stderr |
+      yq -r '.spec.ports[0].nodePort' | tee /dev/stderr)
+  [ "${actual}" = "30009" ]
+}
+
+@test "server/ha-lb-Service: nodeport can't set when type isn't NodePort" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/server-ha-lb.yaml \
+      --set 'server.ha.enabled=true' \
+      --set 'server.ha.lb.enabled=true' \
+      --set 'server.service.nodePort=30009' \
+      . | tee /dev/stderr |
+      yq -r '.spec.ports[0].nodePort' | tee /dev/stderr)
+  [ "${actual}" = "null" ]
+}
+
+@test "server/ha-lb-Service: vault port name is http, when tlsDisable is true" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/server-ha-lb.yaml \
+      --set 'server.ha.enabled=true' \
+      --set 'server.ha.lb.enabled=true' \
+      --set 'global.tlsDisable=true' \
+      . | tee /dev/stderr |
+      yq -r '.spec.ports | map(select(.port==8200)) | .[] .name' | tee /dev/stderr)
+  [ "${actual}" = "http" ]
+}
+
+@test "server/ha-lb-Service: vault port name is https, when tlsDisable is false" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/server-ha-lb.yaml \
+      --set 'server.ha.enabled=true' \
+      --set 'server.ha.lb.enabled=true' \
+      --set 'global.tlsDisable=false' \
+      . | tee /dev/stderr |
+      yq -r '.spec.ports | map(select(.port==8200)) | .[] .name' | tee /dev/stderr)
+  [ "${actual}" = "https" ]
+}

--- a/values.yaml
+++ b/values.yaml
@@ -481,10 +481,19 @@ server:
     # cross-cluster replication, but it may be useful for other cases too.
     lb:
       enabled: false
-      # Set the externalTrafficPolicy to "Local". Local preserves the client source
-      # IP and avoids a second hop for LoadBalancer and Nodeport type services, but
-      # risks potentially imbalanced traffic spreading
-      #local: true
+      
+      # Local preserves the client source IP and avoids a second hop for
+      # LoadBalancer services, but risks potentially imbalanced traffic spreading.
+      externalTrafficPolicy: Local
+
+      # publishNotReadyAddresses indicates that any agent which deals with endpoints
+      # for this Service should disregard any indications of ready/not-ready.
+      publishNotReadyAddresses: false
+
+      # Extra annotations for the service definition. This can either be YAML or a
+      # YAML-formatted multi-line templated string map of the annotations to apply
+      # to the service.
+      annotations: {}
 
     # Set the api_addr configuration for Vault HA
     # See https://www.vaultproject.io/docs/configuration#api_addr

--- a/values.yaml
+++ b/values.yaml
@@ -469,13 +469,22 @@ server:
       #}
 
   # Run Vault in "HA" mode. There are no storage requirements unless audit log
-  # persistence is required.  In HA mode Vault will configure itself to use Consul
-  # for its storage backend.  The default configuration provided will work the Consul
-  # Helm project by default.  It is possible to manually configure Vault to use a
+  # persistence is required. In HA mode Vault will configure itself to use Consul
+  # for its storage backend. The default configuration provided will work with the Consul
+  # Helm project by default. It is possible to manually configure Vault to use a
   # different HA backend.
   ha:
     enabled: false
     replicas: 3
+
+    # Create a LoadBalancer service type. This is the recommended ingress for
+    # cross-cluster replication, but it may be useful for other cases too.
+    lb:
+      enabled: false
+      # Set the externalTrafficPolicy to "Local". Local preserves the client source
+      # IP and avoids a second hop for LoadBalancer and Nodeport type services, but
+      # risks potentially imbalanced traffic spreading
+      #local: true
 
     # Set the api_addr configuration for Vault HA
     # See https://www.vaultproject.io/docs/configuration#api_addr


### PR DESCRIPTION
This adds an optional `LoadBalancer` service type when operating in HA mode, specifically to address cross-cluster replication, but more widely useful as well.

Still TODO: Acceptance tests.

Unit tests pass locally:
```bash
docker build -t vault-helm-test -f test/docker/Test.dockerfile .
docker run --rm -v `pwd`:/root vault-helm-test bats -t /root/test/unit/server-ha-lb.bats
1..15
ok 1 server/ha-lb-Service: generic annotations
ok 2 server/ha-lb-Service: disable with ha.enabled false
ok 3 server/ha-lb-Service: disable with ha.lb.enabled false
ok 4 server/ha-lb-Service: disable with server.service.enabled false
ok 5 server/ha-lb-Service: type LoadBalancer
ok 6 server/ha-lb-Service: clusterIP empty by default
ok 7 server/ha-lb-Service: externalTrafficPolicy Local and publishNotReadyAddresses false as defaults
ok 8 server/ha-lb-Service: externalTrafficPolicy can be set
ok 9 server/ha-lb-Service: publishNotReadyAddresses can be set
ok 10 server/ha-lb-Service: port and targetPort will be 8200 by default
ok 11 server/ha-lb-Service: port and targetPort can be set
ok 12 server/ha-lb-Service: nodeport can be set
ok 13 server/ha-lb-Service: nodeport can't set when type isn't NodePort
ok 14 server/ha-lb-Service: vault port name is http, when tlsDisable is true
ok 15 server/ha-lb-Service: vault port name is https, when tlsDisable is false
```