### PR TITLE
Tests: Increase the timeout for leader elector ready

### DIFF
--- a/test/acceptance/injector-leader-elector.bats
+++ b/test/acceptance/injector-leader-elector.bats
@@ -11,7 +11,7 @@ load _helpers
 
   helm install "$(name_prefix)" \
     --set="injector.replicas=3" .
-  kubectl wait --for condition=Ready pod -l app.kubernetes.io/name=vault-agent-injector
+  kubectl wait --for condition=Ready pod -l app.kubernetes.io/name=vault-agent-injector --timeout=5m
 
   pods=($(kubectl get pods -l app.kubernetes.io/name=vault-agent-injector -o json | jq -r '.items[] | .metadata.name'))
   [ "${#pods[@]}" == 3 ]


### PR DESCRIPTION
Bumps the timeout waiting for the injector replicas (with
leader-elector containers) to be "Ready" to 5 minutes. Default was 30
seconds.

Hopefully this helps with intermittent tests failures with the leader-elector, for example: https://app.circleci.com/pipelines/github/hashicorp/vault-helm/599/workflows/f1a7b2ce-b5d0-41a5-923a-84cf79a10460/jobs/728