### PR TITLE
Add logLevel and logFormat values for Vault

### DIFF
--- a/templates/server-statefulset.yaml
+++ b/templates/server-statefulset.yaml
@@ -117,10 +117,14 @@ spec:
             {{- end }}
             - name: HOME
               value: "/home/vault"
+            {{- if .Values.server.logLevel }}
             - name: VAULT_LOG_LEVEL
               value: "{{ .Values.server.logLevel }}"
+            {{- end }}
+            {{- if .Values.server.logFormat }}
             - name: VAULT_LOG_FORMAT
               value: "{{ .Values.server.logFormat }}"
+            {{- end }}
             {{ template "vault.envs" . }}
             {{- include "vault.extraEnvironmentVars" .Values.server | nindent 12 }}
             {{- include "vault.extraSecretEnvironmentVars" .Values.server | nindent 12 }}

--- a/templates/server-statefulset.yaml
+++ b/templates/server-statefulset.yaml
@@ -117,6 +117,10 @@ spec:
             {{- end }}
             - name: HOME
               value: "/home/vault"
+            - name: VAULT_LOG_LEVEL
+              value: "{{ .Values.server.logLevel }}"
+            - name: VAULT_LOG_FORMAT
+              value: "{{ .Values.server.logFormat }}"
             {{ template "vault.envs" . }}
             {{- include "vault.extraEnvironmentVars" .Values.server | nindent 12 }}
             {{- include "vault.extraSecretEnvironmentVars" .Values.server | nindent 12 }}

--- a/test/unit/server-dev-statefulset.bats
+++ b/test/unit/server-dev-statefulset.bats
@@ -247,11 +247,11 @@ load _helpers
       yq -r '.spec.template.spec.containers[0].env' | tee /dev/stderr)
 
   local actual=$(echo $object |
-      yq -r '.[11].name' | tee /dev/stderr)
+      yq -r '.[13].name' | tee /dev/stderr)
   [ "${actual}" = "VAULT_DEV_ROOT_TOKEN_ID" ]
 
   local actual=$(echo $object |
-      yq -r '.[11].value' | tee /dev/stderr)
+      yq -r '.[13].value' | tee /dev/stderr)
   [ "${actual}" = "root" ]
 }
 
@@ -265,11 +265,11 @@ load _helpers
       yq -r '.spec.template.spec.containers[0].env' | tee /dev/stderr)
 
   local actual=$(echo $object |
-      yq -r '.[11].name' | tee /dev/stderr)
+      yq -r '.[13].name' | tee /dev/stderr)
   [ "${actual}" = "VAULT_DEV_ROOT_TOKEN_ID" ]
 
   local actual=$(echo $object |
-      yq -r '.[11].value' | tee /dev/stderr)
+      yq -r '.[13].value' | tee /dev/stderr)
   [ "${actual}" = "customtoken" ]
 }
 
@@ -341,25 +341,25 @@ load _helpers
       yq -r '.spec.template.spec.containers[0].env' | tee /dev/stderr)
 
   local actual=$(echo $object |
-      yq -r '.[11].name' | tee /dev/stderr)
+      yq -r '.[13].name' | tee /dev/stderr)
   [ "${actual}" = "ENV_FOO_0" ]
   local actual=$(echo $object |
-      yq -r '.[11].valueFrom.secretKeyRef.name' | tee /dev/stderr)
+      yq -r '.[13].valueFrom.secretKeyRef.name' | tee /dev/stderr)
   [ "${actual}" = "secret_name_0" ]
   local actual=$(echo $object |
-      yq -r '.[11].valueFrom.secretKeyRef.key' | tee /dev/stderr)
+      yq -r '.[13].valueFrom.secretKeyRef.key' | tee /dev/stderr)
   [ "${actual}" = "secret_key_0" ]
 
   local actual=$(echo $object |
-      yq -r '.[12].name' | tee /dev/stderr)
+      yq -r '.[14].name' | tee /dev/stderr)
   [ "${actual}" = "ENV_FOO_1" ]
 
   local actual=$(echo $object |
-      yq -r '.[12].valueFrom.secretKeyRef.name' | tee /dev/stderr)
+      yq -r '.[14].valueFrom.secretKeyRef.name' | tee /dev/stderr)
   [ "${actual}" = "secret_name_1" ]
 
   local actual=$(echo $object |
-      yq -r '.[12].valueFrom.secretKeyRef.key' | tee /dev/stderr)
+      yq -r '.[14].valueFrom.secretKeyRef.key' | tee /dev/stderr)
   [ "${actual}" = "secret_key_1" ]
 }
 

