### PR TITLE
Update to v0.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+## 0.12.0 (May 25th, 2021)
+
 Features:
 * Pass additional arguments to `vault-csi-provider` using `csi.extraArgs` [GH-526](https://github.com/hashicorp/vault-helm/pull/526)
 

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: vault
-version: 0.11.0
-appVersion: 1.7.0
+version: 0.12.0
+appVersion: 1.7.2
 kubeVersion: ">= 1.14.0-0"
 description: Official HashiCorp Vault Chart
 home: https://www.vaultproject.io

--- a/test/acceptance/server-ha-enterprise-dr.bats
+++ b/test/acceptance/server-ha-enterprise-dr.bats
@@ -7,7 +7,7 @@ load _helpers
 
   helm install "$(name_prefix)-east" \
     --set='server.image.repository=hashicorp/vault-enterprise' \
-    --set='server.image.tag=1.7.0_ent' \
+    --set='server.image.tag=1.7.2_ent' \
     --set='injector.enabled=false' \
     --set='server.ha.enabled=true' \
     --set='server.ha.raft.enabled=true' .
@@ -76,7 +76,7 @@ load _helpers
   helm install "$(name_prefix)-west" \
     --set='injector.enabled=false' \
     --set='server.image.repository=hashicorp/vault-enterprise' \
-    --set='server.image.tag=1.6.2_ent' \
+    --set='server.image.tag=1.7.2_ent' \
     --set='server.ha.enabled=true' \
     --set='server.ha.raft.enabled=true' .
   wait_for_running "$(name_prefix)-west-0"

--- a/test/acceptance/server-ha-enterprise-perf.bats
+++ b/test/acceptance/server-ha-enterprise-perf.bats
@@ -8,7 +8,7 @@ load _helpers
   helm install "$(name_prefix)-east" \
     --set='injector.enabled=false' \
     --set='server.image.repository=hashicorp/vault-enterprise' \
-    --set='server.image.tag=1.7.0_ent' \
+    --set='server.image.tag=1.7.2_ent' \
     --set='server.ha.enabled=true' \
     --set='server.ha.raft.enabled=true' .
   wait_for_running "$(name_prefix)-east-0"
@@ -76,7 +76,7 @@ load _helpers
   helm install "$(name_prefix)-west" \
     --set='injector.enabled=false' \
     --set='server.image.repository=hashicorp/vault-enterprise' \
-    --set='server.image.tag=1.6.2_ent' \
+    --set='server.image.tag=1.7.2_ent' \
     --set='server.ha.enabled=true' \
     --set='server.ha.raft.enabled=true' .
   wait_for_running "$(name_prefix)-west-0"

--- a/values.schema.json
+++ b/values.schema.json
@@ -9,7 +9,10 @@
                     "type": "object",
                     "properties": {
                         "annotations": {
-                            "type": "object"
+                            "type": [
+                                "object",
+                                "string"
+                            ]
                         },
                         "updateStrategy": {
                             "type": "object",
@@ -71,10 +74,13 @@
                     "type": "object",
                     "properties": {
                         "annotations": {
-                            "type": "object"
+                            "type": [
+                                "object",
+                                "string"
+                            ]
                         },
                         "tolerations": {
-                            "type": "null"
+                            "type": ["null", "string"]
                         }
                     }
                 },
@@ -105,15 +111,24 @@
                     "type": "object",
                     "properties": {
                         "annotations": {
-                            "type": "object"
+                            "type": [
+                                "object",
+                                "string"
+                            ]
                         }
                     }
                 },
                 "volumeMounts": {
-                    "type": "null"
+                    "type": [
+                        "null",
+                        "array"
+                    ]
                 },
                 "volumes": {
-                    "type": "null"
+                    "type": [
+                        "null",
+                        "array"
+                    ]
                 }
             }
         },
@@ -133,7 +148,10 @@
                     "type": "object",
                     "properties": {
                         "annotations": {
-                            "type": "string"
+                            "type": [
+                                "object",
+                                "string"
+                            ]
                         },
                         "enable": {
                             "type": "boolean"
@@ -183,7 +201,10 @@
                     }
                 },
                 "annotations": {
-                    "type": "object"
+                    "type": [
+                        "object",
+                        "string"
+                    ]
                 },
                 "authPath": {
                     "type": "string"
@@ -201,7 +222,10 @@
                             "type": "string"
                         },
                         "secretName": {
-                            "type": "null"
+                            "type": [
+                                "null",
+                                "string"
+                            ]
                         }
                     }
                 },
