### PR TITLE
* Make ha standby service generate random nodeport -

### DIFF
--- a/templates/server-ha-standby-service.yaml
+++ b/templates/server-ha-standby-service.yaml
@@ -27,7 +27,7 @@ spec:
       port: {{ .Values.server.service.port }}
       targetPort: {{ .Values.server.service.targetPort }}
       {{- if and (.Values.server.service.nodePort) (eq (.Values.server.service.type | toString) "NodePort") }}
-      nodePort: {{ .Values.server.service.nodePort }}
+      nodePort:
       {{- end }}
     - name: https-internal
       port: 8201

--- a/templates/server-ha-standby-service.yaml
+++ b/templates/server-ha-standby-service.yaml
@@ -26,9 +26,6 @@ spec:
     - name: {{ include "vault.scheme" . }}
       port: {{ .Values.server.service.port }}
       targetPort: {{ .Values.server.service.targetPort }}
-      {{- if and (.Values.server.service.nodePort) (eq (.Values.server.service.type | toString) "NodePort") }}
-      nodePort:
-      {{- end }}
     - name: https-internal
       port: 8201
       targetPort: 8201

--- a/templates/server-service.yaml
+++ b/templates/server-service.yaml
@@ -28,12 +28,8 @@ spec:
     - name: {{ include "vault.scheme" . }}
       port: {{ .Values.server.service.port }}
       targetPort: {{ .Values.server.service.targetPort }}
-      {{- if and (.Values.server.service.nodePort) (eq (.Values.server.service.type | toString) "NodePort") }}
-      {{- if eq .mode "ha" -}}
-      nodePort:
-      {{- else -}}
+      {{- if and (.Values.server.service.nodePort) (eq (.Values.server.service.type | toString) "NodePort") (ne .mode "ha") }}
       nodePort: {{ .Values.server.service.nodePort }}
-      {{- end -}}
       {{- end }}
     - name: https-internal
       port: 8201

--- a/templates/server-service.yaml
+++ b/templates/server-service.yaml
@@ -29,7 +29,11 @@ spec:
       port: {{ .Values.server.service.port }}
       targetPort: {{ .Values.server.service.targetPort }}
       {{- if and (.Values.server.service.nodePort) (eq (.Values.server.service.type | toString) "NodePort") }}
+      {{- if eq .mode "ha" -}}
+      nodePort:
+      {{- else -}}
       nodePort: {{ .Values.server.service.nodePort }}
+      {{- end -}}
       {{- end }}
     - name: https-internal
       port: 8201

--- a/test/unit/server-ha-standby-service.bats
+++ b/test/unit/server-ha-standby-service.bats
@@ -132,8 +132,8 @@ load _helpers
       --set 'server.service.type=NodePort' \
       --set 'server.service.nodePort=30009' \
       . | tee /dev/stderr |
-      yq -r '.spec.ports[0].nodePort' | tee /dev/stderr)
-  [ "${actual}" = "30009" ]
+      yq -r '.spec.type' | tee /dev/stderr)
+  [ "${actual}" = "NodePort" ]
 }
 
 @test "server/ha-standby-Service: nodeport can't set when type isn't NodePort" {

--- a/test/unit/server-service.bats
+++ b/test/unit/server-service.bats
@@ -324,8 +324,8 @@ load _helpers
       --set 'server.service.type=NodePort' \
       --set 'server.service.nodePort=30009' \
       . | tee /dev/stderr |
-      yq -r '.spec.ports[0].nodePort' | tee /dev/stderr)
-  [ "${actual}" = "30009" ]
+      yq -r '.spec.type' | tee /dev/stderr)
+  [ "${actual}" = "NodePort" ]
 
   local actual=$(helm template \
       --show-only templates/server-service.yaml \


### PR DESCRIPTION
In order to prevent collision with the ha active svc
* Make the generic server svc generate a random
nodeport if using HA mode, otherwise use the
value supplied by the user on the chart

This addresses this issue: 
https://github.com/hashicorp/vault-helm/issues/344
