### PR TITLE
Add extra time to injector initial probe delay

### DIFF
--- a/templates/injector-deployment.yaml
+++ b/templates/injector-deployment.yaml
@@ -106,7 +106,7 @@ spec:
               port: 8080
               scheme: HTTPS
             failureThreshold: 2
-            initialDelaySeconds: 1
+            initialDelaySeconds: 5
             periodSeconds: 2
             successThreshold: 1
             timeoutSeconds: 5
@@ -116,7 +116,7 @@ spec:
               port: 8080
               scheme: HTTPS
             failureThreshold: 2
-            initialDelaySeconds: 2
+            initialDelaySeconds: 5
             periodSeconds: 2
             successThreshold: 1
             timeoutSeconds: 5
@@ -134,7 +134,7 @@ spec:
               port: 4040
               scheme: HTTP
             failureThreshold: 2
-            initialDelaySeconds: 1
+            initialDelaySeconds: 5
             periodSeconds: 2
             successThreshold: 1
             timeoutSeconds: 5
@@ -144,7 +144,7 @@ spec:
               port: 4040
               scheme: HTTP
             failureThreshold: 2
-            initialDelaySeconds: 2
+            initialDelaySeconds: 5
             periodSeconds: 2
             successThreshold: 1
             timeoutSeconds: 5


### PR DESCRIPTION
We need a little more time before probing the health of the Injector due to the leader election logic so I added 3 extra seconds. In the future we should expose all these configurables like we do for the Vault server.