### PR TITLE
Ingress: match all hosts by omitting `host`

### DIFF
--- a/templates/server-ingress.yaml
+++ b/templates/server-ingress.yaml
@@ -39,7 +39,9 @@ spec:
 {{- end }}
   rules:
   {{- range .Values.server.ingress.hosts }}
-    - host: {{ .host | quote }}
+    - {{- if .host }}
+      host: {{ .host | quote }}
+      {{- end }}
       http:
         paths:
 {{ if $extraPaths }}

--- a/test/unit/server-ingress.bats
+++ b/test/unit/server-ingress.bats
@@ -43,6 +43,17 @@ load _helpers
   [ "${actual}" = '/' ]
 }
 
+@test "server/ingress: support ingress rule without host to match all hosts" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/server-ingress.yaml \
+      --set 'server.ingress.enabled=true' \
+      --set 'server.ingress.hosts[0].paths[0]=/' \
+      . | tee /dev/stderr |
+      yq  -r '.spec.rules[0].http.paths[0] | has("host")' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+}
+
 @test "server/ingress: vault backend should be added when I specify a path" {
   cd `chart_dir`
 


### PR DESCRIPTION
Previously, a `host` was mandatory, and `*` is not supported by kubernetes as it is an invalid domain name.

In kubernetes Ingress when the `host` is not specified in a rule, then it applies to all hosts of incoming requests: this PR adds support for that.

An alternate implementation could be to explicitly expose to helm values the `defaultBackend`.