--- a/test/unit/server-dev-statefulset.bats
+++ b/test/unit/server-dev-statefulset.bats
@@ -246,13 +246,9 @@ load _helpers
       . | tee /dev/stderr |
       yq -r '.spec.template.spec.containers[0].env' | tee /dev/stderr)
 
-  local actual=$(echo $object |
-      yq -r '.[13].name' | tee /dev/stderr)
-  [ "${actual}" = "VAULT_DEV_ROOT_TOKEN_ID" ]
-
-  local actual=$(echo $object |
-      yq -r '.[13].value' | tee /dev/stderr)
-  [ "${actual}" = "root" ]
+  local name=$(echo $object |
+      yq -r 'map(select(.name=="VAULT_DEV_ROOT_TOKEN_ID")) | .[] .value' | tee /dev/stderr)
+  [ "${name}" = "root" ]
 }
 
 @test "server/dev-StatefulSet: set custom devRootToken" {
@@ -264,13 +260,9 @@ load _helpers
       . | tee /dev/stderr |
       yq -r '.spec.template.spec.containers[0].env' | tee /dev/stderr)
 
-  local actual=$(echo $object |
-      yq -r '.[13].name' | tee /dev/stderr)
-  [ "${actual}" = "VAULT_DEV_ROOT_TOKEN_ID" ]
-
-  local actual=$(echo $object |
-      yq -r '.[13].value' | tee /dev/stderr)
-  [ "${actual}" = "customtoken" ]
+  local name=$(echo $object |
+      yq -r 'map(select(.name=="VAULT_DEV_ROOT_TOKEN_ID")) | .[] .value' | tee /dev/stderr)
+  [ "${name}" = "customtoken" ]
 }
 
 #--------------------------------------------------------------------
@@ -340,27 +332,21 @@ load _helpers
       . | tee /dev/stderr |
       yq -r '.spec.template.spec.containers[0].env' | tee /dev/stderr)
 
-  local actual=$(echo $object |
-      yq -r '.[13].name' | tee /dev/stderr)
-  [ "${actual}" = "ENV_FOO_0" ]
-  local actual=$(echo $object |
-      yq -r '.[13].valueFrom.secretKeyRef.name' | tee /dev/stderr)
-  [ "${actual}" = "secret_name_0" ]
-  local actual=$(echo $object |
-      yq -r '.[13].valueFrom.secretKeyRef.key' | tee /dev/stderr)
-  [ "${actual}" = "secret_key_0" ]
+  local value=$(echo $object |
+      yq -r 'map(select(.name=="ENV_FOO_0")) | .[] .valueFrom.secretKeyRef.name' | tee /dev/stderr)
+  [ "${value}" = "secret_name_0" ]
 
-  local actual=$(echo $object |
-      yq -r '.[14].name' | tee /dev/stderr)
-  [ "${actual}" = "ENV_FOO_1" ]
+  local value=$(echo $object |
+      yq -r 'map(select(.name=="ENV_FOO_0")) | .[] .valueFrom.secretKeyRef.key' | tee /dev/stderr)
+  [ "${value}" = "secret_key_0" ]
 
-  local actual=$(echo $object |
-      yq -r '.[14].valueFrom.secretKeyRef.name' | tee /dev/stderr)
-  [ "${actual}" = "secret_name_1" ]
+  local value=$(echo $object |
+      yq -r 'map(select(.name=="ENV_FOO_1")) | .[] .valueFrom.secretKeyRef.name' | tee /dev/stderr)
+  [ "${value}" = "secret_name_1" ]
 
-  local actual=$(echo $object |
-      yq -r '.[14].valueFrom.secretKeyRef.key' | tee /dev/stderr)
-  [ "${actual}" = "secret_key_1" ]
+  local value=$(echo $object |
+      yq -r 'map(select(.name=="ENV_FOO_1")) | .[] .valueFrom.secretKeyRef.key' | tee /dev/stderr)
+  [ "${value}" = "secret_key_1" ]
 }
 
 #--------------------------------------------------------------------

