### PR TITLE
Update version of consul-helm in server-ha test

### DIFF
--- a/test/acceptance/server-ha.bats
+++ b/test/acceptance/server-ha.bats
@@ -90,7 +90,7 @@ setup() {
   kubectl config set-context --current --namespace=acceptance
 
   helm install consul \
-    https://github.com/hashicorp/consul-helm/archive/v0.16.2.tar.gz \
+    https://github.com/hashicorp/consul-helm/archive/v0.28.0.tar.gz \
     --set 'ui.enabled=false' \
 
   wait_for_running_consul


### PR DESCRIPTION
consul-helm v0.16.2 doesn't work with newer versions of helm (like 3.4), so this makes it easier to run the acceptance tests directly using the local helm version (i.e. `bats test/acceptance`).

Also tested with helm 3.2.0, which appears to be the version used in the vault-helm-test:0.1.0 container.