### PR TITLE
allow using templated values in MutatingWebhookConfiguration selectors

### DIFF
--- a/templates/injector-mutating-webhook.yaml
+++ b/templates/injector-mutating-webhook.yaml
@@ -28,15 +28,15 @@ webhooks:
         apiGroups: [""]
         apiVersions: ["v1"]
         resources: ["pods"]
-{{- if .Values.injector.namespaceSelector }}
+    {{- if .Values.injector.namespaceSelector }}
     namespaceSelector:
-{{ toYaml .Values.injector.namespaceSelector | indent 6}}
-{{ end }}
-{{- if .Values.injector.objectSelector }}
+    {{- tpl (toYaml .Values.injector.namespaceSelector | toString) . | nindent 6}}
+    {{- end }}
+    {{- if .Values.injector.objectSelector }}
     objectSelector:
-{{ toYaml .Values.injector.objectSelector | indent 6}}
-{{ end }}
-{{- with .Values.injector.failurePolicy }}
+    {{- tpl (toYaml .Values.injector.objectSelector | toString) . | nindent 6}}
+    {{- end }}
+    {{- with .Values.injector.failurePolicy }}
     failurePolicy: {{.}}
-{{ end }}
+    {{ end }}
 {{ end }}

--- a/test/unit/injector-mutating-webhook.bats
+++ b/test/unit/injector-mutating-webhook.bats
@@ -5,7 +5,7 @@ load _helpers
 @test "injector/MutatingWebhookConfiguration: enabled by default" {
   cd `chart_dir`
   local actual=$(helm template \
-      --show-only templates/injector-mutating-webhook.yaml  \
+      --show-only templates/injector-mutating-webhook.yaml \
       . | tee /dev/stderr |
       yq 'length > 0' | tee /dev/stderr)
   [ "${actual}" = "true" ]
@@ -14,7 +14,7 @@ load _helpers
 @test "injector/MutatingWebhookConfiguration: disable with global.enabled false" {
   cd `chart_dir`
   local actual=$( (helm template \
-      --show-only templates/injector-mutating-webhook.yaml  \
+      --show-only templates/injector-mutating-webhook.yaml \
       --set 'global.enabled=false' \
       . || echo "---") | tee /dev/stderr |
       yq 'length > 0' | tee /dev/stderr)
@@ -24,7 +24,7 @@ load _helpers
 @test "injector/MutatingWebhookConfiguration: disable with injector.enabled false" {
   cd `chart_dir`
   local actual=$( (helm template \
-      --show-only templates/injector-mutating-webhook.yaml  \
+      --show-only templates/injector-mutating-webhook.yaml \
       --set 'injector.enabled=false' \
       . || echo "---") | tee /dev/stderr |
       yq 'length > 0' | tee /dev/stderr)
@@ -34,7 +34,7 @@ load _helpers
 @test "injector/MutatingWebhookConfiguration: namespace is set" {
   cd `chart_dir`
   local actual=$(helm template \
-      --show-only templates/injector-mutating-webhook.yaml  \
+      --show-only templates/injector-mutating-webhook.yaml \
       --set 'injector.enabled=true' \
       --namespace foo \
       . | tee /dev/stderr |
@@ -45,7 +45,7 @@ load _helpers
 @test "injector/MutatingWebhookConfiguration: caBundle is empty string" {
   cd `chart_dir`
   local actual=$(helm template \
-      --show-only templates/injector-mutating-webhook.yaml  \
+      --show-only templates/injector-mutating-webhook.yaml \
       --set 'injector.enabled=true' \
       --namespace foo \
       . | tee /dev/stderr |
@@ -56,7 +56,7 @@ load _helpers
 @test "injector/MutatingWebhookConfiguration: namespaceSelector empty by default" {
   cd `chart_dir`
   local actual=$(helm template \
-      --show-only templates/injector-mutating-webhook.yaml  \
+      --show-only templates/injector-mutating-webhook.yaml \
       --set 'injector.enabled=true' \
       --namespace foo \
       . | tee /dev/stderr |
@@ -67,19 +67,30 @@ load _helpers
 @test "injector/MutatingWebhookConfiguration: can set namespaceSelector" {
   cd `chart_dir`
   local actual=$(helm template \
-      --show-only templates/injector-mutating-webhook.yaml  \
+      --show-only templates/injector-mutating-webhook.yaml \
       --set 'injector.enabled=true' \
       --set 'injector.namespaceSelector.matchLabels.injector=true' \
       . | tee /dev/stderr |
       yq '.webhooks[0].namespaceSelector.matchLabels.injector' | tee /dev/stderr)
-
   [ "${actual}" = "true" ]
+}
+
+@test "injector/MutatingWebhookConfiguration: can set templated namespaceSelector" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/injector-mutating-webhook.yaml \
+      --namespace foo \
+      --set 'injector.enabled=true' \
+      --set 'injector.namespaceSelector.matchLabels.injector=\{\{ .Release.Namespace \}\}-injector' \
+      . | tee /dev/stderr |
+      yq -r '.webhooks[0].namespaceSelector.matchLabels.injector' | tee /dev/stderr)
+  [ "${actual}" = "foo-injector" ]
 }
 
 @test "injector/MutatingWebhookConfiguration: objectSelector empty by default" {
   cd `chart_dir`
   local actual=$(helm template \
-      --show-only templates/injector-mutating-webhook.yaml  \
+      --show-only templates/injector-mutating-webhook.yaml \
       --set 'injector.enabled=true' \
       --namespace foo \
       . | tee /dev/stderr |
@@ -95,14 +106,25 @@ load _helpers
       --set 'injector.objectSelector.matchLabels.injector=true' \
       . | tee /dev/stderr |
       yq '.webhooks[0].objectSelector.matchLabels.injector' | tee /dev/stderr)
-
   [ "${actual}" = "true" ]
+}
+
+@test "injector/MutatingWebhookConfiguration: can set templated objectSelector" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/injector-mutating-webhook.yaml \
+      --namespace foo \
+      --set 'injector.enabled=true' \
+      --set 'injector.objectSelector.matchLabels.injector=\{\{ .Release.Namespace \}\}-injector' \
+      . | tee /dev/stderr |
+      yq -r '.webhooks[0].objectSelector.matchLabels.injector' | tee /dev/stderr)
+  [ "${actual}" = "foo-injector" ]
 }
 
 @test "injector/MutatingWebhookConfiguration: failurePolicy 'Ignore' by default" {
   cd `chart_dir`
   local actual=$(helm template \
-      --show-only templates/injector-mutating-webhook.yaml  \
+      --show-only templates/injector-mutating-webhook.yaml \
       --set 'injector.enabled=true' \
       --namespace foo \
       . | tee /dev/stderr |
@@ -113,11 +135,10 @@ load _helpers
 @test "injector/MutatingWebhookConfiguration: can set failurePolicy" {
   cd `chart_dir`
   local actual=$(helm template \
-      --show-only templates/injector-mutating-webhook.yaml  \
+      --show-only templates/injector-mutating-webhook.yaml \
       --set 'injector.enabled=true' \
       --set 'injector.failurePolicy=Fail' \
       . | tee /dev/stderr |
       yq '.webhooks[0].failurePolicy' | tee /dev/stderr)
-
   [ "${actual}" = "\"Fail\"" ]
 }

--- a/values.yaml
+++ b/values.yaml
@@ -90,6 +90,7 @@ injector:
 
   # namespaceSelector is the selector for restricting the webhook to only
   # specific namespaces.
+  # Values can use templated strings.
   # See https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/#matching-requests-namespaceselector
   # for more details.
   # Example:
@@ -99,6 +100,7 @@ injector:
   namespaceSelector: {}
   # objectSelector is the selector for restricting the webhook to only
   # specific labels.
+  # Values can use templated strings.
   # See https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/#matching-requests-objectselector
   # for more details.
   # Example:


### PR DESCRIPTION
Allow using templated values in MutatingWebhookConfiguration `namespaceSelector` and `objectSelector` selectors.
This provides more flexibility when using Vault chart as sub-chart. Particularly helpful when there are multiple Vault Injector instances present.

Example sub-chart usage:
```yaml
vault:
  install: true
  injector:
    namespaceSelector:
      matchLabels:
        vault-injector: '{{ .Release.Namespace }}-injector'
```
Produces the following `MutatingWebhookConfiguration` manifest
```yaml
apiVersion: admissionregistration.k8s.io/v1
kind: MutatingWebhookConfiguration
metadata:
  name: RELEASE-NAME-vault-agent-injector-cfg
  labels:
    app.kubernetes.io/name: vault-agent-injector
    app.kubernetes.io/instance: RELEASE-NAME
    app.kubernetes.io/managed-by: Helm
webhooks:
  - name: vault.hashicorp.com
    sideEffects: None
    admissionReviewVersions:
    - "v1beta1"
    - "v1"
    clientConfig:
      service:
        name: RELEASE-NAME-vault-agent-injector-svc
        namespace: default
        path: "/mutate"
      caBundle: ""
    rules:
      - operations: ["CREATE", "UPDATE"]
        apiGroups: [""]
        apiVersions: ["v1"]
        resources: ["pods"]
    namespaceSelector:
      matchLabels:
        vault-injector-by: 'default-injector'
    failurePolicy: Ignore
```

Signed-off-by: Anastas Dancha <anapsix@random.io>