### PR TITLE
Add UI targetPort option

### DIFF
--- a/templates/ui-service.yaml
+++ b/templates/ui-service.yaml
@@ -25,7 +25,7 @@ spec:
   ports:
     - name: {{ include "vault.scheme" . }}
       port: {{ .Values.ui.externalPort }}
-      targetPort: 8200
+      targetPort: {{ .Values.ui.targetPort }}
       {{- if .Values.ui.serviceNodePort }}
       nodePort: {{ .Values.ui.serviceNodePort }}
       {{- end }}

--- a/values.yaml
+++ b/values.yaml
@@ -597,6 +597,7 @@ ui:
   serviceType: "ClusterIP"
   serviceNodePort: null
   externalPort: 8200
+  targetPort: 8200
 
   # loadBalancerSourceRanges:
   #   - 10.0.0.0/16


### PR DESCRIPTION
Use custom `targetPort` for UI service. See the usecase in https://github.com/hashicorp/vault-helm/issues/385#issuecomment-749560213