### PR TITLE
[ingress] allow api-version spec

### DIFF
--- a/templates/server-ingress.yaml
+++ b/templates/server-ingress.yaml
@@ -7,7 +7,11 @@
 {{- $serviceName = printf "%s-%s" $serviceName "active" -}}
 {{- end }}
 {{- $servicePort := .Values.server.service.port -}}
-{{ if .Capabilities.APIVersions.Has "networking.k8s.io/v1beta1" }}
+{{ if .Values.server.ingress.apiVersion }}
+apiVersion: {{ .Values.server.ingress.apiVersion }}
+{{ else if .Capabilities.APIVersions.Has "networking.k8s.io/v1" }}
+apiVersion: networking.k8s.io/v1
+{{ else if .Capabilities.APIVersions.Has "networking.k8s.io/v1beta1" }}
 apiVersion: networking.k8s.io/v1beta1
 {{ else }}
 apiVersion: extensions/v1beta1

--- a/test/unit/server-ingress.bats
+++ b/test/unit/server-ingress.bats
@@ -121,3 +121,26 @@ load _helpers
       yq -r '.spec.rules[0].http.paths[0].backend.serviceName' | tee /dev/stderr)
   [ "${actual}" = "RELEASE-NAME-vault" ]
 }
+
+@test "server/ingress: api version capabilities default" {
+  cd `chart_dir`
+
+  local actual=$(helm template \
+      --show-only templates/server-ingress.yaml \
+      --set 'server.ingress.enabled=true' \
+      . | tee /dev/stderr |
+      yq -r '.apiVersion' | tee /dev/stderr)
+  [ "${actual}" = "networking.k8s.io/v1" ]
+}
+
+@test "server/ingress: api version custom" {
+  cd `chart_dir`
+
+  local actual=$(helm template \
+      --show-only templates/server-ingress.yaml \
+      --set 'server.ingress.enabled=true' \
+      --set 'server.ingress.apiVersion=networking.k8s.io/v2' \
+      . | tee /dev/stderr |
+      yq -r '.apiVersion' | tee /dev/stderr)
+  [ "${actual}" = "networking.k8s.io/v2" ]
+}


### PR DESCRIPTION
```
helm template --debug -n ae-system --set server.ingress.enabled=1 my-release .
```

```yaml
---
# Source: vault/templates/server-ingress.yaml
apiVersion: networking.k8s.io/v1beta1


kind: Ingress
metadata:
  name: my-release-vault
  namespace: ae-system
  labels:
    helm.sh/chart: vault-0.10.0
    app.kubernetes.io/name: vault
    app.kubernetes.io/instance: my-release
    app.kubernetes.io/managed-by: Helm
spec:
  rules:
    - host: "chart-example.local"
      http:
        paths:
          - path: /
            backend:
              serviceName: my-release-vault
              servicePort: 8200
---
```

```
helm template --debug -n ae-system --set server.ingress.enabled=1 --set server.ingress.apiVersion=networking.k8s.io/v1 my-release .
```

```yaml
---
# Source: vault/templates/server-ingress.yaml
apiVersion: networking.k8s.io/v1

kind: Ingress
metadata:
  name: my-release-vault
  namespace: ae-system
  labels:
    helm.sh/chart: vault-0.10.0
    app.kubernetes.io/name: vault
    app.kubernetes.io/instance: my-release
    app.kubernetes.io/managed-by: Helm
spec:
  rules:
    - host: "chart-example.local"
      http:
        paths:
          - path: /
            backend:
              serviceName: my-release-vault
              servicePort: 8200
---
```