### PR TITLE
fix(injector): label component value in anti-affinity rule

### DIFF
--- a/values.yaml
+++ b/values.yaml
@@ -132,7 +132,7 @@ injector:
             matchLabels:
               app.kubernetes.io/name: {{ template "vault.name" . }}
               app.kubernetes.io/instance: "{{ .Release.Name }}"
-              component: injector
+              component: webhook
           topologyKey: kubernetes.io/hostname
 
   # Toleration Settings for injector pods


### PR DESCRIPTION
Hello folks 👋 

First of all, thanks a lot 👏 for the great work you did on the replicas topic related to the injector 💪 

Find that issue related to the label called "component" in the anti-affinity rule which doesn't match the one in the deployment manifest (webhook vs injector).

Also it could be an idea to rename all related label to injector. Tell me what you think about it. 

Cheers 😉
