### PR TITLE
add artifacthub ownership file

### DIFF
--- a/artifacthub-repo.yml
+++ b/artifacthub-repo.yml
@@ -1,0 +1,3 @@
+owners:
+  - name: hashicorp
+    email: rel-eng+artifacthub@hashicorp.com


### PR DESCRIPTION
This PR adds an `artifacthub-repo.yml` file specifying a service user I created to claim ownership of the vault helm chart according to https://github.com/artifacthub/hub/blob/master/docs/repositories.md#ownership-claim. I will need another follow-up PR once the ownership is claimed to apply the `repositoryID` field as described in https://github.com/artifacthub/hub/blob/master/docs/repositories.md#verified-publisher.