### PR TITLE
Fixing condition evaluation on `openshift` value

### DIFF
--- a/templates/server-statefulset.yaml
+++ b/templates/server-statefulset.yaml
@@ -46,7 +46,7 @@ spec:
       {{ if  .Values.server.shareProcessNamespace }}
       shareProcessNamespace: true
       {{ end }}
-      {{- if not .Values.global.openshift }}
+      {{- if .Values.global.openshift }}
       securityContext:
         runAsNonRoot: true
         runAsGroup: {{ .Values.server.gid | default 1000 }}


### PR DESCRIPTION
Removing errant `not` in `openshift: true` condition evaluation.