### PR TITLE
feat/enforce readonly fs

### DIFF
--- a/templates/injector-deployment.yaml
+++ b/templates/injector-deployment.yaml
@@ -50,6 +50,7 @@ spec:
           {{- if not .Values.global.openshift }}
           securityContext:
             allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
           {{- end }}
           env:
             - name: AGENT_INJECT_LISTEN


### PR DESCRIPTION
At the moment we are using the injector deployment to mutate pods and injects the secrets.

As a best practice we have enabled `readOnlyRootFilesystem: true` so i am submitting this. Did not make it togglable since I do not believe there is a use case for it in the injector deployment. Wdyt?

Best regards