### PR TITLE
Adds ability to override cluster_addr

### DIFF
--- a/templates/server-statefulset.yaml
+++ b/templates/server-statefulset.yaml
@@ -107,8 +107,13 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.name
+            {{- if .Values.server.ha.clusterAddr }}
+            - name: VAULT_CLUSTER_ADDR
+              value: {{ .Values.server.ha.clusterAddr }}
+            {{- else }}
             - name: VAULT_CLUSTER_ADDR
               value: "https://$(HOSTNAME).{{ template "vault.fullname" . }}-internal:8201"
+            {{- end }}
             {{- if and (eq (.Values.server.ha.raft.enabled | toString) "true") (eq (.Values.server.ha.raft.setNodeId | toString) "true") }}
             - name: VAULT_RAFT_NODE_ID
               valueFrom:

--- a/values.yaml
+++ b/values.yaml
@@ -558,6 +558,12 @@ server:
     # If set to null, this will be set to the Pod IP Address
     apiAddr: null
 
+
+    # Set the cluster_addr configuration for Vault HA
+    # See https://www.vaultproject.io/docs/configuration#cluster_addr
+    # If set to null, this will be set to the Pod Hostname
+    clusterAddr: null
+
     # Enables Vault's integrated Raft storage.  Unlike the typical HA modes where
     # Vault's persistence is external (such as Consul), enabling Raft mode will create
     # persistent volumes for Vault to store data according to the configuration under server.dataStorage.


### PR DESCRIPTION
We have a use case where we're required to use `$(POD_IP)` over `$(HOSTNAME)` for `VAULT_CLUSTER_ADDR` environment variable. 

This change adds the ability to override this variable. 

The contribution guidelines don't define how chart versioning works with Pull Requests, but happy to amend the PR if you advise what you would like included. 

