### PR TITLE
Set VAULT_DEV_LISTEN_ADDRESS in dev mode

### DIFF
--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -132,6 +132,8 @@ Set's additional environment variables based on the mode.
   {{ if eq .mode "dev" }}
             - name: VAULT_DEV_ROOT_TOKEN_ID
               value: {{ .Values.server.dev.devRootToken }}
+            - name: VAULT_DEV_LISTEN_ADDRESS
+              value: "[::]:8200"
   {{ end }}
 {{- end -}}
 


### PR DESCRIPTION
Addresses https://github.com/hashicorp/vault-k8s/issues/206

Since vault in dev mode now binds to localhost (127.0.0.1) by default, this adds the environment variable VAULT_DEV_LISTEN_ADDRESS to the server statefulset so that vault will accept traffic from outside the pod.

Also adds a couple tests for the new var, and modifies one that was affected by the extra env var added to the pod spec.