### PR TITLE
Add server.extraLabels to the StatefulSet metadata in addition to its Pods

### DIFF
--- a/templates/server-statefulset.yaml
+++ b/templates/server-statefulset.yaml
@@ -11,6 +11,9 @@ metadata:
     app.kubernetes.io/name: {{ include "vault.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
+    {{- if  .Values.server.extraLabels -}}
+      {{- toYaml .Values.server.extraLabels | nindent 4 -}}
+    {{- end -}}
   {{- template "vault.statefulSet.annotations" . }}
 spec:
   serviceName: {{ template "vault.fullname" . }}-internal

--- a/test/unit/server-statefulset.bats
+++ b/test/unit/server-statefulset.bats
@@ -973,6 +973,13 @@ load _helpers
       . | tee /dev/stderr |
       yq -r '.spec.template.metadata.labels.foo' | tee /dev/stderr)
   [ "${actual}" = "bar" ]
+
+  local actual=$(helm template \
+      --show-only templates/server-statefulset.yaml \
+      --set 'server.extraLabels.foo=bar' \
+      . | tee /dev/stderr |
+      yq -r '.metadata.labels.foo' | tee /dev/stderr)
+  [ "${actual}" = "bar" ]
 }
 
 # extra annotations

--- a/values.yaml
+++ b/values.yaml
@@ -422,7 +422,7 @@ server:
   # Priority class for server pods
   priorityClassName: ""
 
-  # Extra labels to attach to the server pods
+  # Extra labels to attach to the server statefulset and pods
   # This should be a YAML map of the labels to apply to the server pods
   extraLabels: {}
 


### PR DESCRIPTION
We use OPA Gatekeeper to enforce some labels on all apps/v1 metadata and spec.template.metadata.

The vault helm chart was missing a way to add extra labels at the sts metadata levels.

In this PR I propose to reuse the `server.extraLabels` values for sts metadata labels, in addition to the existing sts pod spec metadata labels.

Other resources such as Ingress have directly `ingress.labels`, it's missing on Services. I haven't checked more, but this could be generalized and normalized (sometimes it's `labels`, other times `extraLabels`).