--- a/test/unit/server-ha-statefulset.bats
+++ b/test/unit/server-ha-statefulset.bats
@@ -349,19 +349,19 @@ load _helpers
       yq -r '.spec.template.spec.containers[0].env' | tee /dev/stderr)
 
   local actual=$(echo $object |
-     yq -r '.[11].name' | tee /dev/stderr)
+     yq -r '.[13].name' | tee /dev/stderr)
   [ "${actual}" = "FOO" ]
 
   local actual=$(echo $object |
-      yq -r '.[11].value' | tee /dev/stderr)
+      yq -r '.[13].value' | tee /dev/stderr)
   [ "${actual}" = "bar" ]
 
   local actual=$(echo $object |
-      yq -r '.[12].name' | tee /dev/stderr)
+      yq -r '.[14].name' | tee /dev/stderr)
   [ "${actual}" = "FOOBAR" ]
 
   local actual=$(echo $object |
-      yq -r '.[12].value' | tee /dev/stderr)
+      yq -r '.[14].value' | tee /dev/stderr)
   [ "${actual}" = "foobar" ]
 }
 
@@ -383,23 +383,23 @@ load _helpers
       yq -r '.spec.template.spec.containers[0].env' | tee /dev/stderr)
 
   local actual=$(echo $object |
-      yq -r '.[11].name' | tee /dev/stderr)
+      yq -r '.[13].name' | tee /dev/stderr)
   [ "${actual}" = "ENV_FOO_0" ]
   local actual=$(echo $object |
-      yq -r '.[11].valueFrom.secretKeyRef.name' | tee /dev/stderr)
+      yq -r '.[13].valueFrom.secretKeyRef.name' | tee /dev/stderr)
   [ "${actual}" = "secret_name_0" ]
   local actual=$(echo $object |
-      yq -r '.[11].valueFrom.secretKeyRef.key' | tee /dev/stderr)
+      yq -r '.[13].valueFrom.secretKeyRef.key' | tee /dev/stderr)
   [ "${actual}" = "secret_key_0" ]
 
   local actual=$(echo $object |
-      yq -r '.[12].name' | tee /dev/stderr)
+      yq -r '.[14].name' | tee /dev/stderr)
   [ "${actual}" = "ENV_FOO_1" ]
   local actual=$(echo $object |
-      yq -r '.[12].valueFrom.secretKeyRef.name' | tee /dev/stderr)
+      yq -r '.[14].valueFrom.secretKeyRef.name' | tee /dev/stderr)
   [ "${actual}" = "secret_name_1" ]
   local actual=$(echo $object |
-      yq -r '.[12].valueFrom.secretKeyRef.key' | tee /dev/stderr)
+      yq -r '.[14].valueFrom.secretKeyRef.key' | tee /dev/stderr)
   [ "${actual}" = "secret_key_1" ]
 }
 

--- a/test/unit/server-ha-statefulset.bats
+++ b/test/unit/server-ha-statefulset.bats
@@ -70,14 +70,11 @@ load _helpers
       . | tee /dev/stderr |
       yq -r '.spec.template.spec.containers[0].env' | tee /dev/stderr)
 
-  local actual=$(echo $object |
-     yq -r '.[4].name' | tee /dev/stderr)
-  [ "${actual}" = "VAULT_ADDR" ]
-
-  local actual=$(echo $object |
-     yq -r '.[4].value' | tee /dev/stderr)
-  [ "${actual}" = "http://127.0.0.1:8200" ]
+  local value=$(echo $object |
+      yq -r 'map(select(.name=="VAULT_ADDR")) | .[] .value' | tee /dev/stderr)
+  [ "${value}" = "http://127.0.0.1:8200" ]
 }
+
 @test "server/ha-StatefulSet: tls enabled" {
   cd `chart_dir`
   local object=$(helm template \
@@ -86,13 +83,9 @@ load _helpers
       . | tee /dev/stderr |
       yq -r '.spec.template.spec.containers[0].env' | tee /dev/stderr)
 
-  local actual=$(echo $object |
-     yq -r '.[4].name' | tee /dev/stderr)
-  [ "${actual}" = "VAULT_ADDR" ]
-
-  local actual=$(echo $object |
-     yq -r '.[4].value' | tee /dev/stderr)
-  [ "${actual}" = "https://127.0.0.1:8200" ]
+  local value=$(echo $object |
+      yq -r 'map(select(.name=="VAULT_ADDR")) | .[] .value' | tee /dev/stderr)
+  [ "${value}" = "https://127.0.0.1:8200" ]
 }
 
 #--------------------------------------------------------------------
