### PR TITLE
Target vault-csi-provider release 0.1.0

### DIFF
--- a/templates/csi-daemonset.yaml
+++ b/templates/csi-daemonset.yaml
@@ -47,7 +47,6 @@ spec:
               mountPath: {{ .path | default "/vault/userconfig" }}/{{ .name }}
               readOnly: true
             {{- end }}
-          {{- if .Values.csi.livenessProbe.enabled }}
           livenessProbe:
             httpGet:
               path: /health/ready
@@ -57,8 +56,6 @@ spec:
             periodSeconds: {{ .Values.csi.livenessProbe.periodSeconds }}
             successThreshold: {{ .Values.csi.livenessProbe.successThreshold }}
             timeoutSeconds: {{ .Values.csi.livenessProbe.timeoutSeconds }}
-          {{- end }}
-          {{- if .Values.csi.readinessProbe.enabled }}
           readinessProbe:
             httpGet:
               path: /health/ready
@@ -68,7 +65,6 @@ spec:
             periodSeconds: {{ .Values.csi.readinessProbe.periodSeconds }}
             successThreshold: {{ .Values.csi.readinessProbe.successThreshold }}
             timeoutSeconds: {{ .Values.csi.readinessProbe.timeoutSeconds }}
-          {{- end }}
       volumes:
         - name: providervol
           hostPath:

--- a/test/acceptance/csi-test/nginx.yaml
+++ b/test/acceptance/csi-test/nginx.yaml
@@ -10,6 +10,7 @@ metadata:
   name: nginx
 spec:
   terminationGracePeriodSeconds: 0
+  serviceAccountName: nginx
   containers:
   - image: docker.mirror.hashicorp.services/nginx
     name: nginx

--- a/test/acceptance/csi-test/vault-kv-secretproviderclass.yaml
+++ b/test/acceptance/csi-test/vault-kv-secretproviderclass.yaml
@@ -9,7 +9,6 @@ spec:
     roleName: "kv-role"
     vaultAddress: http://vault:8200
     objects: |
-      array:
-        - |
-          objectName: "bar1"
-          objectPath: "v1/secret/kv1"
+      - objectName: "bar"
+        secretPath: "secret/data/kv1"
+        secretKey: "bar1"

--- a/test/acceptance/csi-test/vault-policy.hcl
+++ b/test/acceptance/csi-test/vault-policy.hcl
@@ -1,7 +1,3 @@
-path "sys/mounts" {
-  capabilities = ["read"]
-}
-
-path "secret/*" {
+path "secret/data/kv1" {
   capabilities = ["read"]
 }

--- a/test/acceptance/csi.bats
+++ b/test/acceptance/csi.bats
@@ -9,11 +9,10 @@ load _helpers
   kubectl create namespace acceptance
 
   # Install Secrets Store CSI driver
-  helm install secrets-store-csi-driver https://github.com/kubernetes-sigs/secrets-store-csi-driver/blob/master/charts/secrets-store-csi-driver-0.0.19.tgz?raw=true \
+  helm install secrets-store-csi-driver https://github.com/kubernetes-sigs/secrets-store-csi-driver/blob/master/charts/secrets-store-csi-driver-0.0.20.tgz?raw=true \
     --wait --timeout=5m \
     --namespace=acceptance \
-    --set linux.image.pullPolicy="IfNotPresent" \
-    --set grpcSupportedProviders="azure;gcp;vault"
+    --set linux.image.pullPolicy="IfNotPresent"
   # Install Vault and Vault provider
   helm install vault \
     --wait --timeout=5m \
@@ -30,9 +29,10 @@ load _helpers
   kubectl --namespace=acceptance exec vault-0 -- sh -c 'vault write auth/kubernetes/config \
     token_reviewer_jwt="$(cat /var/run/secrets/kubernetes.io/serviceaccount/token)" \
     kubernetes_host="https://$KUBERNETES_PORT_443_TCP_ADDR:443" \
-    kubernetes_ca_cert=@/var/run/secrets/kubernetes.io/serviceaccount/ca.crt'
+    kubernetes_ca_cert=@/var/run/secrets/kubernetes.io/serviceaccount/ca.crt \
+    disable_iss_validation=true'
   kubectl --namespace=acceptance exec vault-0 -- vault write auth/kubernetes/role/kv-role \
-    bound_service_account_names=vault-csi-provider \
+    bound_service_account_names=nginx \
     bound_service_account_namespaces=acceptance \
     policies=kv-policy \
     ttl=20m
@@ -42,7 +42,7 @@ load _helpers
   kubectl --namespace=acceptance apply -f ./test/acceptance/csi-test/nginx.yaml
   kubectl --namespace=acceptance wait --for=condition=Ready --timeout=5m pod nginx
 
-  result=$(kubectl --namespace=acceptance exec nginx -- cat /mnt/secrets-store/bar1)
+  result=$(kubectl --namespace=acceptance exec nginx -- cat /mnt/secrets-store/bar)
   [[ "$result" == "hello1" ]]
 }
 

