### PR TITLE
change maxUnavailable to integer

### DIFF
--- a/test/unit/server-ha-disruptionbudget.bats
+++ b/test/unit/server-ha-disruptionbudget.bats
@@ -85,3 +85,15 @@ load _helpers
       yq '.spec.maxUnavailable' | tee /dev/stderr)
   [ "${actual}" = "2" ]
 }
+
+@test "server/DisruptionBudget: correct maxUnavailable with custom value" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/server-disruptionbudget.yaml  \
+      --set 'server.ha.enabled=true' \
+      --set 'server.ha.replicas=3' \
+      --set 'server.ha.disruptionBudget.maxUnavailable=2' \
+      . | tee /dev/stderr |
+      yq '.spec.maxUnavailable' | tee /dev/stderr)
+  [ "${actual}" = "2" ]
+}

--- a/values.schema.json
+++ b/values.schema.json
@@ -484,7 +484,10 @@
                                     "type": "boolean"
                                 },
                                 "maxUnavailable": {
-                                    "type": "integer"
+                                    "type": [
+                                        "null",
+                                        "integer"
+                                    ]
                                 }
                             }
                         },

--- a/values.schema.json
+++ b/values.schema.json
@@ -484,7 +484,7 @@
                                     "type": "boolean"
                                 },
                                 "maxUnavailable": {
-                                    "type": "null"
+                                    "type": "integer"
                                 }
                             }
                         },


### PR DESCRIPTION
change maxUnavailable from `null` to `integer` to enable upgrade from 0.11.0 to 0.12.0 when using the specific variable.

solves:

- https://github.com/hashicorp/vault-helm/issues/534