### PR TITLE
fix(injector): label component (app.kubernetes.io/name) value in anti-affinity rule

### DIFF
--- a/values.yaml
+++ b/values.yaml
@@ -130,7 +130,7 @@ injector:
       requiredDuringSchedulingIgnoredDuringExecution:
         - labelSelector:
             matchLabels:
-              app.kubernetes.io/name: {{ template "vault.name" . }}
+              app.kubernetes.io/name: {{ template "vault.name" . }}-agent-injector
               app.kubernetes.io/instance: "{{ .Release.Name }}"
               component: webhook
           topologyKey: kubernetes.io/hostname


### PR DESCRIPTION
Hey I missed that label also 😅 
Same as https://github.com/hashicorp/vault-helm/pull/441
Cheers