### PR TITLE
fix csi helm deployment

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: vault
-version: 0.10.1
+version: 0.10.0
 appVersion: 1.7.0
 description: Official HashiCorp Vault Chart
 home: https://www.vaultproject.io

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: vault
-version: 0.10.0
+version: 0.10.1
 appVersion: 1.7.0
 description: Official HashiCorp Vault Chart
 home: https://www.vaultproject.io

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -53,7 +53,7 @@ template logic.
 {{- define "vault.mode" -}}
   {{- if .Values.injector.externalVaultAddr -}}
     {{- $_ := set . "mode" "external" -}}
-  {{- else if eq (.Values.server.enabled | toString) "false" -}}
+  {{- else if ne (.Values.server.enabled | toString) "true" -}}
     {{- $_ := set . "mode" "external" -}}
   {{- else if eq (.Values.server.dev.enabled | toString) "true" -}}
     {{- $_ := set . "mode" "dev" -}}

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -53,6 +53,8 @@ template logic.
 {{- define "vault.mode" -}}
   {{- if .Values.injector.externalVaultAddr -}}
     {{- $_ := set . "mode" "external" -}}
+  {{- else if eq (.Values.server.enabled | toString) "false" -}}
+    {{- $_ := set . "mode" "external" -}}
   {{- else if eq (.Values.server.dev.enabled | toString) "true" -}}
     {{- $_ := set . "mode" "dev" -}}
   {{- else if eq (.Values.server.ha.enabled | toString) "true" -}}

--- a/templates/csi-clusterrole.yaml
+++ b/templates/csi-clusterrole.yaml
@@ -2,7 +2,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: {{ include "vault.name" . }}-csi-provider-clusterrole
+  name: {{ template "vault.fullname" . }}-csi-provider-clusterrole
   labels:
     app.kubernetes.io/name: {{ include "vault.name" . }}-csi-provider
     app.kubernetes.io/instance: {{ .Release.Name }}

--- a/templates/csi-daemonset.yaml
+++ b/templates/csi-daemonset.yaml
@@ -27,7 +27,7 @@ spec:
         app.kubernetes.io/instance: {{ .Release.Name }}
       {{ template "csi.pod.annotations" . }}
     spec:
-      serviceAccountName: {{ include "vault.name" . }}-csi-provider
+      serviceAccountName: {{ template "vault.fullname" . }}-csi-provider
       containers:
         - name: {{ include "vault.name" . }}-csi-provider
           {{ template "csi.resources" . }}

--- a/test/unit/csi-clusterrole.bats
+++ b/test/unit/csi-clusterrole.bats
@@ -20,3 +20,14 @@ load _helpers
       yq 'length > 0' | tee /dev/stderr)
   [ "${actual}" = "true" ]
 }
+
+# ClusterRole name
+@test "csi/ClusterRole: name" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/csi-clusterrole.yaml \
+      --set "csi.enabled=true" \
+      . | tee /dev/stderr |
+      yq -r '.metadata.name' | tee /dev/stderr)
+  [ "${actual}" = "RELEASE-NAME-vault-csi-provider-clusterrole" ]
+}

--- a/test/unit/csi-clusterrolebinding.bats
+++ b/test/unit/csi-clusterrolebinding.bats
@@ -20,3 +20,25 @@ load _helpers
       yq 'length > 0' | tee /dev/stderr)
   [ "${actual}" = "true" ]
 }
+
+# ClusterRoleBinding cluster role ref name
+@test "csi/ClusterRoleBinding: cluster role ref name" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/csi-clusterrolebinding.yaml \
+      --set "csi.enabled=true" \
+      . | tee /dev/stderr |
+      yq -r '.roleRef.name' | tee /dev/stderr)
+  [ "${actual}" = "RELEASE-NAME-vault-csi-provider-clusterrole" ]
+}
+
+# ClusterRoleBinding service account name
+@test "csi/ClusterRoleBinding: service account name" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/csi-clusterrolebinding.yaml \
+      --set "csi.enabled=true" \
+      . | tee /dev/stderr |
+      yq -r '.subjects[0].name' | tee /dev/stderr)
+  [ "${actual}" = "RELEASE-NAME-vault-csi-provider" ]
+}

--- a/test/unit/csi-daemonset.bats
+++ b/test/unit/csi-daemonset.bats
@@ -30,6 +30,17 @@ load _helpers
   [ "${actual}" = "false" ]
 }
 
