### PR TITLE
Add volumes and mounts support for CSI

### DIFF
--- a/templates/csi-daemonset.yaml
+++ b/templates/csi-daemonset.yaml
@@ -42,10 +42,8 @@ spec:
             - name: mountpoint-dir
               mountPath: /var/lib/kubelet/pods
               mountPropagation: HostToContainer
-            {{- range .Values.csi.extraVolumes }}
-            - name: userconfig-{{ .name }}
-              mountPath: {{ .path | default "/vault/userconfig" }}/{{ .name }}
-              readOnly: true
+            {{- if .Values.csi.volumeMounts }}
+              {{- toYaml .Values.csi.volumeMounts | nindent 12}}
             {{- end }}
           livenessProbe:
             httpGet:
@@ -72,14 +70,7 @@ spec:
         - name: mountpoint-dir
           hostPath:
             path: /var/lib/kubelet/pods
-        {{- range .Values.csi.extraVolumes }}
-        - name: userconfig-{{ .name }}
-          {{ .type }}:
-          {{- if (eq .type "configMap") }}
-            name: {{ .name }}
-          {{- else if (eq .type "secret") }}
-            secretName: {{ .name }}
-          {{- end }}
-            defaultMode: {{ .defaultMode | default 420 }}
-        {{- end }}
+       {{- if .Values.csi.volumes }}
+         {{- toYaml .Values.csi.volumes | nindent 8}}
+       {{- end }}
 {{- end }}

--- a/values.yaml
+++ b/values.yaml
@@ -320,6 +320,7 @@ server:
     #   secretName: vault
     #   secretKey: AWS_SECRET_ACCESS_KEY
 
+  # Deprecated: please use 'volumes' instead.
   # extraVolumes is a list of extra volumes to mount. These will be exposed
   # to Vault in the path `/vault/userconfig/<name>/`. The value below is
   # an array of objects, examples are shown below.
@@ -656,13 +657,20 @@ csi:
     tag: "0.1.0"
     pullPolicy: IfNotPresent
 
-  # extraVolumes is a list of extra volumes to mount. These will be exposed
-  # to Vault in the path `/vault/userconfig/<name>/`. The value below is
-  # an array of objects, examples are shown below.
-  extraVolumes: []
-    # - type: secret (or "configMap")
-    #   name: my-secret
-    #   path: null # default is `/vault/userconfig`
+  # volumes is a list of volumes made available to all containers. These are rendered
+  # via toYaml rather than pre-processed like the extraVolumes value.
+  # The purpose is to make it easy to share volumes between containers.
+  volumes: null
+  # - name: tls
+  #   emptyDir: {}
+
+  # volumeMounts is a list of volumeMounts for the main server container. These are rendered
+  # via toYaml rather than pre-processed like the extraVolumes value.
+  # The purpose is to make it easy to share volumes between containers.
+  volumeMounts: null
+  # - mountPath: /vault/tls
+  #   name: tls
+  #   readOnly: true
 
   resources: {}
   # resources:

--- a/values.yaml
+++ b/values.yaml
@@ -662,14 +662,15 @@ csi:
   # The purpose is to make it easy to share volumes between containers.
   volumes: null
   # - name: tls
-  #   emptyDir: {}
+  #   secret:
+  #     secretName: vault-tls
 
   # volumeMounts is a list of volumeMounts for the main server container. These are rendered
   # via toYaml rather than pre-processed like the extraVolumes value.
   # The purpose is to make it easy to share volumes between containers.
   volumeMounts: null
-  # - mountPath: /vault/tls
-  #   name: tls
+  # - name: tls
+  #   mountPath: "/vault/tls"
   #   readOnly: true
 
   resources: {}


### PR DESCRIPTION
I missed in the CSI review that `extraVolumes` was being used. We've deprecated that configuration in favor of `volumes` and `volumeMounts` which offers more flexibility in what can be mounted and where.

This removes `extraVolumes` and adds support for `csi.volumes` and `csi.volumeMounts`.

Additionally I added a note about the deprecation in `values.yaml`. This note already exists on the website.