### PR TITLE
Support extra kubernetes resources on server Service and Ingress

### DIFF
--- a/templates/server-ingress.yaml
+++ b/templates/server-ingress.yaml
@@ -52,6 +52,10 @@ spec:
               servicePort: {{ $servicePort }}
         {{- end }}
   {{- end }}
+{{ if .Values.server.ingress.extraResources }}
+---
+{{- tpl .Values.server.ingress.extraResources . }}
+{{- end }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/templates/server-service.yaml
+++ b/templates/server-service.yaml
@@ -38,5 +38,9 @@ spec:
     app.kubernetes.io/name: {{ include "vault.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     component: server
+{{ if .Values.server.service.extraResources }}
+---
+{{- tpl .Values.server.service.extraResources . }}
+{{- end }}
 {{- end }}
 {{- end }}

--- a/values.yaml
+++ b/values.yaml
@@ -258,6 +258,27 @@ server:
     #    hosts:
     #      - chart-example.local
 
+    # Extra kubernetes resources needed by the Ingress. This is a YAML-formatted
+    # multi-line templated string.
+    # Example: ManagedCertificate on GKE (with external-dns)
+    # hostname: chart-example.local
+    # annotations: |-
+    #   external-dns.alpha.kubernetes.io/hostname: {{ .Values.server.ingress.hostname }}
+    #   networking.gke.io/managed-certificates: {{ template "vault.fullname" . }}-certificate
+    # extraResources: |-
+    #   apiVersion: networking.gke.io/v1beta1
+    #   kind: ManagedCertificate
+    #   metadata:
+    #     name: {{ template "vault.fullname" . }}-certificate
+    #     labels:
+    #       helm.sh/chart: {{ include "vault.chart" . }}
+    #       app.kubernetes.io/name: {{ include "vault.name" . }}
+    #       app.kubernetes.io/instance: {{ .Release.Name }}
+    #       app.kubernetes.io/managed-by: {{ .Release.Service }}
+    #   spec:
+    #     domains:
+    #       - {{ .Values.server.ingress.hostname }}
+
   # OpenShift only - create a route to expose the service
   # The created route will be of type passthrough
   route:
@@ -458,6 +479,29 @@ server:
     # YAML-formatted multi-line templated string map of the annotations to apply
     # to the service.
     annotations: {}
+
+    # Extra kubernetes resources needed by the Service. This is a YAML-formatted
+    # multi-line templated string.
+    # Example: BackendConfig on GKE
+    # annotations: |-
+    #   cloud.google.com/backend-config: '{"ports": {"8200":"{{ template "vault.fullname" . }}-bec"}}'
+    # extraResources: |-
+    #   apiVersion: cloud.google.com/v1
+    #   kind: BackendConfig
+    #   metadata:
+    #     name: {{ template "vault.fullname" . }}-bec
+    #     labels:
+    #       helm.sh/chart: {{ include "vault.chart" . }}
+    #       app.kubernetes.io/name: {{ include "vault.name" . }}
+    #       app.kubernetes.io/instance: {{ .Release.Name }}
+    #       app.kubernetes.io/managed-by: {{ .Release.Service }}
+    #   spec:
+    #     healthCheck:
+    #       checkIntervalSec: 5
+    #       timeoutSec: 3
+    #       port: 8200
+    #       type: HTTP
+    #       requestPath: /v1/sys/health?standbyok=true
 
   # This configures the Vault Statefulset to create a PVC for data
   # storage when using the file or raft backend storage engines.


### PR DESCRIPTION
Useful for GKE GCLB integration:
- backend configuration (Service level) to define GCLB Health Checks without touching
  exec-based Pod readinessProbe
- managed certificates (Ingress level) to define a GCP
  ManagedCertificate to be attached to the GCLB

Examples are shown in values.yml

GKE documentation: https://cloud.google.com/kubernetes-engine/docs/concepts/ingress

If this kind of feature is accepted, I will write some bats tests covering this.
