### PR TITLE
Fix injector unit test failing

### DIFF
--- a/test/unit/injector-deployment.bats
+++ b/test/unit/injector-deployment.bats
@@ -159,9 +159,13 @@ load _helpers
       yq -r 'map(select(.name=="AGENT_INJECT_TLS_AUTO")) | .[] .value' | tee /dev/stderr)
   [ "${value}" = "RELEASE-NAME-vault-agent-injector-cfg" ]
 
+  # helm template does uses current context namespace and ignores namespace flags, so
+  # discover the targeted namespace so we can check the rendered value correctly.
+  local namespace=$(kubectl config view --minify --output 'jsonpath={..namespace}')
+
   local value=$(echo $object |
       yq -r 'map(select(.name=="AGENT_INJECT_TLS_AUTO_HOSTS")) | .[] .value' | tee /dev/stderr)
-  [ "${value}" = "RELEASE-NAME-vault-agent-injector-svc,RELEASE-NAME-vault-agent-injector-svc.default,RELEASE-NAME-vault-agent-injector-svc.default.svc" ]
+  [ "${value}" = "RELEASE-NAME-vault-agent-injector-svc,RELEASE-NAME-vault-agent-injector-svc.${namespace?},RELEASE-NAME-vault-agent-injector-svc.${namespace?}.svc" ]
 }
 
 @test "injector/deployment: with externalVaultAddr" {

--- a/test/unit/injector-deployment.bats
+++ b/test/unit/injector-deployment.bats
@@ -162,11 +162,10 @@ load _helpers
   # helm template does uses current context namespace and ignores namespace flags, so
   # discover the targeted namespace so we can check the rendered value correctly.
   local namespace=$(kubectl config view --minify --output 'jsonpath={..namespace}')
-  [ "${namespace}" != "" ]
 
   local value=$(echo $object |
       yq -r 'map(select(.name=="AGENT_INJECT_TLS_AUTO_HOSTS")) | .[] .value' | tee /dev/stderr)
-  [ "${value}" = "RELEASE-NAME-vault-agent-injector-svc,RELEASE-NAME-vault-agent-injector-svc.${namespace?},RELEASE-NAME-vault-agent-injector-svc.${namespace?}.svc" ]
+  [ "${value}" = "RELEASE-NAME-vault-agent-injector-svc,RELEASE-NAME-vault-agent-injector-svc.${namespace:-default},RELEASE-NAME-vault-agent-injector-svc.${namespace:-default}.svc" ]
 }
 
 @test "injector/deployment: with externalVaultAddr" {

--- a/test/unit/injector-deployment.bats
+++ b/test/unit/injector-deployment.bats
@@ -162,6 +162,7 @@ load _helpers
   # helm template does uses current context namespace and ignores namespace flags, so
   # discover the targeted namespace so we can check the rendered value correctly.
   local namespace=$(kubectl config view --minify --output 'jsonpath={..namespace}')
+  [ "${namespace}" != "" ]
 
   local value=$(echo $object |
       yq -r 'map(select(.name=="AGENT_INJECT_TLS_AUTO_HOSTS")) | .[] .value' | tee /dev/stderr)


### PR DESCRIPTION
If your current `kubectl` context is set to a namespace other than `default`, this unit test will fail. Unfortunately `helm template` will not honor the namespace flag if set, so I added discovery to ensure the correct value no matter the namespace selected.