### PR TITLE
match kubeVersion on semver pre-releases

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: vault
 version: 0.11.0
 appVersion: 1.7.0
-kubeVersion: ">= 1.14"
+kubeVersion: ">= 1.14.0-0"
 description: Official HashiCorp Vault Chart
 home: https://www.vaultproject.io
 icon: https://github.com/hashicorp/vault/raw/f22d202cde2018f9455dec755118a9b84586e082/Vault_PrimaryLogo_Black.png


### PR DESCRIPTION
Since clouds like GKE set their kubeVersion as a pre-release (e.g. v1.17.17-gke.6700).

See https://github.com/helm/helm/issues/3810 for details.