@@ -348,21 +341,13 @@ load _helpers
       . | tee /dev/stderr |
       yq -r '.spec.template.spec.containers[0].env' | tee /dev/stderr)
 
-  local actual=$(echo $object |
-     yq -r '.[13].name' | tee /dev/stderr)
-  [ "${actual}" = "FOO" ]
+  local value=$(echo $object |
+      yq -r 'map(select(.name=="FOO")) | .[] .value' | tee /dev/stderr)
+  [ "${value}" = "bar" ]
 
-  local actual=$(echo $object |
-      yq -r '.[13].value' | tee /dev/stderr)
-  [ "${actual}" = "bar" ]
-
-  local actual=$(echo $object |
-      yq -r '.[14].name' | tee /dev/stderr)
-  [ "${actual}" = "FOOBAR" ]
-
-  local actual=$(echo $object |
-      yq -r '.[14].value' | tee /dev/stderr)
-  [ "${actual}" = "foobar" ]
+  local value=$(echo $object |
+      yq -r 'map(select(.name=="FOOBAR")) | .[] .value' | tee /dev/stderr)
+  [ "${value}" = "foobar" ]
 }
 
 #--------------------------------------------------------------------
@@ -382,25 +367,21 @@ load _helpers
       . | tee /dev/stderr |
       yq -r '.spec.template.spec.containers[0].env' | tee /dev/stderr)
 
-  local actual=$(echo $object |
-      yq -r '.[13].name' | tee /dev/stderr)
-  [ "${actual}" = "ENV_FOO_0" ]
-  local actual=$(echo $object |
-      yq -r '.[13].valueFrom.secretKeyRef.name' | tee /dev/stderr)
-  [ "${actual}" = "secret_name_0" ]
-  local actual=$(echo $object |
-      yq -r '.[13].valueFrom.secretKeyRef.key' | tee /dev/stderr)
-  [ "${actual}" = "secret_key_0" ]
+  local value=$(echo $object |
+      yq -r 'map(select(.name=="ENV_FOO_0")) | .[] .valueFrom.secretKeyRef.name' | tee /dev/stderr)
+  [ "${value}" = "secret_name_0" ]
 
-  local actual=$(echo $object |
-      yq -r '.[14].name' | tee /dev/stderr)
-  [ "${actual}" = "ENV_FOO_1" ]
-  local actual=$(echo $object |
-      yq -r '.[14].valueFrom.secretKeyRef.name' | tee /dev/stderr)
-  [ "${actual}" = "secret_name_1" ]
-  local actual=$(echo $object |
-      yq -r '.[14].valueFrom.secretKeyRef.key' | tee /dev/stderr)
-  [ "${actual}" = "secret_key_1" ]
+  local value=$(echo $object |
+      yq -r 'map(select(.name=="ENV_FOO_0")) | .[] .valueFrom.secretKeyRef.key' | tee /dev/stderr)
+  [ "${value}" = "secret_key_0" ]
+
+  local value=$(echo $object |
+      yq -r 'map(select(.name=="ENV_FOO_1")) | .[] .valueFrom.secretKeyRef.name' | tee /dev/stderr)
+  [ "${value}" = "secret_name_1" ]
+
+  local value=$(echo $object |
+      yq -r 'map(select(.name=="ENV_FOO_1")) | .[] .valueFrom.secretKeyRef.key' | tee /dev/stderr)
+  [ "${value}" = "secret_key_1" ]
 }
 
 #--------------------------------------------------------------------
@@ -414,16 +395,12 @@ load _helpers
       . | tee /dev/stderr |
       yq -r '.spec.template.spec.containers[0].env' | tee /dev/stderr)
 
-  local actual=$(echo $object |
-     yq -r '.[5].name' | tee /dev/stderr)
-  [ "${actual}" = "VAULT_API_ADDR" ]
-
-  local actual=$(echo $object |
-     yq -r '.[5].value' | tee /dev/stderr)
-  [ "${actual}" = 'http://$(POD_IP):8200' ]
+  local value=$(echo $object |
+      yq -r 'map(select(.name=="VAULT_API_ADDR")) | .[] .value' | tee /dev/stderr)
+  [ "${value}" = 'http://$(POD_IP):8200' ]
 }
 