@@ -277,7 +301,7 @@
                     "type": "object"
                 },
                 "nodeSelector": {
-                    "type": "null"
+                    "type": ["null", "string"]
                 },
                 "objectSelector": {
                     "type": "object"
@@ -301,12 +325,18 @@
                     "type": "object",
                     "properties": {
                         "annotations": {
-                            "type": "object"
+                            "type": [
+                                "object",
+                                "string"
+                            ]
                         }
                     }
                 },
                 "tolerations": {
-                    "type": "null"
+                    "type": [
+                        "null",
+                        "string"
+                    ]
                 }
             }
         },
@@ -317,7 +347,10 @@
                     "type": "string"
                 },
                 "annotations": {
-                    "type": "object"
+                    "type": [
+                        "object",
+                        "string"
+                    ]
                 },
                 "auditStorage": {
                     "type": "object",
@@ -326,10 +359,16 @@
                             "type": "string"
                         },
                         "annotations": {
-                            "type": "object"
+                            "type": [
+                                "object",
+                                "string"
+                            ]
                         },
                         "enabled": {
-                            "type": "boolean"
+                            "type": [
+                                "boolean",
+                                "string"
+                            ]
                         },
                         "mountPath": {
                             "type": "string"
@@ -338,7 +377,10 @@
                             "type": "string"
                         },
                         "storageClass": {
-                            "type": "null"
+                            "type": [
+                                "null",
+                                "string"
+                            ]
                         }
                     }
                 },
@@ -357,10 +399,16 @@
                             "type": "string"
                         },
                         "annotations": {
-                            "type": "object"
+                            "type": [
+                                "object",
+                                "string"
+                            ]
                         },
                         "enabled": {
-                            "type": "boolean"
+                            "type": [
+                                "boolean",
+                                "string"
+                            ]
                         },
                         "mountPath": {
                             "type": "string"
@@ -369,7 +417,10 @@
                             "type": "string"
                         },
                         "storageClass": {
-                            "type": "null"
+                            "type": [
+                                "null",
+                                "string"
+                            ]
                         }
                     }
                 },
@@ -391,13 +442,19 @@
                     "type": "string"
                 },
                 "extraContainers": {
-                    "type": "null"
+                    "type": [
+                        "null",
+                        "array"
+                    ]
                 },
                 "extraEnvironmentVars": {
                     "type": "object"
                 },
                 "extraInitContainers": {
-                    "type": "null"
+                    "type": [
+                        "null",
+                        "array"
+                    ]
                 },
                 "extraLabels": {
                     "type": "object"
@@ -412,7 +469,10 @@
                     "type": "object",
                     "properties": {
                         "apiAddr": {
-                            "type": "null"
+                            "type": [
+                                "null",
+                                "string"
+                            ]
                         },
                         "config": {
                             "type": "string"
@@ -468,7 +528,10 @@
                     "type": "object",
                     "properties": {
                         "annotations": {
-                            "type": "object"
+                            "type": [
+                                "object",
+                                "string"
+                            ]
                         },
                         "enabled": {
                             "type": "boolean"
@@ -542,7 +605,10 @@
                     }
                 },
                 "nodeSelector": {
-                    "type": "null"
+                    "type": [
+                        "null",
+                        "string"
+                    ]
                 },
                 "postStart": {
                     "type": "array"
@@ -583,7 +649,10 @@
                     "type": "object",
                     "properties": {
                         "annotations": {
-                            "type": "object"
+                            "type": [
+                                "object",
+                                "string"
+                            ]
                         },
                         "enabled": {
                             "type": "boolean"
@@ -600,7 +669,10 @@
                     "type": "object",
                     "properties": {
                         "annotations": {
-                            "type": "object"
+                            "type": [
+                                "object",
+                                "string"
+                            ]
                         },
                         "enabled": {
                             "type": "boolean"
@@ -617,7 +689,10 @@
                     "type": "object",
                     "properties": {
                         "annotations": {
-                            "type": "object"
+                            "type": [
+                                "object",
+                                "string"
+                            ]
                         },
                         "create": {
                             "type": "boolean"
@@ -637,7 +712,10 @@
                             "type": "string"
                         },
                         "enabled": {
-                            "type": "string"
+                            "type": [
+                                "string",
+                                "boolean"
+                            ]
                         }
                     }
                 },
@@ -645,21 +723,33 @@
                     "type": "object",
                     "properties": {
                         "annotations": {
-                            "type": "object"
+                            "type": [
+                                "object",
+                                "string"
+                            ]
                         }
                     }
                 },
                 "tolerations": {
-                    "type": "null"
+                    "type": [
+                        "null",
+                        "string"
+                    ]
                 },
                 "updateStrategyType": {
                     "type": "string"
                 },
                 "volumeMounts": {
-                    "type": "null"
+                    "type": [
+                        "null",
+                        "array"
+                    ]
                 },
                 "volumes": {
-                    "type": "null"
+                    "type": [
+                        "null",
+                        "array"
+                    ]
                 }
             }
         },
@@ -670,7 +760,10 @@
                     "type": "boolean"
                 },
                 "annotations": {
-                    "type": "object"
+                    "type": [
+                        "object",
+                        "string"
+                    ]
                 },
                 "enabled": {
                     "type": "boolean"

--- a/values.schema.json
+++ b/values.schema.json
@@ -9,7 +9,7 @@
                     "type": "object",
                     "properties": {
                         "annotations": {
-                            "type": ["object", "string"]
+                            "type": "object"
                         },
                         "updateStrategy": {
                             "type": "object",
@@ -71,7 +71,10 @@
                     "type": "object",
                     "properties": {
                         "annotations": {
-                            "type": ["object", "string"]
+                            "type": "object"
+                        },
+                        "tolerations": {
+                            "type": "null"
                         }
                     }
                 },
@@ -102,15 +105,15 @@
                     "type": "object",
                     "properties": {
                         "annotations": {
-                            "type": ["object", "string"]
+                            "type": "object"
                         }
                     }
                 },
                 "volumeMounts": {
-                    "type": ["null", "array"]
+                    "type": "null"
                 },
                 "volumes": {
-                    "type": ["null", "array"]
+                    "type": "null"
                 }
             }
         },
@@ -130,7 +133,7 @@
                     "type": "object",
                     "properties": {
                         "annotations": {
-                            "type": ["object", "string"]
+                            "type": "string"
                         },
                         "enable": {
                             "type": "boolean"
@@ -180,7 +183,7 @@
                     }
                 },
                 "annotations": {
-                    "type": ["object", "string"]
+                    "type": "object"
                 },
                 "authPath": {
                     "type": "string"
@@ -198,7 +201,7 @@
                             "type": "string"
                         },
                         "secretName": {
-                            "type": ["null", "string"]
+                            "type": "null"
                         }
                     }
                 },
