### PR TITLE
Add injector agent default overrides

### DIFF
--- a/templates/injector-deployment.yaml
+++ b/templates/injector-deployment.yaml
@@ -97,6 +97,16 @@ spec:
                 fieldRef:
                   fieldPath: metadata.namespace
             {{- end }}
+            - name: AGENT_INJECT_CPU_REQUEST
+              value: "{{ .Values.injector.agentDefaults.cpuRequest }}"
+            - name: AGENT_INJECT_CPU_LIMIT
+              value: "{{ .Values.injector.agentDefaults.cpuLimit }}"
+            - name: AGENT_INJECT_MEM_REQUEST
+              value: "{{ .Values.injector.agentDefaults.memRequest }}"
+            - name: AGENT_INJECT_MEM_LIMIT
+              value: "{{ .Values.injector.agentDefaults.memLimit }}"
+            - name: AGENT_INJECT_DEFAULT_TEMPLATE
+              value: "{{ .Values.injector.agentDefaults.template }}"
             {{- include "vault.extraEnvironmentVars" .Values.injector | nindent 12 }}
           args:
             - agent-inject

--- a/test/unit/injector-deployment.bats
+++ b/test/unit/injector-deployment.bats
@@ -133,21 +133,13 @@ load _helpers
       . | tee /dev/stderr |
       yq -r '.spec.template.spec.containers[0].env' | tee /dev/stderr)
 
-  local actual=$(echo $object |
-     yq -r '.[5].name' | tee /dev/stderr)
-  [ "${actual}" = "AGENT_INJECT_TLS_CERT_FILE" ]
+  local value=$(echo $object |
+      yq -r 'map(select(.name=="AGENT_INJECT_TLS_CERT_FILE")) | .[] .value' | tee /dev/stderr)
+  [ "${value}" = "/etc/webhook/certs/test.crt" ]
 
-  local actual=$(echo $object |
-      yq -r '.[5].value' | tee /dev/stderr)
-  [ "${actual}" = "/etc/webhook/certs/test.crt" ]
-
-  local actual=$(echo $object |
-      yq -r '.[6].name' | tee /dev/stderr)
-  [ "${actual}" = "AGENT_INJECT_TLS_KEY_FILE" ]
-
-  local actual=$(echo $object |
-      yq -r '.[6].value' | tee /dev/stderr)
-  [ "${actual}" = "/etc/webhook/certs/test.key" ]
+  local value=$(echo $object |
+      yq -r 'map(select(.name=="AGENT_INJECT_TLS_KEY_FILE")) | .[] .value' | tee /dev/stderr)
+  [ "${value}" = "/etc/webhook/certs/test.key" ]
 }
 
 @test "injector/deployment: auto TLS by default" {
@@ -163,13 +155,13 @@ load _helpers
       . | tee /dev/stderr |
       yq -r '.spec.template.spec.containers[0].env' | tee /dev/stderr)
 
-  local actual=$(echo $object |
-     yq -r '.[5].name' | tee /dev/stderr)
-  [ "${actual}" = "AGENT_INJECT_TLS_AUTO" ]
+  local value=$(echo $object |
+      yq -r 'map(select(.name=="AGENT_INJECT_TLS_AUTO")) | .[] .name' | tee /dev/stderr)
+  [ "${value}" = "AGENT_INJECT_TLS_AUTO" ]
 
-  local actual=$(echo $object |
-      yq -r '.[6].name' | tee /dev/stderr)
-  [ "${actual}" = "AGENT_INJECT_TLS_AUTO_HOSTS" ]
+  local value=$(echo $object |
+      yq -r 'map(select(.name=="AGENT_INJECT_TLS_AUTO_HOSTS")) | .[] .name' | tee /dev/stderr)
+  [ "${value}" = "AGENT_INJECT_TLS_AUTO_HOSTS" ]
 }
 
 @test "injector/deployment: with externalVaultAddr" {
@@ -180,13 +172,9 @@ load _helpers
       . | tee /dev/stderr |
       yq -r '.spec.template.spec.containers[0].env' | tee /dev/stderr)
 
