### PR TITLE
Custom value of agent port 

### DIFF
--- a/templates/injector-deployment.yaml
+++ b/templates/injector-deployment.yaml
@@ -52,7 +52,7 @@ spec:
           {{- end }}
           env:
             - name: AGENT_INJECT_LISTEN
-              value: ":8080"
+              value: {{ printf ":%v" .Values.injector.port | default ":8080" }}
             - name: AGENT_INJECT_LOG_LEVEL
               value: {{ .Values.injector.logLevel | default "info" }}
             - name: AGENT_INJECT_VAULT_ADDR

--- a/templates/injector-deployment.yaml
+++ b/templates/injector-deployment.yaml
@@ -103,7 +103,7 @@ spec:
           livenessProbe:
             httpGet:
               path: /health/ready
-              port: 8080
+              port: {{ .Values.injector.port }}
               scheme: HTTPS
             failureThreshold: 2
             initialDelaySeconds: 5
@@ -113,7 +113,7 @@ spec:
           readinessProbe:
             httpGet:
               path: /health/ready
-              port: 8080
+              port: {{ .Values.injector.port }}
               scheme: HTTPS
             failureThreshold: 2
             initialDelaySeconds: 5

--- a/templates/injector-deployment.yaml
+++ b/templates/injector-deployment.yaml
@@ -52,7 +52,7 @@ spec:
           {{- end }}
           env:
             - name: AGENT_INJECT_LISTEN
-              value: {{ printf ":%v" .Values.injector.port | default ":8080" }}
+              value: {{ printf ":%v" .Values.injector.port  }}
             - name: AGENT_INJECT_LOG_LEVEL
               value: {{ .Values.injector.logLevel | default "info" }}
             - name: AGENT_INJECT_VAULT_ADDR

--- a/templates/injector-service.yaml
+++ b/templates/injector-service.yaml
@@ -12,7 +12,7 @@ metadata:
 spec:
   ports:
   - port: 443
-    targetPort: {{ .Values.injector.port | default "8080" }}
+    targetPort: {{ .Values.injector.port }}
   selector:
     app.kubernetes.io/name: {{ include "vault.name" . }}-agent-injector
     app.kubernetes.io/instance: {{ .Release.Name }}

--- a/templates/injector-service.yaml
+++ b/templates/injector-service.yaml
@@ -12,7 +12,7 @@ metadata:
 spec:
   ports:
   - port: 443
-    targetPort: 8080
+    targetPort: {{ .Values.injector.port | default "8080" }}
   selector:
     app.kubernetes.io/name: {{ include "vault.name" . }}-agent-injector
     app.kubernetes.io/instance: {{ .Release.Name }}

--- a/test/unit/injector-deployment.bats
+++ b/test/unit/injector-deployment.bats
@@ -423,6 +423,42 @@ load _helpers
 }
 
 #--------------------------------------------------------------------
+# agent port
+
+@test "injector/deployment: default agentPort" {
+  cd `chart_dir`
+  local object=$(helm template \
+      --show-only templates/injector-deployment.yaml  \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.containers[0].env' | tee /dev/stderr)
+
+  local actual=$(echo $object |
+     yq -r '.[0].name' | tee /dev/stderr)
+  [ "${actual}" = "AGENT_INJECT_LISTEN" ]
+
+  local actual=$(echo $object |
+      yq -r '.[0].value' | tee /dev/stderr)
+  [ "${actual}" = ":8080" ]
+}
+
+@test "injector/deployment: custom agentPort" {
+  cd `chart_dir`
+  local object=$(helm template \
+      --show-only templates/injector-deployment.yaml  \
+      --set 'injector.port=8443' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.containers[0].env' | tee /dev/stderr)
+
+  local actual=$(echo $object |
+     yq -r '.[0].name' | tee /dev/stderr)
+  [ "${actual}" = "AGENT_INJECT_LISTEN" ]
+
+  local actual=$(echo $object |
+      yq -r '.[0].value' | tee /dev/stderr)
+  [ "${actual}" = ":8443" ]
+}
+
+#--------------------------------------------------------------------
 # affinity
 
 @test "injector/deployment: affinity set by default" {

--- a/test/unit/injector-service.bats
+++ b/test/unit/injector-service.bats
@@ -18,6 +18,25 @@ load _helpers
   [ "${actual}" = "true" ]
 }
 
+@test "injector/Service: service with default port" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/injector-service.yaml \
+      . | tee /dev/stderr |
+       yq -r '.spec.ports[0].targetPort' | tee /dev/stderr)
+  [ "${actual}" = "8080" ]
+}
+
+@test "injector/Service: service with custom port" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/injector-service.yaml \
+      --set 'injector.port=8443' \
+      . | tee /dev/stderr |
+       yq -r '.spec.ports[0].targetPort' | tee /dev/stderr)
+  [ "${actual}" = "8443" ]
+}
+
 @test "injector/Service: disable with global.enabled false" {
   cd `chart_dir`
   local actual=$( (helm template \

--- a/values.yaml
+++ b/values.yaml
@@ -29,7 +29,7 @@ injector:
 
   replicas: 1
 
-  # Configures the port the agent should listen on
+  # Configures the port the injector should listen on
   port: 8080
 
   # If multiple replicas are specified, by default a leader-elector side-car

--- a/values.yaml
+++ b/values.yaml
@@ -29,6 +29,9 @@ injector:
 
   replicas: 1
 
+  # Configures the port the agent should listen on
+  port: 8080
+
   # If multiple replicas are specified, by default a leader-elector side-car
   # will be created so that only one injector attempts to create TLS certificates.
   leaderElector:


### PR DESCRIPTION
This PR allows users to set the different port of `AGENT_INJECT_LISTEN`, other than the default one.
Ref [issue](https://github.com/hashicorp/vault-k8s/issues/240)