### PR TITLE
feat(ingress): Extra paths to prepend to the host configuration

### DIFF
--- a/templates/server-ingress.yaml
+++ b/templates/server-ingress.yaml
@@ -2,6 +2,7 @@
 {{ template "vault.mode" . }}
 {{- if ne .mode "external" }}
 {{- if .Values.server.ingress.enabled -}}
+{{- $extraPaths := .Values.server.ingress.extraPaths -}}
 {{- $serviceName := include "vault.fullname" . -}}
 {{- if and (eq .mode "ha" ) (and (eq (.Values.server.service.enabled | toString) "true" ) (eq (.Values.global.enabled | toString) "true")) }}
 {{- $serviceName = printf "%s-%s" $serviceName "active" -}}
@@ -41,6 +42,9 @@ spec:
     - host: {{ .host | quote }}
       http:
         paths:
+{{ if $extraPaths }}
+{{ toYaml $extraPaths | indent 10 }}
+{{- end }}
         {{- range (.paths | default (list "/")) }}
           - path: {{ . }}
             backend:

--- a/values.yaml
+++ b/values.yaml
@@ -206,7 +206,12 @@ server:
     hosts:
       - host: chart-example.local
         paths: []
-
+    ## Extra paths to prepend to the host configuration. This is useful when working with annotation based services.
+    extraPaths: []
+    # - path: /*
+    #   backend:
+    #     serviceName: ssl-redirect
+    #     servicePort: use-annotation
     tls: []
     #  - secretName: chart-example-tls
     #    hosts:


### PR DESCRIPTION
Extra paths to prepend to the ingress host configuration. This is helpful for annotation services such as HTTPS redirects.

Refs #361