-  local actual=$(echo $object |
-     yq -r '.[2].name' | tee /dev/stderr)
-  [ "${actual}" = "AGENT_INJECT_VAULT_ADDR" ]
-
-  local actual=$(echo $object |
-      yq -r '.[2].value' | tee /dev/stderr)
-  [ "${actual}" = "http://vault-outside" ]
+  local value=$(echo $object |
+      yq -r 'map(select(.name=="AGENT_INJECT_VAULT_ADDR")) | .[] .value' | tee /dev/stderr)
+  [ "${value}" = "http://vault-outside" ]
 }
 
 @test "injector/deployment: without externalVaultAddr" {
@@ -198,13 +186,9 @@ load _helpers
       . | tee /dev/stderr |
       yq -r '.spec.template.spec.containers[0].env' | tee /dev/stderr)
 
-  local actual=$(echo $object |
-     yq -r '.[2].name' | tee /dev/stderr)
-  [ "${actual}" = "AGENT_INJECT_VAULT_ADDR" ]
-
-  local actual=$(echo $object |
-      yq -r '.[2].value' | tee /dev/stderr)
-  [ "${actual}" = "http://not-external-test-vault.default.svc:8200" ]
+  local value=$(echo $object |
+      yq -r 'map(select(.name=="AGENT_INJECT_VAULT_ADDR")) | .[] .value' | tee /dev/stderr)
+  [ "${value}" = "http://not-external-test-vault.default.svc:8200" ]
 }
 
 @test "injector/deployment: default authPath" {
@@ -214,13 +198,9 @@ load _helpers
       . | tee /dev/stderr |
       yq -r '.spec.template.spec.containers[0].env' | tee /dev/stderr)
 
-  local actual=$(echo $object |
-     yq -r '.[3].name' | tee /dev/stderr)
-  [ "${actual}" = "AGENT_INJECT_VAULT_AUTH_PATH" ]
-
-  local actual=$(echo $object |
-      yq -r '.[3].value' | tee /dev/stderr)
-  [ "${actual}" = "auth/kubernetes" ]
+  local value=$(echo $object |
+      yq -r 'map(select(.name=="AGENT_INJECT_VAULT_AUTH_PATH")) | .[] .value' | tee /dev/stderr)
+  [ "${value}" = "auth/kubernetes" ]
 }
 
 @test "injector/deployment: custom authPath" {
@@ -231,13 +211,9 @@ load _helpers
       . | tee /dev/stderr |
       yq -r '.spec.template.spec.containers[0].env' | tee /dev/stderr)
 
-  local actual=$(echo $object |
-     yq -r '.[3].name' | tee /dev/stderr)
-  [ "${actual}" = "AGENT_INJECT_VAULT_AUTH_PATH" ]
-
-  local actual=$(echo $object |
-      yq -r '.[3].value' | tee /dev/stderr)
-  [ "${actual}" = "auth/k8s" ]
+  local value=$(echo $object |
+      yq -r 'map(select(.name=="AGENT_INJECT_VAULT_AUTH_PATH")) | .[] .value' | tee /dev/stderr)
+  [ "${value}" = "auth/k8s" ]
 }
 
 @test "injector/deployment: default logLevel" {
@@ -247,13 +223,9 @@ load _helpers
       . | tee /dev/stderr |
       yq -r '.spec.template.spec.containers[0].env' | tee /dev/stderr)
 
-  local actual=$(echo $object |
-     yq -r '.[1].name' | tee /dev/stderr)
-  [ "${actual}" = "AGENT_INJECT_LOG_LEVEL" ]
-
-  local actual=$(echo $object |
-      yq -r '.[1].value' | tee /dev/stderr)
-  [ "${actual}" = "info" ]
+  local value=$(echo $object |
+      yq -r 'map(select(.name=="AGENT_INJECT_LOG_LEVEL")) | .[] .value' | tee /dev/stderr)
+  [ "${value}" = "info" ]
 }
 
 @test "injector/deployment: custom logLevel" {
@@ -264,13 +236,9 @@ load _helpers
       . | tee /dev/stderr |
       yq -r '.spec.template.spec.containers[0].env' | tee /dev/stderr)
 
-  local actual=$(echo $object |
-     yq -r '.[1].name' | tee /dev/stderr)
-  [ "${actual}" = "AGENT_INJECT_LOG_LEVEL" ]
-
-  local actual=$(echo $object |
-      yq -r '.[1].value' | tee /dev/stderr)
-  [ "${actual}" = "foo" ]
+  local value=$(echo $object |
+      yq -r 'map(select(.name=="AGENT_INJECT_LOG_LEVEL")) | .[] .value' | tee /dev/stderr)
+  [ "${value}" = "foo" ]
 }
 
 @test "injector/deployment: default logFormat" {
@@ -280,13 +248,9 @@ load _helpers
       . | tee /dev/stderr |
       yq -r '.spec.template.spec.containers[0].env' | tee /dev/stderr)
 