-@test "server/ha-StatefulSet: api addr can be overriden" {
+@test "server/ha-StatefulSet: api addr is configurable" {
   cd `chart_dir`
   local object=$(helm template \
       --show-only templates/server-statefulset.yaml  \
@@ -432,13 +409,9 @@ load _helpers
       . | tee /dev/stderr |
       yq -r '.spec.template.spec.containers[0].env' | tee /dev/stderr)
 
-  local actual=$(echo $object |
-     yq -r '.[5].name' | tee /dev/stderr)
-  [ "${actual}" = "VAULT_API_ADDR" ]
-
-  local actual=$(echo $object |
-     yq -r '.[5].value' | tee /dev/stderr)
-  [ "${actual}" = 'https://example.com:8200' ]
+  local value=$(echo $object |
+      yq -r 'map(select(.name=="VAULT_API_ADDR")) | .[] .value' | tee /dev/stderr)
+  [ "${value}" = "https://example.com:8200" ]
 }
 
 #--------------------------------------------------------------------
@@ -453,13 +426,9 @@ load _helpers
       . | tee /dev/stderr |
       yq -r '.spec.template.spec.containers[0].env' | tee /dev/stderr)
 
-  local actual=$(echo $object |
-     yq -r '.[9].name' | tee /dev/stderr)
-  [ "${actual}" = "VAULT_CLUSTER_ADDR" ]
-
-  local actual=$(echo $object |
-     yq -r '.[9].value' | tee /dev/stderr)
-  [ "${actual}" = 'https://$(HOSTNAME).RELEASE-NAME-vault-internal:8201' ]
+  local value=$(echo $object |
+      yq -r 'map(select(.name=="VAULT_CLUSTER_ADDR")) | .[] .value' | tee /dev/stderr)
+  [ "${value}" = 'https://$(HOSTNAME).RELEASE-NAME-vault-internal:8201' ]
 }
 
 #--------------------------------------------------------------------
@@ -475,13 +444,9 @@ load _helpers
       . | tee /dev/stderr |
       yq -r '.spec.template.spec.containers[0].env' | tee /dev/stderr)
 
-  local actual=$(echo $object |
-     yq -r '.[10].name' | tee /dev/stderr)
-  [ "${actual}" = "VAULT_RAFT_NODE_ID" ]
-
-  local actual=$(echo $object |
-     yq -r '.[10].valueFrom.fieldRef.fieldPath' | tee /dev/stderr)
-  [ "${actual}" = 'metadata.name' ]
+  local value=$(echo $object |
+      yq -r 'map(select(.name=="VAULT_RAFT_NODE_ID")) | .[] .valueFrom.fieldRef.fieldPath' | tee /dev/stderr)
+  [ "${value}" = "metadata.name" ]
 }
 
 #--------------------------------------------------------------------

--- a/test/unit/server-statefulset.bats
+++ b/test/unit/server-statefulset.bats
@@ -414,6 +414,78 @@ load _helpers
 }
 
 #--------------------------------------------------------------------
