### PR TITLE
Remove extra word in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ use Vault with Kubernetes, please see the
 ## Prerequisites
 
 To use the charts here, [Helm](https://helm.sh/) must be configured for your
-Kubernetes cluster. Setting up Kubernetes and Helm and is outside the scope of
+Kubernetes cluster. Setting up Kubernetes and Helm is outside the scope of
 this README. Please refer to the Kubernetes and Helm documentation.
 
 The versions required are:


### PR DESCRIPTION
The README seems to have a sentence with an extra word, so I propose to remove it.