-  local actual=$(echo $object |
-     yq -r '.[7].name' | tee /dev/stderr)
-  [ "${actual}" = "AGENT_INJECT_LOG_FORMAT" ]
-
-  local actual=$(echo $object |
-      yq -r '.[7].value' | tee /dev/stderr)
-  [ "${actual}" = "standard" ]
+  local value=$(echo $object |
+      yq -r 'map(select(.name=="AGENT_INJECT_LOG_FORMAT")) | .[] .value' | tee /dev/stderr)
+  [ "${value}" = "standard" ]
 }
 
 @test "injector/deployment: custom logFormat" {
@@ -297,13 +261,9 @@ load _helpers
       . | tee /dev/stderr |
       yq -r '.spec.template.spec.containers[0].env' | tee /dev/stderr)
 
-  local actual=$(echo $object |
-     yq -r '.[7].name' | tee /dev/stderr)
-  [ "${actual}" = "AGENT_INJECT_LOG_FORMAT" ]
-
-  local actual=$(echo $object |
-      yq -r '.[7].value' | tee /dev/stderr)
-  [ "${actual}" = "json" ]
+  local value=$(echo $object |
+      yq -r 'map(select(.name=="AGENT_INJECT_LOG_FORMAT")) | .[] .value' | tee /dev/stderr)
+  [ "${value}" = "json" ]
 }
 
 @test "injector/deployment: default revoke on shutdown" {
@@ -313,13 +273,9 @@ load _helpers
       . | tee /dev/stderr |
       yq -r '.spec.template.spec.containers[0].env' | tee /dev/stderr)
 
-  local actual=$(echo $object |
-     yq -r '.[8].name' | tee /dev/stderr)
-  [ "${actual}" = "AGENT_INJECT_REVOKE_ON_SHUTDOWN" ]
-
-  local actual=$(echo $object |
-      yq -r '.[8].value' | tee /dev/stderr)
-  [ "${actual}" = "false" ]
+  local value=$(echo $object |
+      yq -r 'map(select(.name=="AGENT_INJECT_REVOKE_ON_SHUTDOWN")) | .[] .value' | tee /dev/stderr)
+  [ "${value}" = "false" ]
 }
 
 @test "injector/deployment: custom revoke on shutdown" {
@@ -330,13 +286,9 @@ load _helpers
       . | tee /dev/stderr |
       yq -r '.spec.template.spec.containers[0].env' | tee /dev/stderr)
 
-  local actual=$(echo $object |
-     yq -r '.[8].name' | tee /dev/stderr)
-  [ "${actual}" = "AGENT_INJECT_REVOKE_ON_SHUTDOWN" ]
-
-  local actual=$(echo $object |
-      yq -r '.[8].value' | tee /dev/stderr)
-  [ "${actual}" = "true" ]
+  local value=$(echo $object |
+      yq -r 'map(select(.name=="AGENT_INJECT_REVOKE_ON_SHUTDOWN")) | .[] .value' | tee /dev/stderr)
+  [ "${value}" = "true" ]
 }
 
 @test "injector/deployment: disable security context when openshift enabled" {
@@ -347,9 +299,9 @@ load _helpers
       . | tee /dev/stderr |
       yq -r '.spec.template.spec.containers[0].env' | tee /dev/stderr)
 
-  local actual=$(echo $object |
-    yq -r '.[9].name' | tee /dev/stderr)
-  [ "${actual}" = "AGENT_INJECT_SET_SECURITY_CONTEXT" ]
+  local value=$(echo $object |
+      yq -r 'map(select(.name=="AGENT_INJECT_SET_SECURITY_CONTEXT")) | .[] .name' | tee /dev/stderr)
+  [ "${value}" = "AGENT_INJECT_SET_SECURITY_CONTEXT" ]
 }
 
 #--------------------------------------------------------------------
@@ -365,29 +317,17 @@ load _helpers
       . | tee /dev/stderr |
       yq -r '.spec.template.spec.containers[0].env' | tee /dev/stderr)
 
