### PR TITLE
use namespace in the name of cluster-wide resource

### DIFF
--- a/templates/csi-clusterrole.yaml
+++ b/templates/csi-clusterrole.yaml
@@ -2,7 +2,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: {{ template "vault.fullname" . }}-csi-provider-clusterrole
+  name: {{ template "vault.fullname" . }}-{{ .Release.Namespace }}-csi-provider-clusterrole
   labels:
     app.kubernetes.io/name: {{ include "vault.name" . }}-csi-provider
     app.kubernetes.io/instance: {{ .Release.Name }}

--- a/templates/csi-clusterrolebinding.yaml
+++ b/templates/csi-clusterrolebinding.yaml
@@ -2,7 +2,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: {{ template "vault.fullname" . }}-csi-provider-clusterrolebinding
+  name: {{ template "vault.fullname" . }}-{{ .Release.Namespace }}-csi-provider-clusterrolebinding
   labels:
     app.kubernetes.io/name: {{ include "vault.name" . }}-csi-provider
     app.kubernetes.io/instance: {{ .Release.Name }}
@@ -10,7 +10,7 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: {{ template "vault.fullname" . }}-csi-provider-clusterrole
+  name: {{ template "vault.fullname" . }}-{{ .Release.Namespace }}-csi-provider-clusterrole
 subjects:
 - kind: ServiceAccount
   name: {{ template "vault.fullname" . }}-csi-provider

--- a/templates/injector-clusterrole.yaml
+++ b/templates/injector-clusterrole.yaml
@@ -2,7 +2,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: {{ template "vault.fullname" . }}-agent-injector-clusterrole
+  name: {{ template "vault.fullname" . }}-{{ .Release.Namespace }}-agent-injector-clusterrole
   labels:
     app.kubernetes.io/name: {{ include "vault.name" . }}-agent-injector
     app.kubernetes.io/instance: {{ .Release.Name }}
@@ -10,7 +10,7 @@ metadata:
 rules:
 - apiGroups: ["admissionregistration.k8s.io"]
   resources: ["mutatingwebhookconfigurations"]
-  verbs: 
+  verbs:
     - "get"
     - "list"
     - "watch"

--- a/templates/injector-clusterrolebinding.yaml
+++ b/templates/injector-clusterrolebinding.yaml
@@ -2,7 +2,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: {{ template "vault.fullname" . }}-agent-injector-binding
+  name: {{ template "vault.fullname" . }}-{{ .Release.Namespace }}-agent-injector-binding
   labels:
     app.kubernetes.io/name: {{ include "vault.name" . }}-agent-injector
     app.kubernetes.io/instance: {{ .Release.Name }}
@@ -10,7 +10,7 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: {{ template "vault.fullname" . }}-agent-injector-clusterrole
+  name: {{ template "vault.fullname" . }}-{{ .Release.Namespace }}-agent-injector-clusterrole
 subjects:
 - kind: ServiceAccount
   name: {{ template "vault.fullname" . }}-agent-injector

--- a/templates/server-clusterrolebinding.yaml
+++ b/templates/server-clusterrolebinding.yaml
@@ -7,7 +7,7 @@ apiVersion: rbac.authorization.k8s.io/v1beta1
 {{- end }}
 kind: ClusterRoleBinding
 metadata:
-  name: {{ template "vault.fullname" . }}-server-binding
+  name: {{ template "vault.fullname" . }}-{{ .Release.Namespace }}-server-binding
   labels:
     helm.sh/chart: {{ include "vault.chart" . }}
     app.kubernetes.io/name: {{ include "vault.name" . }}

--- a/test/unit/csi-clusterrole.bats
+++ b/test/unit/csi-clusterrole.bats
@@ -29,5 +29,17 @@ load _helpers
       --set "csi.enabled=true" \
       . | tee /dev/stderr |
       yq -r '.metadata.name' | tee /dev/stderr)
-  [ "${actual}" = "RELEASE-NAME-vault-csi-provider-clusterrole" ]
+  [ "${actual}" = "RELEASE-NAME-vault-default-csi-provider-clusterrole" ]
+}
+
+# ClusterRole name in custom namespace
+@test "csi/ClusterRole: name in custom namespace" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --namespace my-custom-namespace \
+      --show-only templates/csi-clusterrole.yaml \
+      --set "csi.enabled=true" \
+      . | tee /dev/stderr |
+      yq -r '.metadata.name' | tee /dev/stderr)
+  [ "${actual}" = "RELEASE-NAME-vault-my-custom-namespace-csi-provider-clusterrole" ]
 }

--- a/test/unit/csi-clusterrolebinding.bats
+++ b/test/unit/csi-clusterrolebinding.bats
@@ -15,10 +15,33 @@ load _helpers
   cd `chart_dir`
   local actual=$(helm template \
       --show-only templates/csi-clusterrolebinding.yaml  \
-      --set 'csi.enabled=true' \
+      --set "csi.enabled=true" \
       . | tee /dev/stderr |
       yq 'length > 0' | tee /dev/stderr)
   [ "${actual}" = "true" ]
+}
+
+# ClusterRoleBinding name
+@test "csi/ClusterRoleBinding: name" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/csi-clusterrolebinding.yaml \
+      --set "csi.enabled=true" \
+      . | tee /dev/stderr |
+      yq -r '.metadata.name' | tee /dev/stderr)
+  [ "${actual}" = "RELEASE-NAME-vault-default-csi-provider-clusterrolebinding" ]
+}
+
+# ClusterRoleBinding name in custom namespace
+@test "csi/ClusterRoleBinding: name in custom namespace" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --namespace my-custom-namespace \
+      --show-only templates/csi-clusterrolebinding.yaml \
+      --set "csi.enabled=true" \
+      . | tee /dev/stderr |
+      yq -r '.metadata.name' | tee /dev/stderr)
+  [ "${actual}" = "RELEASE-NAME-vault-my-custom-namespace-csi-provider-clusterrolebinding" ]
 }
 
 # ClusterRoleBinding cluster role ref name