--- a/test/unit/csi-daemonset.bats
+++ b/test/unit/csi-daemonset.bats
@@ -248,23 +248,6 @@ load _helpers
 #--------------------------------------------------------------------
 # Readiness/liveness probes
 
-@test "csi/daemonset: csi.livenessProbe and csi.readinessProbe default to disabled" {
-  cd `chart_dir`
-  local actual=$(helm template \
-      --show-only templates/csi-daemonset.yaml \
-      --set 'csi.enabled=true' \
-      . | tee /dev/stderr |
-      yq -r '.spec.template.spec.containers[0].livenessProbe' | tee /dev/stderr)
-  [ "${actual}" = "null" ]
-
-  local actual=$(helm template \
-      --show-only templates/csi-daemonset.yaml \
-      --set 'csi.enabled=true' \
-      . | tee /dev/stderr |
-      yq -r '.spec.template.spec.containers[0].readinessProbe' | tee /dev/stderr)
-  [ "${actual}" = "null" ]
-}
-
 @test "csi/daemonset: csi.livenessProbe is configurable" {
   cd `chart_dir`
 
@@ -272,7 +255,6 @@ load _helpers
   local object=$(helm template \
       --show-only templates/csi-daemonset.yaml  \
       --set 'csi.enabled=true' \
-      --set 'csi.livenessProbe.enabled=true' \
       . | tee /dev/stderr |
       yq -r '.spec.template.spec.containers[0].livenessProbe' | tee /dev/stderr)
 
@@ -296,7 +278,6 @@ load _helpers
   local object=$(helm template \
       --show-only templates/csi-daemonset.yaml  \
       --set 'csi.enabled=true' \
-      --set 'csi.livenessProbe.enabled=true' \
       --set 'csi.livenessProbe.failureThreshold=10' \
       --set 'csi.livenessProbe.initialDelaySeconds=11' \
       --set 'csi.livenessProbe.periodSeconds=12' \
@@ -329,7 +310,6 @@ load _helpers
   local object=$(helm template \
       --show-only templates/csi-daemonset.yaml  \
       --set 'csi.enabled=true' \
-      --set 'csi.readinessProbe.enabled=true' \
       . | tee /dev/stderr |
       yq -r '.spec.template.spec.containers[0].readinessProbe' | tee /dev/stderr)
 
@@ -353,7 +333,6 @@ load _helpers
   local object=$(helm template \
       --show-only templates/csi-daemonset.yaml  \
       --set 'csi.enabled=true' \
-      --set 'csi.readinessProbe.enabled=true' \
       --set 'csi.readinessProbe.failureThreshold=10' \
       --set 'csi.readinessProbe.initialDelaySeconds=11' \
       --set 'csi.readinessProbe.periodSeconds=12' \

--- a/values.yaml
+++ b/values.yaml
@@ -652,8 +652,8 @@ csi:
   enabled: false
 
   image:
-    repository: "hashicorp/secrets-store-csi-driver-provider-vault"
-    tag: "0.0.7"
+    repository: "hashicorp/vault-csi-provider"
+    tag: "0.1.0"
     pullPolicy: IfNotPresent
 
   # extraVolumes is a list of extra volumes to mount. These will be exposed
@@ -696,8 +696,6 @@ csi:
 
   # Used to configure readinessProbe for the pods.
   readinessProbe:
-  # Vault CSI provider does not support a readiness probe in versions <= 0.7.0
-    enabled: false
     failureThreshold: 2
     initialDelaySeconds: 5
     periodSeconds: 5
@@ -705,8 +703,6 @@ csi:
     timeoutSeconds: 3
   # Used to configure livenessProbe for the pods.
   livenessProbe:
-    # Vault CSI provider does not support a liveness probe in versions <= 0.7.0
-    enabled: false
     failureThreshold: 2
     initialDelaySeconds: 5
     periodSeconds: 5


### PR DESCRIPTION
Now that `vault-csi-provider` 0.1.0 with liveness and readiness probes is released, target that by default.

```bash
bats test/acceptance/csi.bats 
 ✓ csi: testing deployment 

1 test, 0 failures
```

Also manually tested as working with some updates to the `vault-csi-provider`'s integration tests.