-  local actual=$(echo $object |
-     yq -r '.[9].name' | tee /dev/stderr)
-  [ "${actual}" = "FOO" ]
+  local value=$(echo $object |
+      yq -r 'map(select(.name=="FOO")) | .[] .value' | tee /dev/stderr)
+  [ "${value}" = "bar" ]
 
-  local actual=$(echo $object |
-      yq -r '.[9].value' | tee /dev/stderr)
-  [ "${actual}" = "bar" ]
+  local value=$(echo $object |
+      yq -r 'map(select(.name=="FOOBAR")) | .[] .value' | tee /dev/stderr)
+  [ "${value}" = "foobar" ]
 
-  local actual=$(echo $object |
-      yq -r '.[10].name' | tee /dev/stderr)
-  [ "${actual}" = "FOOBAR" ]
-
-  local actual=$(echo $object |
-      yq -r '.[10].value' | tee /dev/stderr)
-  [ "${actual}" = "foobar" ]
-
-  local actual=$(echo $object |
-      yq -r '.[11].name' | tee /dev/stderr)
-  [ "${actual}" = "LOWER_CASE" ]
-
-  local actual=$(echo $object |
-      yq -r '.[11].value' | tee /dev/stderr)
-  [ "${actual}" = "sanitized" ]
+  local value=$(echo $object |
+      yq -r 'map(select(.name=="LOWER_CASE")) | .[] .value' | tee /dev/stderr)
+  [ "${value}" = "sanitized" ]
 }
 
 #--------------------------------------------------------------------
@@ -564,4 +504,81 @@ load _helpers
       . | tee /dev/stderr |
       yq -r '.spec.template.spec.hostNetwork' | tee /dev/stderr)
   [ "${actual}" = "true" ]
+}
+
+@test "injector/deployment: agent default resources" {
+  cd `chart_dir`
+  local object=$(helm template \
+      --show-only templates/injector-deployment.yaml  \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.containers[0].env' | tee /dev/stderr)
+
+  local value=$(echo $object |
+      yq -r 'map(select(.name=="AGENT_INJECT_CPU_LIMIT")) | .[] .value' | tee /dev/stderr)
+  [ "${value}" = "500m" ]
+
+  local value=$(echo $object |
+      yq -r 'map(select(.name=="AGENT_INJECT_CPU_REQUEST")) | .[] .value' | tee /dev/stderr)
+  [ "${value}" = "250m" ]
+
+  local value=$(echo $object |
+      yq -r 'map(select(.name=="AGENT_INJECT_MEM_LIMIT")) | .[] .value' | tee /dev/stderr)
+  [ "${value}" = "128Mi" ]
+
+  local value=$(echo $object |
+      yq -r 'map(select(.name=="AGENT_INJECT_MEM_REQUEST")) | .[] .value' | tee /dev/stderr)
+  [ "${value}" = "64Mi" ]
+}
+
+@test "injector/deployment: can set agent default resources" {
+  cd `chart_dir`
+  local object=$(helm template \
+      --show-only templates/injector-deployment.yaml  \
+      --set 'injector.agentDefaults.cpuLimit=cpuLimit' \
+      --set 'injector.agentDefaults.cpuRequest=cpuRequest' \
+      --set 'injector.agentDefaults.memLimit=memLimit' \
+      --set 'injector.agentDefaults.memRequest=memRequest' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.containers[0].env' | tee /dev/stderr)
+
+  local value=$(echo $object |
+      yq -r 'map(select(.name=="AGENT_INJECT_CPU_LIMIT")) | .[] .value' | tee /dev/stderr)
+  [ "${value}" = "cpuLimit" ]
+
+  local value=$(echo $object |
+      yq -r 'map(select(.name=="AGENT_INJECT_CPU_REQUEST")) | .[] .value' | tee /dev/stderr)
+  [ "${value}" = "cpuRequest" ]
+
+  local value=$(echo $object |
+      yq -r 'map(select(.name=="AGENT_INJECT_MEM_LIMIT")) | .[] .value' | tee /dev/stderr)
+  [ "${value}" = "memLimit" ]
+
+  local value=$(echo $object |
+      yq -r 'map(select(.name=="AGENT_INJECT_MEM_REQUEST")) | .[] .value' | tee /dev/stderr)
+  [ "${value}" = "memRequest" ]
+}
+
+@test "injector/deployment: agent default template" {
+  cd `chart_dir`
+  local object=$(helm template \
+      --show-only templates/injector-deployment.yaml  \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.containers[0].env' | tee /dev/stderr)
+
+  local value=$(echo $object |
+      yq -r 'map(select(.name=="AGENT_INJECT_DEFAULT_TEMPLATE")) | .[] .value' | tee /dev/stderr)
+  [ "${value}" = "map" ]
+}
+
+@test "injector/deployment: can set agent default template" {
+  cd `chart_dir`
+  local object=$(helm template \
+      --show-only templates/injector-deployment.yaml  \
+      --set='injector.agentDefaults.template=json' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.containers[0].env' | tee /dev/stderr)
+
+  local value=$(echo $object |
+      yq -r 'map(select(.name=="AGENT_INJECT_DEFAULT_TEMPLATE")) | .[] .value' | tee /dev/stderr)
+  [ "${value}" = "json" ]
 }

--- a/test/unit/injector-deployment.bats
+++ b/test/unit/injector-deployment.bats
@@ -300,8 +300,8 @@ load _helpers
       yq -r '.spec.template.spec.containers[0].env' | tee /dev/stderr)
 
   local value=$(echo $object |
-      yq -r 'map(select(.name=="AGENT_INJECT_SET_SECURITY_CONTEXT")) | .[] .name' | tee /dev/stderr)
-  [ "${value}" = "AGENT_INJECT_SET_SECURITY_CONTEXT" ]
+      yq -r 'map(select(.name=="AGENT_INJECT_SET_SECURITY_CONTEXT")) | .[] .value' | tee /dev/stderr)
+  [ "${value}" = "false" ]
 }
 
 #--------------------------------------------------------------------

--- a/test/unit/injector-deployment.bats
+++ b/test/unit/injector-deployment.bats
@@ -156,8 +156,8 @@ load _helpers
       yq -r '.spec.template.spec.containers[0].env' | tee /dev/stderr)
 
   local value=$(echo $object |
-      yq -r 'map(select(.name=="AGENT_INJECT_TLS_AUTO")) | .[] .name' | tee /dev/stderr)
-  [ "${value}" = "AGENT_INJECT_TLS_AUTO" ]
+      yq -r 'map(select(.name=="AGENT_INJECT_TLS_AUTO")) | .[] .value' | tee /dev/stderr)
+  [ "${value}" = "RELEASE-NAME-vault-agent-injector-cfg" ]
 
   local value=$(echo $object |
       yq -r 'map(select(.name=="AGENT_INJECT_TLS_AUTO_HOSTS")) | .[] .name' | tee /dev/stderr)