+# serviceAccountName reference name
+@test "csi/daemonset: serviceAccountName reference name" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/csi-daemonset.yaml \
+      --set "csi.enabled=true" \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.serviceAccountName' | tee /dev/stderr)
+  [ "${actual}" = "RELEASE-NAME-vault-csi-provider" ]
+}
+
 # Image
 @test "csi/daemonset: image is configurable" {
   cd `chart_dir`

--- a/test/unit/csi-serviceaccount.bats
+++ b/test/unit/csi-serviceaccount.bats
@@ -21,6 +21,17 @@ load _helpers
   [ "${actual}" = "true" ]
 }
 
+# serviceAccountName reference name
+@test "csi/daemonset: serviceAccountName name" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/csi-serviceaccount.yaml \
+      --set "csi.enabled=true" \
+      . | tee /dev/stderr |
+      yq -r '.metadata.name' | tee /dev/stderr)
+  [ "${actual}" = "RELEASE-NAME-vault-csi-provider" ]
+}
+
 @test "csi/serviceAccount: specify annotations" {
   cd `chart_dir`
   local actual=$(helm template \

--- a/test/unit/server-statefulset.bats
+++ b/test/unit/server-statefulset.bats
@@ -2,7 +2,10 @@
 
 load _helpers
 
-@test "server/standalone-StatefulSet: disabled server.enabled" {
+#--------------------------------------------------------------------
+# disable / enable server deployment
+
+@test "server/StatefulSet: disabled server.enabled" {
   cd `chart_dir`
   local actual=$( (helm template \
       --show-only templates/server-statefulset.yaml  \
@@ -11,6 +14,28 @@ load _helpers
       yq 'length > 0' | tee /dev/stderr)
   [ "${actual}" = "false" ]
 }
+
+@test "server/StatefulSet: disabled server.enabled random string" {
+  cd `chart_dir`
+  local actual=$( (helm template \
+      --show-only templates/server-statefulset.yaml  \
+      --set 'server.enabled=blabla' \
+      . || echo "---") | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+}
+
+@test "server/StatefulSet: enabled server.enabled explicit true" {
+  cd `chart_dir`
+  local actual=$( (helm template \
+      --show-only templates/server-statefulset.yaml  \
+      --set 'server.enabled=true' \
+      . || echo "---") | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}
+
+#--------------------------------------------------------------------
 
 @test "server/standalone-StatefulSet: default server.standalone.enabled" {
   cd `chart_dir`

--- a/test/unit/server-statefulset.bats
+++ b/test/unit/server-statefulset.bats
@@ -2,6 +2,16 @@
 
 load _helpers
 
+@test "server/standalone-StatefulSet: disabled server.enabled" {
+  cd `chart_dir`
+  local actual=$( (helm template \
+      --show-only templates/server-statefulset.yaml  \
+      --set 'server.enabled=false' \
+      . || echo "---") | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+}
+
 @test "server/standalone-StatefulSet: default server.standalone.enabled" {
   cd `chart_dir`
   local actual=$(helm template \

--- a/values.yaml
+++ b/values.yaml
@@ -174,7 +174,7 @@ injector:
     annotations: {}
 
 server:
-  # If set to false, Vault server will not be installed. See vault.mode in _helpers.tpl for implementation details
+  # If not set to true, Vault server will not be installed. See vault.mode in _helpers.tpl for implementation details
   enabled: true
 
   # Resource requests, limits, etc. for the server cluster placement. This

--- a/values.yaml
+++ b/values.yaml
@@ -174,6 +174,9 @@ injector:
     annotations: {}
 
 server:
+  # if set to false, chart "mode" will define as "external", see _helpers.tpl
+  enabled: true
+
   # Resource requests, limits, etc. for the server cluster placement. This
   # should map directly to the value of the resources field for a PodSpec.
   # By default no direct resource request is made.

--- a/values.yaml
+++ b/values.yaml
@@ -174,7 +174,7 @@ injector:
     annotations: {}
 
 server:
-  # if set to false, chart "mode" will define as "external", see _helpers.tpl
+  # If set to false, Vault server will not be installed. See vault.mode in _helpers.tpl for implementation details
   enabled: true
 
   # Resource requests, limits, etc. for the server cluster placement. This


### PR DESCRIPTION
fixed the SA reference from daemonset, and from clusterrolebinding to clusterrole (using "vault.fullname").

added the `server.enable` option,
the [documentation](https://github.com/hashicorp/vault-csi-provider#using-helm) stated to use `--set "server.enabled=false"` but was not possible.