### PR TITLE
Add container based tests documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -62,24 +62,23 @@ The unit tests don't require any active Kubernetes cluster and complete
 very quickly. These should be used for fast feedback during development.
 The acceptance tests require a Kubernetes cluster with a configured `kubectl`.
 
-### Test using Docker Container
-execute all commands from `vault-helm` directory  
-build test image
+### Test Using Docker Container
+
+The following are the instructions for running bats tests using a Docker container.
+
+#### Prerequisites
+
+* Docker installed
+* `vault-helm` checked out locally
+
+#### Test
+
+**Note:** the following commands should be run from the `vault-helm` directory.
+
+First, build the Docker image for running the tests:
+
 ```shell
 docker build -f ${PWD}/test/docker/Test.dockerfile ${PWD}/test/docker/ -t vault-helm-test
-```
-execute tests
-```shell
-docker run -it --rm -v "${PWD}:/test" vault-helm-test bats /test/test/unit
-```
-if you contribute to specific part, for example `injector` only, run only the tests matching a regular expression:
-```shell
-docker run -it --rm -v "${PWD}:/test" vault-helm-test bats /test/test/unit -f "injector"
-```
-
-### Test Manually
-#### Prequisites
-* [Bats](https://github.com/bats-core/bats-core)
   ```bash
   brew install bats-core
   ```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -62,7 +62,19 @@ The unit tests don't require any active Kubernetes cluster and complete
 very quickly. These should be used for fast feedback during development.
 The acceptance tests require a Kubernetes cluster with a configured `kubectl`.
 
-### Prequisites
+### Test using Docker Container
+execute all commands from `vault-helm` directory  
+build test image
+```shell
+docker build -f ${PWD}/test/docker/Test.dockerfile ${PWD}/test/docker/ -t vault-helm-test
+```
+execute tests
+```shell
+docker run -it --rm -v "${PWD}:/test" vault-helm-test bats /test/test/unit
+```
+
+### Test Manually
+#### Prequisites
 * [Bats](https://github.com/bats-core/bats-core)
   ```bash
   brew install bats-core
@@ -76,7 +88,7 @@ The acceptance tests require a Kubernetes cluster with a configured `kubectl`.
   brew install kubernetes-helm
   ```
 
-### Running The Tests
+#### Running The Tests
 
 To run the unit tests:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -72,6 +72,10 @@ execute tests
 ```shell
 docker run -it --rm -v "${PWD}:/test" vault-helm-test bats /test/test/unit
 ```
+if you contribute to specific part, for example `injector` only, run only the tests matching a regular expression:
+```shell
+docker run -it --rm -v "${PWD}:/test" vault-helm-test bats /test/test/unit -f "injector"
+```
 
 ### Test Manually
 #### Prequisites

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -91,7 +91,7 @@ docker build -f ${PWD}/test/docker/Test.dockerfile ${PWD}/test/docker/ -t vault-
   brew install kubernetes-helm
   ```
 
-#### Running The Tests
+#### Test
 
 To run the unit tests:
 

--- a/test/docker/Test.dockerfile
+++ b/test/docker/Test.dockerfile
@@ -9,7 +9,7 @@
 FROM docker.mirror.hashicorp.services/alpine:latest
 WORKDIR /root
 
-ENV BATS_VERSION "1.1.0"
+ENV BATS_VERSION "1.3.0"
 ENV TERRAFORM_VERSION "0.12.10"
 
 # base packages


### PR DESCRIPTION
While contributing to vault-helm project I was missing the container part for running tests (and actually wrote my own Dockerfile before noticed the one in the tests directory)

Thought it would be more clear if it was documented.
also, please update if there is an image contributors can pull instead of building locally.

in addition,
promoting `bats` version to `1.3.0` to add [flag to run only the tests matching a regular expression](https://github.com/bats-core/bats-core/pull/126)