--- a/test/unit/injector-deployment.bats
+++ b/test/unit/injector-deployment.bats
@@ -160,8 +160,8 @@ load _helpers
   [ "${value}" = "RELEASE-NAME-vault-agent-injector-cfg" ]
 
   local value=$(echo $object |
-      yq -r 'map(select(.name=="AGENT_INJECT_TLS_AUTO_HOSTS")) | .[] .name' | tee /dev/stderr)
-  [ "${value}" = "AGENT_INJECT_TLS_AUTO_HOSTS" ]
+      yq -r 'map(select(.name=="AGENT_INJECT_TLS_AUTO_HOSTS")) | .[] .value' | tee /dev/stderr)
+  [ "${value}" = "RELEASE-NAME-vault-agent-injector-svc,RELEASE-NAME-vault-agent-injector-svc.default,RELEASE-NAME-vault-agent-injector-svc.default.svc" ]
 }
 
 @test "injector/deployment: with externalVaultAddr" {

--- a/values.yaml
+++ b/values.yaml
@@ -59,6 +59,19 @@ injector:
     repository: "vault"
     tag: "1.7.0"
 
+  # The default values for the injected Vault Agent containers.
+  agentDefaults:
+    # For more information on configuring resources, see the K8s documentation:
+    # https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+    cpuLimit: "500m"
+    cpuRequest: "250m"
+    memLimit: "128Mi"
+    memRequest: "64Mi"
+
+    # Default template type for secrets when no custom template is specified.
+    # Possible values include: "json" and "map".
+    template: "map"
+
   # Mount Path of the Vault Kubernetes Auth Method.
   authPath: "auth/kubernetes"
 


### PR DESCRIPTION
This PR adds the new Vault K8s agent default configurations for changing container resources and the default template. These haven't been released yet so testing will require compilation of Vault K8s.

I also cleaned up the environment variable tests which relied on array indexes. All environment variable tests now use map queries.