### PR TITLE
added values json schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Unreleased
 
+Improvements:
+* Set chart kubeVersion and added chart-verifier tests [GH-510](https://github.com/hashicorp/vault-helm/pull/510)
+
 ## 0.11.0 (April 14th, 2021)
 
 Features:

--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,10 @@ test-bats: test-unit test-acceptance
 
 test: test-image test-bats
 
+# Generate json schema for chart values. See test/README.md for more details.
+gen-values-schema:
+	helm schema-gen values.yaml > values.schema.json
+
 # run acceptance tests on GKE
 # set google project/credential vars above
 test-acceptance:

--- a/test/README.md
+++ b/test/README.md
@@ -21,3 +21,14 @@ Or if you'd rather use the latest chart-verifier docker container, set
 USE_DOCKER:
 
     USE_DOCKER=true bats test/chart/verifier.bats
+
+## Generating the values json schema
+
+There is a make target for generating values.schema.json:
+
+    make gen-values-schema
+
+It relies on the helm [schema-gen plugin][schema-gen]. Note that some manual
+editing will be required, since several properties accept multiple data types.
+
+[schema-gen]: https://github.com/karuppiah7890/helm-schema-gen

--- a/test/README.md
+++ b/test/README.md
@@ -1,4 +1,6 @@
-# Running Vault Helm Acceptance tests
+# vault-helm Tests
+
+## Running Vault Helm Acceptance tests
 
 The Makefile at the top level of this repo contains a few target that should help with running acceptance tests in your own GKE instance.
 
@@ -8,3 +10,14 @@ The Makefile at the top level of this repo contains a few target that should hel
 * Run `make test-acceptance` to run the acceptance tests in this already provisioned cluster.
 * You can choose to only run certain tests by setting the ACCEPTANCE_TESTS variable and re-running the above target.
 * Run `make test-destroy` when you have finished testing and want to tear-down and remove the cluster.
+
+## Running chart verification tests
+
+If [chart-verifier](https://github.com/redhat-certification/chart-verifier) is built and available in your PATH, run:
+
+    bats test/chart/verifier.bats
+
+Or if you'd rather use the latest chart-verifier docker container, set
+USE_DOCKER:
+
+    USE_DOCKER=true bats test/chart/verifier.bats

--- a/test/chart/verifier.bats
+++ b/test/chart/verifier.bats
@@ -61,6 +61,10 @@ teardown_file() {
     check_result contains-values
 }
 
+@test "contains-values-schema" {
+    check_result contains-values-schema
+}
+
 @test "images-are-certified" {
     skip "Skipping until this has been addressed"
     check_result images-are-certified
@@ -69,9 +73,4 @@ teardown_file() {
 @test "contains-test" {
     skip "Skipping until this has been addressed"
     check_result contains-test
-}
-
-@test "contains-values-schema" {
-    skip "Skipping until this has been addressed"
-    check_result contains-values-schema
 }

--- a/values.schema.json
+++ b/values.schema.json
@@ -1,0 +1,687 @@
+{
+    "$schema": "http://json-schema.org/schema#",
+    "type": "object",
+    "properties": {
+        "csi": {
+            "type": "object",
+            "properties": {
+                "daemonSet": {
+                    "type": "object",
+                    "properties": {
+                        "annotations": {
+                            "type": ["object", "string"]
+                        },
+                        "updateStrategy": {
+                            "type": "object",
+                            "properties": {
+                                "maxUnavailable": {
+                                    "type": "string"
+                                },
+                                "type": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
+                },
+                "debug": {
+                    "type": "boolean"
+                },
+                "enabled": {
+                    "type": "boolean"
+                },
+                "image": {
+                    "type": "object",
+                    "properties": {
+                        "pullPolicy": {
+                            "type": "string"
+                        },
+                        "repository": {
+                            "type": "string"
+                        },
+                        "tag": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "livenessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "failureThreshold": {
+                            "type": "integer"
+                        },
+                        "initialDelaySeconds": {
+                            "type": "integer"
+                        },
+                        "periodSeconds": {
+                            "type": "integer"
+                        },
+                        "successThreshold": {
+                            "type": "integer"
+                        },
+                        "timeoutSeconds": {
+                            "type": "integer"
+                        }
+                    }
+                },
+                "pod": {
+                    "type": "object",
+                    "properties": {
+                        "annotations": {
+                            "type": ["object", "string"]
+                        }
+                    }
+                },
+                "readinessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "failureThreshold": {
+                            "type": "integer"
+                        },
+                        "initialDelaySeconds": {
+                            "type": "integer"
+                        },
+                        "periodSeconds": {
+                            "type": "integer"
+                        },
+                        "successThreshold": {
+                            "type": "integer"
+                        },
+                        "timeoutSeconds": {
+                            "type": "integer"
+                        }
+                    }
+                },
+                "resources": {
+                    "type": "object"
+                },
+                "serviceAccount": {
+                    "type": "object",
+                    "properties": {
+                        "annotations": {
+                            "type": ["object", "string"]
+                        }
+                    }
+                },
+                "volumeMounts": {
+                    "type": ["null", "array"]
+                },
+                "volumes": {
+                    "type": ["null", "array"]
+                }
+            }
+        },
+        "global": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean"
+                },
+                "imagePullSecrets": {
+                    "type": "array"
+                },
+                "openshift": {
+                    "type": "boolean"
+                },
+                "psp": {
+                    "type": "object",
+                    "properties": {
+                        "annotations": {
+                            "type": ["object", "string"]
+                        },
+                        "enable": {
+                            "type": "boolean"
+                        }
+                    }
+                },
+                "tlsDisable": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "injector": {
+            "type": "object",
+            "properties": {
+                "affinity": {
+                    "type": "string"
+                },
+                "agentDefaults": {
+                    "type": "object",
+                    "properties": {
+                        "cpuLimit": {
+                            "type": "string"
+                        },
+                        "cpuRequest": {
+                            "type": "string"
+                        },
+                        "memLimit": {
+                            "type": "string"
+                        },
+                        "memRequest": {
+                            "type": "string"
+                        },
+                        "template": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "agentImage": {
+                    "type": "object",
+                    "properties": {
+                        "repository": {
+                            "type": "string"
+                        },
+                        "tag": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "annotations": {
+                    "type": ["object", "string"]
+                },
+                "authPath": {
+                    "type": "string"
+                },
+                "certs": {
+                    "type": "object",
+                    "properties": {
+                        "caBundle": {
+                            "type": "string"
+                        },
+                        "certName": {
+                            "type": "string"
+                        },
+                        "keyName": {
+                            "type": "string"
+                        },
+                        "secretName": {
+                            "type": ["null", "string"]
+                        }
+                    }
+                },
+                "enabled": {
+                    "type": "boolean"
+                },
+                "externalVaultAddr": {
+                    "type": "string"
+                },
+                "extraEnvironmentVars": {
+                    "type": "object"
+                },
+                "extraLabels": {
+                    "type": "object"
+                },
+                "failurePolicy": {
+                    "type": "string"
+                },
+                "hostNetwork": {
+                    "type": "boolean"
+                },
+                "image": {
+                    "type": "object",
+                    "properties": {
+                        "pullPolicy": {
+                            "type": "string"
+                        },
+                        "repository": {
+                            "type": "string"
+                        },
+                        "tag": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "leaderElector": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean"
+                        },
+                        "image": {
+                            "type": "object",
+                            "properties": {
+                                "repository": {
+                                    "type": "string"
+                                },
+                                "tag": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "ttl": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "logFormat": {
+                    "type": "string"
+                },
+                "logLevel": {
+                    "type": "string"
+                },
+                "metrics": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean"
+                        }
+                    }
+                },
+                "namespaceSelector": {
+                    "type": "object"
+                },
+                "nodeSelector": {
+                    "type": ["null", "string"]
+                },
+                "objectSelector": {
+                    "type": "object"
+                },
+                "port": {
+                    "type": "integer"
+                },
+                "priorityClassName": {
+                    "type": "string"
+                },
+                "replicas": {
+                    "type": "integer"
+                },
+                "resources": {
+                    "type": "object"
+                },
+                "revokeOnShutdown": {
+                    "type": "boolean"
+                },
+                "service": {
+                    "type": "object",
+                    "properties": {
+                        "annotations": {
+                            "type": ["object", "string"]
+                        }
+                    }
+                },
+                "tolerations": {
+                    "type": ["null", "string"]
+                }
+            }
+        },
+        "server": {
+            "type": "object",
+            "properties": {
+                "affinity": {
+                    "type": "string"
+                },
+                "annotations": {
+                    "type": ["object", "string"]
+                },
+                "auditStorage": {
+                    "type": "object",
+                    "properties": {
+                        "accessMode": {
+                            "type": "string"
+                        },
+                        "annotations": {
+                            "type": ["object", "string"]
+                        },
+                        "enabled": {
+                            "type": ["boolean", "string"]
+                        },
+                        "mountPath": {
+                            "type": "string"
+                        },
+                        "size": {
+                            "type": "string"
+                        },
+                        "storageClass": {
+                            "type": ["null", "string"]
+                        }
+                    }
+                },
+                "authDelegator": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean"
+                        }
+                    }
+                },
+                "dataStorage": {
+                    "type": "object",
+                    "properties": {
+                        "accessMode": {
+                            "type": "string"
+                        },
+                        "annotations": {
+                            "type": ["object", "string"]
+                        },
+                        "enabled": {
+                            "type": ["boolean", "string"]
+                        },
+                        "mountPath": {
+                            "type": "string"
+                        },
+                        "size": {
+                            "type": "string"
+                        },
+                        "storageClass": {
+                            "type": ["null", "string"]
+                        }
+                    }
+                },
+                "dev": {
+                    "type": "object",
+                    "properties": {
+                        "devRootToken": {
+                            "type": "string"
+                        },
+                        "enabled": {
+                            "type": "boolean"
+                        }
+                    }
+                },
+                "enabled": {
+                    "type": "boolean"
+                },
+                "extraArgs": {
+                    "type": "string"
+                },
+                "extraContainers": {
+                    "type": ["null", "array"]
+                },
+                "extraEnvironmentVars": {
+                    "type": "object"
+                },
+                "extraInitContainers": {
+                    "type": ["null", "array"]
+                },
+                "extraLabels": {
+                    "type": "object"
+                },
+                "extraSecretEnvironmentVars": {
+                    "type": "array"
+                },
+                "extraVolumes": {
+                    "type": "array"
+                },
+                "ha": {
+                    "type": "object",
+                    "properties": {
+                        "apiAddr": {
+                            "type": ["null", "string"]
+                        },
+                        "config": {
+                            "type": "string"
+                        },
+                        "disruptionBudget": {
+                            "type": "object",
+                            "properties": {
+                                "enabled": {
+                                    "type": "boolean"
+                                },
+                                "maxUnavailable": {
+                                    "type": "null"
+                                }
+                            }
+                        },
+                        "enabled": {
+                            "type": "boolean"
+                        },
+                        "raft": {
+                            "type": "object",
+                            "properties": {
+                                "config": {
+                                    "type": "string"
+                                },
+                                "enabled": {
+                                    "type": "boolean"
+                                },
+                                "setNodeId": {
+                                    "type": "boolean"
+                                }
+                            }
+                        },
+                        "replicas": {
+                            "type": "integer"
+                        }
+                    }
+                },
+                "image": {
+                    "type": "object",
+                    "properties": {
+                        "pullPolicy": {
+                            "type": "string"
+                        },
+                        "repository": {
+                            "type": "string"
+                        },
+                        "tag": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "ingress": {
+                    "type": "object",
+                    "properties": {
+                        "annotations": {
+                            "type": ["object", "string"]
+                        },
+                        "enabled": {
+                            "type": "boolean"
+                        },
+                        "extraPaths": {
+                            "type": "array"
+                        },
+                        "hosts": {
+                            "type": "array",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "host": {
+                                        "type": "string"
+                                    },
+                                    "paths": {
+                                        "type": "array"
+                                    }
+                                }
+                            }
+                        },
+                        "labels": {
+                            "type": "object"
+                        },
+                        "tls": {
+                            "type": "array"
+                        }
+                    }
+                },
+                "livenessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean"
+                        },
+                        "failureThreshold": {
+                            "type": "integer"
+                        },
+                        "initialDelaySeconds": {
+                            "type": "integer"
+                        },
+                        "path": {
+                            "type": "string"
+                        },
+                        "periodSeconds": {
+                            "type": "integer"
+                        },
+                        "successThreshold": {
+                            "type": "integer"
+                        },
+                        "timeoutSeconds": {
+                            "type": "integer"
+                        }
+                    }
+                },
+                "logFormat": {
+                    "type": "string"
+                },
+                "logLevel": {
+                    "type": "string"
+                },
+                "networkPolicy": {
+                    "type": "object",
+                    "properties": {
+                        "egress": {
+                            "type": "array"
+                        },
+                        "enabled": {
+                            "type": "boolean"
+                        }
+                    }
+                },
+                "nodeSelector": {
+                    "type": ["null", "string"]
+                },
+                "postStart": {
+                    "type": "array"
+                },
+                "preStopSleepSeconds": {
+                    "type": "integer"
+                },
+                "priorityClassName": {
+                    "type": "string"
+                },
+                "readinessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean"
+                        },
+                        "failureThreshold": {
+                            "type": "integer"
+                        },
+                        "initialDelaySeconds": {
+                            "type": "integer"
+                        },
+                        "periodSeconds": {
+                            "type": "integer"
+                        },
+                        "successThreshold": {
+                            "type": "integer"
+                        },
+                        "timeoutSeconds": {
+                            "type": "integer"
+                        }
+                    }
+                },
+                "resources": {
+                    "type": "object"
+                },
+                "route": {
+                    "type": "object",
+                    "properties": {
+                        "annotations": {
+                            "type": ["object", "string"]
+                        },
+                        "enabled": {
+                            "type": "boolean"
+                        },
+                        "host": {
+                            "type": "string"
+                        },
+                        "labels": {
+                            "type": "object"
+                        }
+                    }
+                },
+                "service": {
+                    "type": "object",
+                    "properties": {
+                        "annotations": {
+                            "type": ["object", "string"]
+                        },
+                        "enabled": {
+                            "type": "boolean"
+                        },
+                        "port": {
+                            "type": "integer"
+                        },
+                        "targetPort": {
+                            "type": "integer"
+                        }
+                    }
+                },
+                "serviceAccount": {
+                    "type": "object",
+                    "properties": {
+                        "annotations": {
+                            "type": ["object", "string"]
+                        },
+                        "create": {
+                            "type": "boolean"
+                        },
+                        "name": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "shareProcessNamespace": {
+                    "type": "boolean"
+                },
+                "standalone": {
+                    "type": "object",
+                    "properties": {
+                        "config": {
+                            "type": "string"
+                        },
+                        "enabled": {
+                            "type": ["string", "boolean"]
+                        }
+                    }
+                },
+                "statefulSet": {
+                    "type": "object",
+                    "properties": {
+                        "annotations": {
+                            "type": ["object", "string"]
+                        }
+                    }
+                },
+                "tolerations": {
+                    "type": ["null", "string"]
+                },
+                "updateStrategyType": {
+                    "type": "string"
+                },
+                "volumeMounts": {
+                    "type": ["null", "array"]
+                },
+                "volumes": {
+                    "type": ["null", "array"]
+                }
+            }
+        },
+        "ui": {
+            "type": "object",
+            "properties": {
+                "activeVaultPodOnly": {
+                    "type": "boolean"
+                },
+                "annotations": {
+                    "type": ["object", "string"]
+                },
+                "enabled": {
+                    "type": "boolean"
+                },
+                "externalPort": {
+                    "type": "integer"
+                },
+                "publishNotReadyAddresses": {
+                    "type": "boolean"
+                },
+                "serviceNodePort": {
+                    "type": "null"
+                },
+                "serviceType": {
+                    "type": "string"
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Generated the schema using the helm [schema-gen plugin](https://github.com/karuppiah7890/helm-schema-gen), and added extra data types to fields that allow it, such as annotations, tolerations, enabled, etc. Also enables the "contains-value-schema" chart-verifier test. Added a blurb to the test readme about running the chart-verifier tests.