### PR TITLE
Add objectSelector to webhookconfiguration

### DIFF
--- a/templates/injector-mutating-webhook.yaml
+++ b/templates/injector-mutating-webhook.yaml
@@ -32,6 +32,10 @@ webhooks:
     namespaceSelector:
 {{ toYaml .Values.injector.namespaceSelector | indent 6}}
 {{ end }}
+{{- if .Values.injector.objectSelector }}
+    objectSelector:
+{{ toYaml .Values.injector.objectSelector | indent 6}}
+{{ end }}
 {{- with .Values.injector.failurePolicy }}
     failurePolicy: {{.}}
 {{ end }}

--- a/test/unit/injector-mutating-webhook.bats
+++ b/test/unit/injector-mutating-webhook.bats
@@ -76,6 +76,29 @@ load _helpers
   [ "${actual}" = "true" ]
 }
 
+@test "injector/MutatingWebhookConfiguration: objectSelector empty by default" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/injector-mutating-webhook.yaml  \
+      --set 'injector.enabled=true' \
+      --namespace foo \
+      . | tee /dev/stderr |
+      yq '.webhooks[0].objectSelector' | tee /dev/stderr)
+  [ "${actual}" = "null" ]
+}
+
+@test "injector/MutatingWebhookConfiguration: can set objectSelector" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/injector-mutating-webhook.yaml  \
+      --set 'injector.enabled=true' \
+      --set 'injector.objectSelector.matchLabels.injector=true' \
+      . | tee /dev/stderr |
+      yq '.webhooks[0].objectSelector.matchLabels.injector' | tee /dev/stderr)
+
+  [ "${actual}" = "true" ]
+}
+
 @test "injector/MutatingWebhookConfiguration: failurePolicy 'Ignore' by default" {
   cd `chart_dir`
   local actual=$(helm template \

--- a/values.yaml
+++ b/values.yaml
@@ -80,6 +80,15 @@ injector:
   #    matchLabels:
   #      sidecar-injector: enabled
   namespaceSelector: {}
+  # objectSelector is the selector for restricting the webhook to only
+  # specific labels.
+  # See https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/#matching-requests-objectselector
+  # for more details.
+  # Example:
+  # objectSelector:
+  #    matchLabels:
+  #      vault-sidecar-injector: enabled
+  objectSelector: {}
 
   # Configures failurePolicy of the webhook. The "unspecified" default behaviour deoends on the
   # API Version of the WebHook.


### PR DESCRIPTION
When all pods in the k8s cluster are deleted in a namespace, some of the pods are starting without vault if the pods start before the vault injector  The failure policy can be set to fail in the webhook to force the deployments to be retried until the injector is available. But if we want the pod creation to fail only for certain pods then an object selector is needed. For instance, consider the vault and application pods are deployed in the same namespace with the failure policy set to fail. The Vault injector(webhook server) is also a pod in the same namespace that doesn't start as the webhook is not available. It’s a deadlock. Hence an object selector is needed to skip the webhook for certain pods.

Without this change, if the pods are deployed in the same namespace and the failure policy is set to fail, then entire deployment will not happen as explained above 

I have provided examples in values. yaml.

Once an object selector is set, only those pods with the label will go through the mutating webhook server.