### PR TITLE
Add labels to deployment, statefulset and service accounts

### DIFF
--- a/templates/injector-deployment.yaml
+++ b/templates/injector-deployment.yaml
@@ -10,6 +10,9 @@ metadata:
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     component: webhook
+    {{- if  .Values.injector.extraLabels -}}
+      {{- toYaml .Values.injector.extraLabels | nindent 4 -}}
+    {{- end -}}
 spec:
   replicas: {{ .Values.injector.replicas }}
   selector:

--- a/templates/injector-deployment.yaml
+++ b/templates/injector-deployment.yaml
@@ -10,9 +10,9 @@ metadata:
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     component: webhook
-    {{- if  .Values.injector.extraLabels -}}
+    {{- if .Values.injector.extraLabels -}}
       {{- toYaml .Values.injector.extraLabels | nindent 4 -}}
-    {{- end -}}
+    {{- end }}
 spec:
   replicas: {{ .Values.injector.replicas }}
   selector:
@@ -26,7 +26,7 @@ spec:
         app.kubernetes.io/name: {{ template "vault.name" . }}-agent-injector
         app.kubernetes.io/instance: {{ .Release.Name }}
         component: webhook
-        {{- if  .Values.injector.extraLabels -}}
+        {{- if .Values.injector.extraLabels -}}
           {{- toYaml .Values.injector.extraLabels | nindent 8 -}}
         {{- end -}}
       {{ template "injector.annotations" . }}

--- a/templates/injector-serviceaccount.yaml
+++ b/templates/injector-serviceaccount.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: {{ include "vault.name" . }}-agent-injector
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
-    {{- if  .Values.injector.extraLabels -}}
+    {{- if .Values.injector.extraLabels -}}
       {{- toYaml .Values.injector.extraLabels | nindent 4 -}}
     {{- end -}}
 {{ end }}

--- a/templates/injector-serviceaccount.yaml
+++ b/templates/injector-serviceaccount.yaml
@@ -8,4 +8,7 @@ metadata:
     app.kubernetes.io/name: {{ include "vault.name" . }}-agent-injector
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
+    {{- if  .Values.injector.extraLabels -}}
+      {{- toYaml .Values.injector.extraLabels | nindent 4 -}}
+    {{- end -}}
 {{ end }}

--- a/templates/server-serviceaccount.yaml
+++ b/templates/server-serviceaccount.yaml
@@ -11,6 +11,9 @@ metadata:
     app.kubernetes.io/name: {{ include "vault.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
+    {{- if  .Values.server.extraLabels -}}
+      {{- toYaml .Values.server.extraLabels | nindent 4 -}}
+    {{- end -}}
   {{ template "vault.serviceAccount.annotations" . }}
 {{ end }}
 {{ end }}

--- a/templates/server-serviceaccount.yaml
+++ b/templates/server-serviceaccount.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/name: {{ include "vault.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
-    {{- if  .Values.server.extraLabels -}}
+    {{- if .Values.server.extraLabels -}}
       {{- toYaml .Values.server.extraLabels | nindent 4 -}}
     {{- end -}}
   {{ template "vault.serviceAccount.annotations" . }}

--- a/templates/server-statefulset.yaml
+++ b/templates/server-statefulset.yaml
@@ -11,6 +11,9 @@ metadata:
     app.kubernetes.io/name: {{ include "vault.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
+    {{- if  .Values.server.extraLabels -}}
+      {{- toYaml .Values.server.extraLabels | nindent 4 -}}
+    {{- end -}}
   {{- template "vault.statefulSet.annotations" . }}
 spec:
   serviceName: {{ template "vault.fullname" . }}-internal

--- a/templates/server-statefulset.yaml
+++ b/templates/server-statefulset.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/name: {{ include "vault.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
-    {{- if  .Values.server.extraLabels -}}
+    {{- if .Values.server.extraLabels -}}
       {{- toYaml .Values.server.extraLabels | nindent 4 -}}
     {{- end -}}
   {{- template "vault.statefulSet.annotations" . }}


### PR DESCRIPTION
This PR adds user defined labels to service accounts, deployment and stateful set. Existing `.Values.server.extraLabels` and `.Values.injector.extraLabels` are now added to more resources