@@ -274,7 +277,7 @@
                     "type": "object"
                 },
                 "nodeSelector": {
-                    "type": ["null", "string"]
+                    "type": "null"
                 },
                 "objectSelector": {
                     "type": "object"
@@ -298,12 +301,12 @@
                     "type": "object",
                     "properties": {
                         "annotations": {
-                            "type": ["object", "string"]
+                            "type": "object"
                         }
                     }
                 },
                 "tolerations": {
-                    "type": ["null", "string"]
+                    "type": "null"
                 }
             }
         },
@@ -314,7 +317,7 @@
                     "type": "string"
                 },
                 "annotations": {
-                    "type": ["object", "string"]
+                    "type": "object"
                 },
                 "auditStorage": {
                     "type": "object",
@@ -323,10 +326,10 @@
                             "type": "string"
                         },
                         "annotations": {
-                            "type": ["object", "string"]
+                            "type": "object"
                         },
                         "enabled": {
-                            "type": ["boolean", "string"]
+                            "type": "boolean"
                         },
                         "mountPath": {
                             "type": "string"
@@ -335,7 +338,7 @@
                             "type": "string"
                         },
                         "storageClass": {
-                            "type": ["null", "string"]
+                            "type": "null"
                         }
                     }
                 },
@@ -354,10 +357,10 @@
                             "type": "string"
                         },
                         "annotations": {
-                            "type": ["object", "string"]
+                            "type": "object"
                         },
                         "enabled": {
-                            "type": ["boolean", "string"]
+                            "type": "boolean"
                         },
                         "mountPath": {
                             "type": "string"
@@ -366,7 +369,7 @@
                             "type": "string"
                         },
                         "storageClass": {
-                            "type": ["null", "string"]
+                            "type": "null"
                         }
                     }
                 },
