### PR TITLE
Update to v0.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+## 0.11.0 (April 14th, 2021)
+
 Features:
 * Added `server.enabled` to explicitly skip installing a Vault server [GH-486](https://github.com/hashicorp/vault-helm/pull/486)
 * Injector now supports enabling host network [GH-471](https://github.com/hashicorp/vault-helm/pull/471)

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: vault
-version: 0.10.0
+version: 0.11.0
 appVersion: 1.7.0
 description: Official HashiCorp Vault Chart
 home: https://www.vaultproject.io
@@ -10,3 +10,4 @@ sources:
   - https://github.com/hashicorp/vault
   - https://github.com/hashicorp/vault-helm
   - https://github.com/hashicorp/vault-k8s
+  - https://github.com/hashicorp/vault-csi-provider

--- a/values.yaml
+++ b/values.yaml
@@ -52,7 +52,7 @@ injector:
   # image sets the repo and tag of the vault-k8s image to use for the injector.
   image:
     repository: "hashicorp/vault-k8s"
-    tag: "0.9.0"
+    tag: "0.10.0"
     pullPolicy: IfNotPresent
 
   # agentImage sets the repo and tag of the Vault image to use for the Vault Agent
@@ -691,7 +691,7 @@ csi:
 
   image:
     repository: "hashicorp/vault-csi-provider"
-    tag: "0.1.0"
+    tag: "0.2.0"
     pullPolicy: IfNotPresent
 
   # volumes is a list of volumes made available to all containers. These are rendered


### PR DESCRIPTION
## Features
* Added `server.enabled` to explicitly skip installing a Vault server [GH-486](https://github.com/hashicorp/vault-helm/pull/486)
* Injector now supports enabling host network [GH-471](https://github.com/hashicorp/vault-helm/pull/471)
* Injector port is now configurable [GH-489](https://github.com/hashicorp/vault-helm/pull/489)
* Injector Vault Agent resource defaults are now configurable [GH-493](https://github.com/hashicorp/vault-helm/pull/493)
* Extra paths can now be added to the Vault ingress service [GH-460](https://github.com/hashicorp/vault-helm/pull/460)
* Log level and format can now be set directly using `server.logFormat` and `server.logLevel` [GH-488](https://github.com/hashicorp/vault-helm/pull/488)

## Improvements
* Added `https` name to injector service port [GH-495](https://github.com/hashicorp/vault-helm/pull/495)

## Bugs
* CSI: Fix ClusterRole name and DaemonSet's service account to properly match deployment name [GH-486](https://github.com/hashicorp/vault-helm/pull/486)