@@ -29,7 +52,19 @@ load _helpers
       --set "csi.enabled=true" \
       . | tee /dev/stderr |
       yq -r '.roleRef.name' | tee /dev/stderr)
-  [ "${actual}" = "RELEASE-NAME-vault-csi-provider-clusterrole" ]
+  [ "${actual}" = "RELEASE-NAME-vault-default-csi-provider-clusterrole" ]
+}
+
+# ClusterRoleBinding cluster role ref name in custom namespace
+@test "csi/ClusterRoleBinding: cluster role ref name in custom namespace" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --namespace my-custom-namespace \
+      --show-only templates/csi-clusterrolebinding.yaml \
+      --set "csi.enabled=true" \
+      . | tee /dev/stderr |
+      yq -r '.roleRef.name' | tee /dev/stderr)
+  [ "${actual}" = "RELEASE-NAME-vault-my-custom-namespace-csi-provider-clusterrole" ]
 }
 
 # ClusterRoleBinding service account name

--- a/test/unit/injector-clusterrole.bats
+++ b/test/unit/injector-clusterrole.bats
@@ -20,3 +20,24 @@ load _helpers
       yq 'length > 0' | tee /dev/stderr)
   [ "${actual}" = "false" ]
 }
+
+# ClusterRole name
+@test "injector/ClusterRole: name" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/injector-clusterrole.yaml \
+      . | tee /dev/stderr |
+      yq -r '.metadata.name' | tee /dev/stderr)
+  [ "${actual}" = "RELEASE-NAME-vault-default-agent-injector-clusterrole" ]
+}
+
+# ClusterRole name in custom namespace
+@test "injector/ClusterRole: name in custom namespace" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --namespace my-custom-namespace \
+      --show-only templates/injector-clusterrole.yaml \
+      . | tee /dev/stderr |
+      yq -r '.metadata.name' | tee /dev/stderr)
+  [ "${actual}" = "RELEASE-NAME-vault-my-custom-namespace-agent-injector-clusterrole" ]
+}

--- a/test/unit/injector-clusterrolebinding.bats
+++ b/test/unit/injector-clusterrolebinding.bats
@@ -20,3 +20,45 @@ load _helpers
       yq 'length > 0' | tee /dev/stderr)
   [ "${actual}" = "false" ]
 }
+
+# ClusterRole name
+@test "injector/ClusterRoleBinding: name" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/injector-clusterrolebinding.yaml \
+      . | tee /dev/stderr |
+      yq -r '.metadata.name' | tee /dev/stderr)
+  [ "${actual}" = "RELEASE-NAME-vault-default-agent-injector-binding" ]
+}
+
+# ClusterRole name in custom namespace
+@test "injector/ClusterRoleBinding: name in custom namespace" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --namespace my-custom-namespace \
+      --show-only templates/injector-clusterrolebinding.yaml \
+      . | tee /dev/stderr |
+      yq -r '.metadata.name' | tee /dev/stderr)
+  [ "${actual}" = "RELEASE-NAME-vault-my-custom-namespace-agent-injector-binding" ]
+}
+
+# ClusterRoleBinding cluster role ref name
+@test "injector/ClusterRoleBinding: cluster role ref name" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/injector-clusterrolebinding.yaml \
+      . | tee /dev/stderr |
+      yq -r '.roleRef.name' | tee /dev/stderr)
+  [ "${actual}" = "RELEASE-NAME-vault-default-agent-injector-clusterrole" ]
+}
+
+# ClusterRoleBinding cluster role ref name in custom namespace
+@test "injector/ClusterRoleBinding: cluster role ref name in custom namespace" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --namespace my-custom-namespace \
+      --show-only templates/injector-clusterrolebinding.yaml \
+      . | tee /dev/stderr |
+      yq -r '.roleRef.name' | tee /dev/stderr)
+  [ "${actual}" = "RELEASE-NAME-vault-my-custom-namespace-agent-injector-clusterrole" ]
+}

--- a/test/unit/server-clusterrolebinding.bats
+++ b/test/unit/server-clusterrolebinding.bats
@@ -35,6 +35,27 @@ load _helpers
   [ "${actual}" = "false" ]
 }
 
+# ClusterRole name
+@test "server/ClusterRoleBinding: name" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/server-clusterrolebinding.yaml \
+      . | tee /dev/stderr |
+      yq -r '.metadata.name' | tee /dev/stderr)
+  [ "${actual}" = "RELEASE-NAME-vault-default-server-binding" ]
+}
+
+# ClusterRole name in custom namespace
+@test "server/ClusterRoleBinding: name in custom namespace" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --namespace my-custom-namespace \
+      --show-only templates/server-clusterrolebinding.yaml \
+      . | tee /dev/stderr |
+      yq -r '.metadata.name' | tee /dev/stderr)
+  [ "${actual}" = "RELEASE-NAME-vault-my-custom-namespace-server-binding" ]
+}
+
 @test "server/ClusterRoleBinding: can disable with server.authDelegator" {
   cd `chart_dir`
   local actual=$( (helm template \


### PR DESCRIPTION
  .. to avoid resource name collision without having to override full name,
  or change·release name, or use other name overrides

Signed-off-by: Anastas Dancha <anapsix@random.io>

first solution I've mentioned in #249