### PR TITLE
Adds support to explicitly configure network policy in injector

### DIFF
--- a/templates/injector-network-policy.yaml
+++ b/templates/injector-network-policy.yaml
@@ -1,4 +1,4 @@
-{{- if and (eq (.Values.injector.enabled | toString) "true" ) (and (eq (.Values.global.enabled | toString) "true") (eq (.Values.global.openshift | toString) "true") ) }}
+{{- if eq (.Values.injector.networkPolicy.enabled | toString) "true" }}
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:

--- a/test/unit/injector-network-policy.bats
+++ b/test/unit/injector-network-policy.bats
@@ -1,0 +1,22 @@
+#!/usr/bin/env bats
+
+load _helpers
+
+@test "injector/network-policy: disabled by default" {
+  cd `chart_dir`
+  local actual=$( (helm template \
+      --show-only templates/injector-network-policy.yaml  \
+      . || echo "---") | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+}
+
+@test "injector/network-policy: enabled by injector.networkPolicy.enabled" {
+  cd `chart_dir`
+  local actual=$( (helm template \
+      --set 'injector.networkPolicy.enabled=true' \
+      --show-only templates/injector-network-policy.yaml  \
+      . || echo "---") | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}

--- a/values.yaml
+++ b/values.yaml
@@ -156,6 +156,10 @@ injector:
   #   beta.kubernetes.io/arch: amd64
   nodeSelector: null
 
+  # Enables network policy for injector pods
+  networkPolicy:
+    enabled: false
+
   # Priority class for injector pods
   priorityClassName: ""
 


### PR DESCRIPTION
Similar to the conversion around PR #381, network policies are useful for the injector independent of openshift.  This allows support for those use cases but similarly will require some configuration changes for openshift users.