### PR TITLE
Add extraArgs value for CSI

### DIFF
--- a/templates/csi-daemonset.yaml
+++ b/templates/csi-daemonset.yaml
@@ -37,6 +37,9 @@ spec:
           args:
             - --endpoint=/provider/vault.sock
             - --debug={{ .Values.csi.debug }}
+            {{- if .Values.csi.extraArgs }}
+              {{- toYaml .Values.csi.extraArgs | nindent 12 }}
+            {{- end }}
           volumeMounts:
             - name: providervol
               mountPath: "/provider"

--- a/test/unit/csi-daemonset.bats
+++ b/test/unit/csi-daemonset.bats
@@ -110,6 +110,36 @@ load _helpers
   [ "${actual}" = "--debug=true" ]
 }
 
+# Extra args
+@test "csi/daemonset: extra args can be passed" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/csi-daemonset.yaml \
+      --set "csi.enabled=true" \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.containers[0].args | length' | tee /dev/stderr)
+  [ "${actual}" = "2" ]
+
+  local object=$(helm template \
+      --show-only templates/csi-daemonset.yaml \
+      --set "csi.enabled=true" \
+      --set "csi.extraArgs={--foo=bar,--bar baz,first}" \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.containers[0]')
+  local actual=$(echo $object |
+      yq -r '.args | length' | tee /dev/stderr)
+  [ "${actual}" = "5" ]
+  local actual=$(echo $object |
+      yq -r '.args[2]' | tee /dev/stderr)
+  [ "${actual}" = "--foo=bar" ]
+  local actual=$(echo $object |
+      yq -r '.args[3]' | tee /dev/stderr)
+  [ "${actual}" = "--bar baz" ]
+  local actual=$(echo $object |
+      yq -r '.args[4]' | tee /dev/stderr)
+  [ "${actual}" = "first" ]
+}
+
 # updateStrategy
 @test "csi/daemonset: updateStrategy is configurable" {
   cd `chart_dir`

--- a/values.schema.json
+++ b/values.schema.json
@@ -30,6 +30,9 @@
                 "enabled": {
                     "type": "boolean"
                 },
+                "extraArgs": {
+                    "type": "array"
+                },
                 "image": {
                     "type": "object",
                     "properties": {

--- a/values.yaml
+++ b/values.yaml
@@ -773,3 +773,6 @@ csi:
 
   # Enables debug logging.
   debug: false
+
+  # Pass arbitrary additional arguments to vault-csi-provider.
+  extraArgs: []


### PR DESCRIPTION
The helm chart does not currently support configuring the more obscure flags in vault-csi-provider.

Additionally, as features like https://github.com/hashicorp/vault-csi-provider/pull/89 come in on the vault-csi-provider, we need a way to easily add extra flags in the tests.

This PR adds `csi.extraArgs` to allow arbitrary additional args to the daemonset container to support the above cases. `server.extraArgs` is a string, but I chose to make `csi.extraArgs` an array to avoid having to do any processing on the flag arguments, because this way the types in the values file and the yaml match. This avoids any headaches around processing space separation of arguments etc. when converting to a yaml array.