+# log level
+
+@test "server/standalone-StatefulSet: default log level to info" {
+  cd `chart_dir`
+  local object=$(helm template \
+      --show-only templates/server-statefulset.yaml  \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.containers[0].env' | tee /dev/stderr)
+
+  local actual=$(echo $object |
+     yq -r '.[11].name' | tee /dev/stderr)
+  [ "${actual}" = "VAULT_LOG_LEVEL" ]
+
+  local actual=$(echo $object |
+      yq -r '.[11].value' | tee /dev/stderr)
+  [ "${actual}" = "info" ]
+}
+
+@test "server/standalone-StatefulSet: log level can be changed" {
+  cd `chart_dir`
+  local object=$(helm template \
+      --show-only templates/server-statefulset.yaml  \
+      --set='server.logLevel=debug' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.containers[0].env' | tee /dev/stderr)
+
+  local actual=$(echo $object |
+     yq -r '.[11].name' | tee /dev/stderr)
+  [ "${actual}" = "VAULT_LOG_LEVEL" ]
+
+  local actual=$(echo $object |
+      yq -r '.[11].value' | tee /dev/stderr)
+  [ "${actual}" = "debug" ]
+}
+
+#--------------------------------------------------------------------
+# log format
+
+@test "server/standalone-StatefulSet: default log format to standard" {
+  cd `chart_dir`
+  local object=$(helm template \
+      --show-only templates/server-statefulset.yaml  \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.containers[0].env' | tee /dev/stderr)
+
+  local actual=$(echo $object |
+     yq -r '.[12].name' | tee /dev/stderr)
+  [ "${actual}" = "VAULT_LOG_FORMAT" ]
+
+  local actual=$(echo $object |
+      yq -r '.[12].value' | tee /dev/stderr)
+  [ "${actual}" = "standard" ]
+}
+
+@test "server/standalone-StatefulSet: default log format to standard" {
+  cd `chart_dir`
+  local object=$(helm template \
+      --show-only templates/server-statefulset.yaml  \
+      --set='server.logFormat=json' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.containers[0].env' | tee /dev/stderr)
+
+  local actual=$(echo $object |
+     yq -r '.[12].name' | tee /dev/stderr)
+  [ "${actual}" = "VAULT_LOG_FORMAT" ]
+
+  local actual=$(echo $object |
+      yq -r '.[12].value' | tee /dev/stderr)
+  [ "${actual}" = "json" ]
+}
+
+#--------------------------------------------------------------------
 # extraEnvironmentVars
 
 @test "server/standalone-StatefulSet: set extraEnvironmentVars" {

--- a/test/unit/server-statefulset.bats
+++ b/test/unit/server-statefulset.bats
@@ -418,35 +418,27 @@ load _helpers
 
 @test "server/standalone-StatefulSet: default log level to info" {
   cd `chart_dir`
-  local object=$(helm template \
+  local objects=$(helm template \
       --show-only templates/server-statefulset.yaml  \
       . | tee /dev/stderr |
       yq -r '.spec.template.spec.containers[0].env' | tee /dev/stderr)
 
-  local actual=$(echo $object |
-     yq -r '.[11].name' | tee /dev/stderr)
-  [ "${actual}" = "VAULT_LOG_LEVEL" ]
-
-  local actual=$(echo $object |
-      yq -r '.[11].value' | tee /dev/stderr)
-  [ "${actual}" = "info" ]
+  local value=$(echo $objects |
+      yq -r 'map(select(.name=="VAULT_LOG_LEVEL")) | .[] .name' | tee /dev/stderr)
+  [ "${value}" = "" ]
 }
 
 @test "server/standalone-StatefulSet: log level can be changed" {
   cd `chart_dir`
-  local object=$(helm template \
+  local objects=$(helm template \
       --show-only templates/server-statefulset.yaml  \
       --set='server.logLevel=debug' \
       . | tee /dev/stderr |
       yq -r '.spec.template.spec.containers[0].env' | tee /dev/stderr)
 
-  local actual=$(echo $object |
-     yq -r '.[11].name' | tee /dev/stderr)
-  [ "${actual}" = "VAULT_LOG_LEVEL" ]
-
-  local actual=$(echo $object |
-      yq -r '.[11].value' | tee /dev/stderr)
-  [ "${actual}" = "debug" ]
+  local value=$(echo $objects |
+      yq -r 'map(select(.name=="VAULT_LOG_LEVEL")) | .[] .value' | tee /dev/stderr)
+  [ "${value}" = "debug" ]
 }
 
 #--------------------------------------------------------------------
@@ -454,35 +446,27 @@ load _helpers
 
 @test "server/standalone-StatefulSet: default log format to standard" {
   cd `chart_dir`
-  local object=$(helm template \
+  local objects=$(helm template \
       --show-only templates/server-statefulset.yaml  \
       . | tee /dev/stderr |
       yq -r '.spec.template.spec.containers[0].env' | tee /dev/stderr)
 
-  local actual=$(echo $object |
-     yq -r '.[12].name' | tee /dev/stderr)
-  [ "${actual}" = "VAULT_LOG_FORMAT" ]
-
-  local actual=$(echo $object |
-      yq -r '.[12].value' | tee /dev/stderr)
-  [ "${actual}" = "standard" ]
+  local value=$(echo $objects |
+      yq -r 'map(select(.name=="VAULT_LOG_FORMAT")) | .[] .name' | tee /dev/stderr)
+  [ "${value}" = "" ]
 }
 
-@test "server/standalone-StatefulSet: default log format to standard" {
+@test "server/standalone-StatefulSet: can set log format" {
   cd `chart_dir`
-  local object=$(helm template \
+  local objects=$(helm template \
       --show-only templates/server-statefulset.yaml  \
       --set='server.logFormat=json' \
       . | tee /dev/stderr |
       yq -r '.spec.template.spec.containers[0].env' | tee /dev/stderr)
 
-  local actual=$(echo $object |
-     yq -r '.[12].name' | tee /dev/stderr)
-  [ "${actual}" = "VAULT_LOG_FORMAT" ]
-
-  local actual=$(echo $object |
-      yq -r '.[12].value' | tee /dev/stderr)
-  [ "${actual}" = "json" ]
+  local value=$(echo $objects |
+      yq -r 'map(select(.name=="VAULT_LOG_FORMAT")) | .[] .value' | tee /dev/stderr)
+  [ "${value}" = "json" ]
 }
 
 #--------------------------------------------------------------------
@@ -498,21 +482,13 @@ load _helpers
       . | tee /dev/stderr |
       yq -r '.spec.template.spec.containers[0].env' | tee /dev/stderr)
 
-  local actual=$(echo $object |
-     yq -r '.[13].name' | tee /dev/stderr)
-  [ "${actual}" = "FOO" ]
+  local name=$(echo $object |
+      yq -r 'map(select(.name=="FOO")) | .[] .value' | tee /dev/stderr)
+  [ "${name}" = "bar" ]
 
-  local actual=$(echo $object |
-      yq -r '.[13].value' | tee /dev/stderr)
-  [ "${actual}" = "bar" ]
-
-  local actual=$(echo $object |
-      yq -r '.[14].name' | tee /dev/stderr)
-  [ "${actual}" = "FOOBAR" ]
-
-  local actual=$(echo $object |
-      yq -r '.[14].value' | tee /dev/stderr)
-  [ "${actual}" = "foobar" ]
+  local name=$(echo $object |
+      yq -r 'map(select(.name=="FOOBAR")) | .[] .value' | tee /dev/stderr)
+  [ "${name}" = "foobar" ]
 
   local object=$(helm template \
       --show-only templates/server-statefulset.yaml  \
@@ -521,21 +497,13 @@ load _helpers
       . | tee /dev/stderr |
       yq -r '.spec.template.spec.containers[0].env' | tee /dev/stderr)
 
-  local actual=$(echo $object |
-     yq -r '.[13].name' | tee /dev/stderr)
-  [ "${actual}" = "FOO" ]
+  local name=$(echo $object |
+      yq -r 'map(select(.name=="FOO")) | .[] .value' | tee /dev/stderr)
+  [ "${name}" = "bar" ]
 
-  local actual=$(echo $object |
-      yq -r '.[13].value' | tee /dev/stderr)
-  [ "${actual}" = "bar" ]
-
-  local actual=$(echo $object |
-      yq -r '.[14].name' | tee /dev/stderr)
-  [ "${actual}" = "FOOBAR" ]
-
-  local actual=$(echo $object |
-      yq -r '.[14].value' | tee /dev/stderr)
-  [ "${actual}" = "foobar" ]
+  local name=$(echo $object |
+      yq -r 'map(select(.name=="FOOBAR")) | .[] .value' | tee /dev/stderr)
+  [ "${name}" = "foobar" ]
 }
 
 #--------------------------------------------------------------------

--- a/test/unit/server-statefulset.bats
+++ b/test/unit/server-statefulset.bats
@@ -416,7 +416,7 @@ load _helpers
 #--------------------------------------------------------------------
 # log level
 
-@test "server/standalone-StatefulSet: default log level to info" {
+@test "server/standalone-StatefulSet: default log level to empty" {
   cd `chart_dir`
   local objects=$(helm template \
       --show-only templates/server-statefulset.yaml  \

--- a/test/unit/server-statefulset.bats
+++ b/test/unit/server-statefulset.bats
@@ -444,7 +444,7 @@ load _helpers
 #--------------------------------------------------------------------
 # log format
 
-@test "server/standalone-StatefulSet: default log format to standard" {
+@test "server/standalone-StatefulSet: default log format to empty" {
   cd `chart_dir`
   local objects=$(helm template \
       --show-only templates/server-statefulset.yaml  \

--- a/test/unit/server-statefulset.bats
+++ b/test/unit/server-statefulset.bats
@@ -427,19 +427,19 @@ load _helpers
       yq -r '.spec.template.spec.containers[0].env' | tee /dev/stderr)
 
   local actual=$(echo $object |
-     yq -r '.[11].name' | tee /dev/stderr)
+     yq -r '.[13].name' | tee /dev/stderr)
   [ "${actual}" = "FOO" ]
 
   local actual=$(echo $object |
-      yq -r '.[11].value' | tee /dev/stderr)
+      yq -r '.[13].value' | tee /dev/stderr)
   [ "${actual}" = "bar" ]
 
   local actual=$(echo $object |
-      yq -r '.[12].name' | tee /dev/stderr)
+      yq -r '.[14].name' | tee /dev/stderr)
   [ "${actual}" = "FOOBAR" ]
 
   local actual=$(echo $object |
-      yq -r '.[12].value' | tee /dev/stderr)
+      yq -r '.[14].value' | tee /dev/stderr)
   [ "${actual}" = "foobar" ]
 
   local object=$(helm template \
@@ -450,19 +450,19 @@ load _helpers
       yq -r '.spec.template.spec.containers[0].env' | tee /dev/stderr)
 
   local actual=$(echo $object |
-     yq -r '.[11].name' | tee /dev/stderr)
+     yq -r '.[13].name' | tee /dev/stderr)
   [ "${actual}" = "FOO" ]
 
   local actual=$(echo $object |
-      yq -r '.[11].value' | tee /dev/stderr)
+      yq -r '.[13].value' | tee /dev/stderr)
   [ "${actual}" = "bar" ]
 
   local actual=$(echo $object |
-      yq -r '.[12].name' | tee /dev/stderr)
+      yq -r '.[14].name' | tee /dev/stderr)
   [ "${actual}" = "FOOBAR" ]
 
   local actual=$(echo $object |
-      yq -r '.[12].value' | tee /dev/stderr)
+      yq -r '.[14].value' | tee /dev/stderr)
   [ "${actual}" = "foobar" ]
 }
 

--- a/values.yaml
+++ b/values.yaml
@@ -62,7 +62,8 @@ injector:
   # Mount Path of the Vault Kubernetes Auth Method.
   authPath: "auth/kubernetes"
 
-  # Configures the log verbosity of the injector. Supported log levels: Trace, Debug, Error, Warn, Info
+  # Configures the log verbosity of the injector.
+  # Supported log levels include: trace, debug, warn, info, error
   logLevel: "info"
 
   # Configures the log format of the injector. Supported log formats: "standard", "json".
@@ -189,7 +190,7 @@ server:
   updateStrategyType: "OnDelete"
 
   # Configure the logging verbosity for the Vault server.
-  # Supported log levels include: trace, debug, error, warn, info
+  # Supported log levels include: trace, debug, warn, info, error
   logLevel: "info"
 
   # Configure the logging format for the Vault server.

--- a/values.yaml
+++ b/values.yaml
@@ -63,7 +63,7 @@ injector:
   authPath: "auth/kubernetes"
 
   # Configures the log verbosity of the injector.
-  # Supported log levels include: trace, debug, warn, info, error
+  # Supported log levels include: trace, debug, info, warn, error
   logLevel: "info"
 
   # Configures the log format of the injector. Supported log formats: "standard", "json".
@@ -190,7 +190,7 @@ server:
   updateStrategyType: "OnDelete"
 
   # Configure the logging verbosity for the Vault server.
-  # Supported log levels include: trace, debug, warn, info, error
+  # Supported log levels include: trace, debug, info, warn, error
   logLevel: "info"
 
   # Configure the logging format for the Vault server.

--- a/values.yaml
+++ b/values.yaml
@@ -191,11 +191,11 @@ server:
 
   # Configure the logging verbosity for the Vault server.
   # Supported log levels include: trace, debug, info, warn, error
-  logLevel: "info"
+  logLevel: ""
 
   # Configure the logging format for the Vault server.
   # Supported log formats include: standard, json
-  logFormat: "standard"
+  logFormat: ""
 
   resources: {}
   # resources:

--- a/values.yaml
+++ b/values.yaml
@@ -188,6 +188,14 @@ server:
   # See https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#update-strategies
   updateStrategyType: "OnDelete"
 
+  # Configure the logging verbosity for the Vault server.
+  # Supported log levels include: trace, debug, error, warn, info
+  logLevel: "info"
+
+  # Configure the logging format for the Vault server.
+  # Supported log formats include: standard, json
+  logFormat: "standard"
+
   resources: {}
   # resources:
   #   requests:


### PR DESCRIPTION
This PR exposes two Vault logging configurations (log level and log format) via explicit server values. These were always configurable in the Vault configuration files, however, these values make them easier to change.

Fixes #487.