@@ -388,13 +391,13 @@
                     "type": "string"
                 },
                 "extraContainers": {
-                    "type": ["null", "array"]
+                    "type": "null"
                 },
                 "extraEnvironmentVars": {
                     "type": "object"
                 },
                 "extraInitContainers": {
-                    "type": ["null", "array"]
+                    "type": "null"
                 },
                 "extraLabels": {
                     "type": "object"
@@ -409,7 +412,7 @@
                     "type": "object",
                     "properties": {
                         "apiAddr": {
-                            "type": ["null", "string"]
+                            "type": "null"
                         },
                         "config": {
                             "type": "string"
@@ -465,7 +468,7 @@
                     "type": "object",
                     "properties": {
                         "annotations": {
-                            "type": ["object", "string"]
+                            "type": "object"
                         },
                         "enabled": {
                             "type": "boolean"
@@ -539,7 +542,7 @@
                     }
                 },
                 "nodeSelector": {
-                    "type": ["null", "string"]
+                    "type": "null"
                 },
                 "postStart": {
                     "type": "array"
@@ -580,7 +583,7 @@
                     "type": "object",
                     "properties": {
                         "annotations": {
-                            "type": ["object", "string"]
+                            "type": "object"
                         },
                         "enabled": {
                             "type": "boolean"
@@ -597,7 +600,7 @@
                     "type": "object",
                     "properties": {
                         "annotations": {
-                            "type": ["object", "string"]
+                            "type": "object"
                         },
                         "enabled": {
                             "type": "boolean"
@@ -614,7 +617,7 @@
                     "type": "object",
                     "properties": {
                         "annotations": {
-                            "type": ["object", "string"]
+                            "type": "object"
                         },
                         "create": {
                             "type": "boolean"
@@ -634,7 +637,7 @@
                             "type": "string"
                         },
                         "enabled": {
-                            "type": ["string", "boolean"]
+                            "type": "string"
                         }
                     }
                 },
@@ -642,21 +645,21 @@
                     "type": "object",
                     "properties": {
                         "annotations": {
-                            "type": ["object", "string"]
+                            "type": "object"
                         }
                     }
                 },
                 "tolerations": {
-                    "type": ["null", "string"]
+                    "type": "null"
                 },
                 "updateStrategyType": {
                     "type": "string"
                 },
                 "volumeMounts": {
-                    "type": ["null", "array"]
+                    "type": "null"
                 },
                 "volumes": {
-                    "type": ["null", "array"]
+                    "type": "null"
                 }
             }
         },
@@ -667,7 +670,7 @@
                     "type": "boolean"
                 },
                 "annotations": {
-                    "type": ["object", "string"]
+                    "type": "object"
                 },
                 "enabled": {
                     "type": "boolean"
@@ -683,6 +686,9 @@
                 },
                 "serviceType": {
                     "type": "string"
+                },
+                "targetPort": {
+                    "type": "integer"
                 }
             }
         }

--- a/values.yaml
+++ b/values.yaml
@@ -51,7 +51,7 @@ injector:
 
   # image sets the repo and tag of the vault-k8s image to use for the injector.
   image:
-    repository: "hashicorp/vault-k8s"
+    repository: "gcr.io/vault-helm-dev/hashicorp/vault-k8s"
     tag: "0.10.1"
     pullPolicy: IfNotPresent
 

--- a/values.yaml
+++ b/values.yaml
@@ -51,7 +51,7 @@ injector:
 
   # image sets the repo and tag of the vault-k8s image to use for the injector.
   image:
-    repository: "gcr.io/vault-helm-dev/hashicorp/vault-k8s"
+    repository: "hashicorp/vault-k8s"
     tag: "0.10.1"
     pullPolicy: IfNotPresent
 

--- a/values.yaml
+++ b/values.yaml
@@ -52,7 +52,7 @@ injector:
   # image sets the repo and tag of the vault-k8s image to use for the injector.
   image:
     repository: "hashicorp/vault-k8s"
-    tag: "0.10.0"
+    tag: "0.10.1"
     pullPolicy: IfNotPresent
 
   # agentImage sets the repo and tag of the Vault image to use for the Vault Agent
@@ -60,7 +60,7 @@ injector:
   # required.
   agentImage:
     repository: "vault"
-    tag: "1.7.0"
+    tag: "1.7.2"
 
   # The default values for the injected Vault Agent containers.
   agentDefaults:
@@ -204,7 +204,7 @@ server:
 
   image:
     repository: "vault"
-    tag: "1.7.0"
+    tag: "1.7.2"
     # Overrides the default Image Pull Policy
     pullPolicy: IfNotPresent
 


### PR DESCRIPTION
## Features:
* Pass additional arguments to `vault-csi-provider` using `csi.extraArgs` [GH-526](https://github.com/hashicorp/vault-helm/pull/526)

## Improvements:
* Set chart kubeVersion and added chart-verifier tests [GH-510](https://github.com/hashicorp/vault-helm/pull/510)
* Added values json schema [GH-513](https://github.com/hashicorp/vault-helm/pull/513)
* Ability to set tolerations for CSI daemonset pods [GH-521](https://github.com/hashicorp/vault-helm/pull/521)
* UI target port is now configurable [GH-437](https://github.com/hashicorp/vault-helm/pull/437)

## Bugs:
* CSI: `global.imagePullSecrets` are now also used for CSI daemonset [GH-519](https://github.com/hashicorp/vault-helm/pull/519)