### PR TITLE
Add server.logLevel value

### DIFF
--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -118,10 +118,10 @@ for users looking to use this chart with Consul Helm.
             [ -n "${API_ADDR}" ] && sed -Ei "s|API_ADDR|${API_ADDR?}|g" /tmp/storageconfig.hcl;
             [ -n "${TRANSIT_ADDR}" ] && sed -Ei "s|TRANSIT_ADDR|${TRANSIT_ADDR?}|g" /tmp/storageconfig.hcl;
             [ -n "${RAFT_ADDR}" ] && sed -Ei "s|RAFT_ADDR|${RAFT_ADDR?}|g" /tmp/storageconfig.hcl;
-            /usr/local/bin/docker-entrypoint.sh vault server -config=/tmp/storageconfig.hcl {{ .Values.server.extraArgs }}
+            /usr/local/bin/docker-entrypoint.sh vault server -config=/tmp/storageconfig.hcl {{ if .Values.server.logLevel }}-log-level={{ .Values.server.logLevel }}{{ end }} {{ .Values.server.extraArgs }}
    {{ else if eq .mode "dev" }}
           - |
-            /usr/local/bin/docker-entrypoint.sh vault server -dev {{ .Values.server.extraArgs }}
+            /usr/local/bin/docker-entrypoint.sh vault server -dev {{ if .Values.server.logLevel }}-log-level={{ .Values.server.logLevel }}{{ end }} {{ .Values.server.extraArgs }}
   {{ end }}
 {{- end -}}
 

--- a/values.yaml
+++ b/values.yaml
@@ -264,6 +264,12 @@ server:
   # extraArgs is a string containing additional Vault server arguments.
   extraArgs: ""
 
+  # logLevel specifies the log verbosity level. Supported values (in order of
+  # detail) are "trace", "debug", "info", "warn", and "err". Vault defaults to
+  # "info" if not specified.
+  # If server.extraArgs also specifies -log-level, that value takes precedence.
+  logLevel: ""
+
   # Used to define custom readinessProbe settings
   readinessProbe:
     enabled: true


### PR DESCRIPTION
Addresses #485. I've ensured the default value is empty so it doesn't override anything in config or existing `server.extraArgs` settings for smoother upgrades. The choice for `server.extraArgs` to take precedence if both are specified is somewhat arbitrary, except to make that precedence explicit. Happy to reverse that precedence if it would make more sense.