### PR TITLE
Add OpenShift default images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ jobs:
   bats-unit-test:
     docker:
       # This image is built from test/docker/Test.dockerfile
-      - image: docker.mirror.hashicorp.services/hashicorpdev/vault-helm-test:0.1.0
+      - image: docker.mirror.hashicorp.services/hashicorpdev/vault-helm-test:0.2.0
     steps:
       - checkout
       - run: bats ./test/unit -t
@@ -36,7 +36,7 @@ jobs:
   acceptance:
     docker:
       # This image is build from test/docker/Test.dockerfile
-      - image: docker.mirror.hashicorp.services/hashicorpdev/vault-helm-test:0.1.0
+      - image: docker.mirror.hashicorp.services/hashicorpdev/vault-helm-test:0.2.0
 
     steps:
       - checkout

--- a/templates/injector-deployment.yaml
+++ b/templates/injector-deployment.yaml
@@ -1,3 +1,4 @@
+{{ template "vault.openshift" . }}
 {{- if and (eq (.Values.injector.enabled | toString) "true" ) (eq (.Values.global.enabled | toString) "true") }}
 # Deployment for the injector
 apiVersion: apps/v1
@@ -35,7 +36,7 @@ spec:
       priorityClassName: {{ .Values.injector.priorityClassName }}
       {{- end }}
       serviceAccountName: "{{ template "vault.fullname" . }}-agent-injector"
-      {{- if not .Values.global.openshift }}
+      {{- if not .openshift }}
       hostNetwork: {{ .Values.injector.hostNetwork }}
       securityContext:
         runAsNonRoot: true
@@ -45,9 +46,10 @@ spec:
       containers:
         - name: sidecar-injector
           {{ template "injector.resources" . }}
-          image: "{{ .Values.injector.image.repository }}:{{ .Values.injector.image.tag }}"
+          {{- $image_data := dict "openshift" .openshift "image" .Values.injector.image }}
+          image: {{ include "platform.image" $image_data }}
           imagePullPolicy: "{{ .Values.injector.image.pullPolicy }}"
-          {{- if not .Values.global.openshift }}
+          {{- if not .openshift }}
           securityContext:
             allowPrivilegeEscalation: false
           {{- end }}
@@ -65,7 +67,8 @@ spec:
             - name: AGENT_INJECT_VAULT_AUTH_PATH
               value: {{ .Values.injector.authPath }}
             - name: AGENT_INJECT_VAULT_IMAGE
-              value: "{{ .Values.injector.agentImage.repository }}:{{ .Values.injector.agentImage.tag }}"
+            {{- $agentData := dict "openshift" .openshift "image" .Values.injector.agentImage }}
+              value: {{ include "platform.image" $agentData }}
             {{- if .Values.injector.certs.secretName }}
             - name: AGENT_INJECT_TLS_CERT_FILE
               value: "/etc/webhook/certs/{{ .Values.injector.certs.certName }}"
@@ -81,7 +84,7 @@ spec:
               value: {{ .Values.injector.logFormat | default "standard" }}
             - name: AGENT_INJECT_REVOKE_ON_SHUTDOWN
               value: "{{ .Values.injector.revokeOnShutdown | default false }}"
-            {{- if .Values.global.openshift }}
+            {{- if .openshift }}
             - name: AGENT_INJECT_SET_SECURITY_CONTEXT
               value: "false"
             {{- end }}

--- a/templates/injector-network-policy.yaml
+++ b/templates/injector-network-policy.yaml
@@ -1,4 +1,5 @@
-{{- if and (eq (.Values.injector.enabled | toString) "true" ) (eq (.Values.global.enabled | toString) "true") (eq (.Values.global.openshift | toString) "true") }}
+{{ template "vault.openshift" . }}
+{{- if and (eq (.Values.injector.enabled | toString) "true" ) (eq (.Values.global.enabled | toString) "true") .openshift }}
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:

--- a/templates/server-ingress.yaml
+++ b/templates/server-ingress.yaml
@@ -1,4 +1,5 @@
-{{- if not .Values.global.openshift }}
+{{ template "vault.openshift" . }}
+{{- if not .openshift }}
 {{ template "vault.mode" . }}
 {{- if ne .mode "external" }}
 {{- if .Values.server.ingress.enabled -}}

--- a/templates/server-route.yaml
+++ b/templates/server-route.yaml
@@ -1,4 +1,5 @@
-{{- if .Values.global.openshift }}
+{{ template "vault.openshift" . }}
+{{- if .openshift }}
 {{- if ne .mode "external" }}
 {{- if .Values.server.route.enabled -}}
 {{- $serviceName := include "vault.fullname" . -}}

--- a/templates/server-statefulset.yaml
+++ b/templates/server-statefulset.yaml
@@ -1,3 +1,4 @@
+{{ template "vault.openshift" . }}
 {{ template "vault.mode" . }}
 {{- if ne .mode "external" }}
 {{- if and (ne .mode "") (eq (.Values.global.enabled | toString) "true") }}

--- a/templates/server-statefulset.yaml
+++ b/templates/server-statefulset.yaml
@@ -46,7 +46,7 @@ spec:
       {{ if  .Values.server.shareProcessNamespace }}
       shareProcessNamespace: true
       {{ end }}
-      {{- if not .Values.global.openshift }}
+      {{- if not .openshift }}
       securityContext:
         runAsNonRoot: true
         runAsGroup: {{ .Values.server.gid | default 1000 }}
@@ -64,13 +64,14 @@ spec:
       containers:
         - name: vault
           {{ template "vault.resources" . }}
-          image: {{ .Values.server.image.repository }}:{{ .Values.server.image.tag | default "latest" }}
+          {{- $image_data := dict "openshift" .openshift "image" .Values.server.image }}
+          image: {{ include "platform.image" $image_data }}
           imagePullPolicy: {{ .Values.server.image.pullPolicy }}
           command:
           - "/bin/sh"
           - "-ec"
           args: {{ template "vault.args" . }}
-          {{- if not .Values.global.openshift }}
+          {{- if not .openshift }}
           securityContext:
             allowPrivilegeEscalation: false
           {{- end }}

--- a/templates/tests/server-test.yaml
+++ b/templates/tests/server-test.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.server.enabled }}
+{{ template "vault.openshift" . }}
 apiVersion: v1
 kind: Pod
 metadata:
@@ -9,7 +10,8 @@ metadata:
 spec:
   containers:
     - name: {{ .Release.Name }}-server-test
-      image: {{ .Values.server.image.repository }}:{{ .Values.server.image.tag | default "latest" }}
+      {{- $image_data := dict "openshift" .openshift "image" .Values.server.image }}
+      image: {{ include "platform.image" $image_data }}
       imagePullPolicy: {{ .Values.server.image.pullPolicy }}
       env:
         - name: VAULT_ADDR

--- a/test/chart/verifier.bats
+++ b/test/chart/verifier.bats
@@ -30,7 +30,8 @@ setup_file() {
     $run_cmd verify $chart_src \
       --output json \
       --openshift-version $OPENSHIFT_VERSION \
-      --disable $DISABLED_TESTS 2>&1 | tee $VERIFY_OUTPUT
+      --disable $DISABLED_TESTS \
+      --chart-set global.openshift=true 2>&1 | tee $VERIFY_OUTPUT
 }
 
 teardown_file() {
@@ -75,12 +76,11 @@ teardown_file() {
     check_result contains-test
 }
 
+@test "images-are-certified" {
+    check_result images-are-certified
+}
+
 @test "chart-testing" {
     skip "Skipping since this test requires a kubernetes/openshift cluster"
     check_result chart-testing
-}
-
-@test "images-are-certified" {
-    skip "Skipping until this has been addressed"
-    check_result images-are-certified
 }

--- a/test/unit/_helpers.bash
+++ b/test/unit/_helpers.bash
@@ -2,3 +2,23 @@
 chart_dir() {
     echo ${BATS_TEST_DIRNAME}/../..
 }
+
+check_image() {
+  local -r container="$1"
+  local -r imageRepo="$2"
+  local -r imageTag="$3"
+
+  local image=$(echo $container |
+      yq -r '.image' | tee /dev/stderr)
+  [ "${image}" = "${imageRepo}:${imageTag}" ]
+}
+
+check_agentImage() {
+  local -r container="$1"
+  local -r agentRepo="$2"
+  local -r agentTag="$3"
+
+  local agentImage=$(echo $container |
+      yq -r '.env | map(select(.name=="AGENT_INJECT_VAULT_IMAGE")) | .[] .value' | tee /dev/stderr)
+  [ "${agentImage}" = "${agentRepo}:${agentTag}" ]
+}

--- a/test/unit/server-dev-statefulset.bats
+++ b/test/unit/server-dev-statefulset.bats
@@ -46,19 +46,6 @@ load _helpers
   [ "${actual}" = "foo:1.2.3" ]
 }
 
-@test "server/ha-StatefulSet: image tag defaults to latest" {
-  cd `chart_dir`
-
-  local actual=$(helm template \
-      --show-only templates/server-statefulset.yaml  \
-      --set 'server.image.repository=foo' \
-      --set 'server.image.tag=' \
-      --set 'server.dev.enabled=true' \
-      . | tee /dev/stderr |
-      yq -r '.spec.template.spec.containers[0].image' | tee /dev/stderr)
-  [ "${actual}" = "foo:latest" ]
-}
-
 #--------------------------------------------------------------------
 # replicas
 

--- a/test/unit/server-dev-statefulset.bats
+++ b/test/unit/server-dev-statefulset.bats
@@ -46,6 +46,20 @@ load _helpers
   [ "${actual}" = "foo:1.2.3" ]
 }
 
+@test "server/dev-StatefulSet: empty image tag defaults to kubernetes" {
+  cd `chart_dir`
+
+  local k8sTag=$(cat values.yaml | yq -r .server.image.kubernetes.tag)
+  local actual=$(helm template \
+      --show-only templates/server-statefulset.yaml  \
+      --set 'server.image.repository=foo' \
+      --set 'server.image.tag=' \
+      --set 'server.dev.enabled=true' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.containers[0].image' | tee /dev/stderr)
+  [ "${actual}" = "foo:${k8sTag}" ]
+}
+
 #--------------------------------------------------------------------
 # replicas
 

--- a/test/unit/server-ha-statefulset.bats
+++ b/test/unit/server-ha-statefulset.bats
@@ -46,6 +46,20 @@ load _helpers
   [ "${actual}" = "foo:1.2.3" ]
 }
 
+@test "server/ha-StatefulSet: empty image tag defaults to kubernetes" {
+  cd `chart_dir`
+
+  local k8sTag=$(cat values.yaml | yq -r .server.image.kubernetes.tag)
+  local actual=$(helm template \
+      --show-only templates/server-statefulset.yaml  \
+      --set 'server.image.repository=foo' \
+      --set 'server.image.tag=' \
+      --set 'server.ha.enabled=true' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.containers[0].image' | tee /dev/stderr)
+  [ "${actual}" = "foo:${k8sTag}" ]
+}
+
 #--------------------------------------------------------------------
 # TLS
 

--- a/test/unit/server-ha-statefulset.bats
+++ b/test/unit/server-ha-statefulset.bats
@@ -46,19 +46,6 @@ load _helpers
   [ "${actual}" = "foo:1.2.3" ]
 }
 
-@test "server/ha-StatefulSet: image tag defaults to latest" {
-  cd `chart_dir`
-
-  local actual=$(helm template \
-      --show-only templates/server-statefulset.yaml  \
-      --set 'server.image.repository=foo' \
-      --set 'server.image.tag=' \
-      --set 'server.ha.enabled=true' \
-      . | tee /dev/stderr |
-      yq -r '.spec.template.spec.containers[0].image' | tee /dev/stderr)
-  [ "${actual}" = "foo:latest" ]
-}
-
 #--------------------------------------------------------------------
 # TLS
 

--- a/test/unit/server-statefulset.bats
+++ b/test/unit/server-statefulset.bats
@@ -106,6 +106,27 @@ setup_file() {
   [ "${actual}" = "foo:1.2.3" ]
 }
 
+@test "server/standalone-StatefulSet: empty image tag defaults to kubernetes" {
+  cd `chart_dir`
+  local k8sTag=$(cat values.yaml | yq -r .server.image.kubernetes.tag)
+  local actual=$(helm template \
+      --show-only templates/server-statefulset.yaml  \
+      --set 'server.image.repository=foo' \
+      --set 'server.image.tag=' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.containers[0].image' | tee /dev/stderr)
+  [ "${actual}" = "foo:${k8sTag}" ]
+
+  local actual=$(helm template \
+      --show-only templates/server-statefulset.yaml  \
+      --set 'server.image.repository=foo' \
+      --set 'server.image.tag=' \
+      --set 'server.standalone.enabled=true' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.containers[0].image' | tee /dev/stderr)
+  [ "${actual}" = "foo:${k8sTag}" ]
+}
+
 @test "server/standalone-StatefulSet: default imagePullPolicy" {
   cd `chart_dir`
   local actual=$(helm template \

--- a/test/unit/server-statefulset.bats
+++ b/test/unit/server-statefulset.bats
@@ -98,26 +98,6 @@ load _helpers
   [ "${actual}" = "foo:1.2.3" ]
 }
 
-@test "server/standalone-StatefulSet: image tag defaults to latest" {
-  cd `chart_dir`
-  local actual=$(helm template \
-      --show-only templates/server-statefulset.yaml  \
-      --set 'server.image.repository=foo' \
-      --set 'server.image.tag=' \
-      . | tee /dev/stderr |
-      yq -r '.spec.template.spec.containers[0].image' | tee /dev/stderr)
-  [ "${actual}" = "foo:latest" ]
-
-  local actual=$(helm template \
-      --show-only templates/server-statefulset.yaml  \
-      --set 'server.image.repository=foo' \
-      --set 'server.image.tag=' \
-      --set 'server.standalone.enabled=true' \
-      . | tee /dev/stderr |
-      yq -r '.spec.template.spec.containers[0].image' | tee /dev/stderr)
-  [ "${actual}" = "foo:latest" ]
-}
-
 @test "server/standalone-StatefulSet: default imagePullPolicy" {
   cd `chart_dir`
   local actual=$(helm template \

--- a/values.yaml
+++ b/values.yaml
@@ -63,7 +63,7 @@ injector:
     # OpenShift is detected)
     openshift:
       repository: "registry.connect.redhat.com/hashicorp/vault-k8s"
-      tag: "0.10.0-ubi"
+      tag: "0.10.1-ubi"
 
   # agentImage sets the repo and tag of the Vault image to use for the Vault Agent
   # containers.  This should be set to the official Vault image.  Vault 1.3.1+ is

--- a/values.yaml
+++ b/values.yaml
@@ -51,16 +51,36 @@ injector:
 
   # image sets the repo and tag of the vault-k8s image to use for the injector.
   image:
-    repository: "hashicorp/vault-k8s"
-    tag: "0.10.0"
+    repository: ""
+    tag: ""
     pullPolicy: IfNotPresent
+    # Kubernetes defaults (these will be used if global.openshift=false and
+    # OpenShift is not detected)
+    kubernetes:
+      repository: "hashicorp/vault-k8s"
+      tag: "0.10.1"
+    # OpenShift defaults (these will be used if global.openshift=true or
+    # OpenShift is detected)
+    openshift:
+      repository: "registry.connect.redhat.com/hashicorp/vault-k8s"
+      tag: "0.10.1-ubi"
 
   # agentImage sets the repo and tag of the Vault image to use for the Vault Agent
   # containers.  This should be set to the official Vault image.  Vault 1.3.1+ is
   # required.
   agentImage:
-    repository: "vault"
-    tag: "1.7.0"
+    repository: ""
+    tag: ""
+    # Kubernetes defaults (these will be used if global.openshift=false and
+    # OpenShift is not detected)
+    kubernetes:
+      repository: "vault"
+      tag: "1.7.2"
+    # OpenShift defaults (these will be used if global.openshift=true or
+    # OpenShift is detected)
+    openshift:
+      repository: "registry.connect.redhat.com/hashicorp/vault"
+      tag: "1.7.2-ubi"
 
   # The default values for the injected Vault Agent containers.
   agentDefaults:
@@ -203,10 +223,20 @@ server:
   # By default no direct resource request is made.
 
   image:
-    repository: "vault"
-    tag: "1.7.0"
+    repository: ""
+    tag: ""
     # Overrides the default Image Pull Policy
     pullPolicy: IfNotPresent
+    # Kubernetes defaults (these will be used if global.openshift=false and
+    # OpenShift is not detected)
+    kubernetes:
+      repository: "vault"
+      tag: "1.7.2"
+    # OpenShift defaults (these will be used if global.openshift=true or
+    # OpenShift is detected)
+    openshift:
+      repository: "registry.connect.redhat.com/hashicorp/vault"
+      tag: "1.7.2-ubi"
 
   # Configure the Update Strategy Type for the StatefulSet
   # See https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#update-strategies

--- a/values.yaml
+++ b/values.yaml
@@ -63,7 +63,7 @@ injector:
     # OpenShift is detected)
     openshift:
       repository: "registry.connect.redhat.com/hashicorp/vault-k8s"
-      tag: "0.10.1-ubi"
+      tag: "0.10.0-ubi"
 
   # agentImage sets the repo and tag of the Vault image to use for the Vault Agent
   # containers.  This should be set to the official Vault image.  Vault 1.3.1+ is


### PR DESCRIPTION
Adds OpenShift UBI images as defaults if `global.openshift=true` or the `apps.openshift.io/v1` API is present in the deployment system. Otherwise the defaults are the images from dockerhub. The images can also be set by user overrides in either case.

Also sets `global.openshift=true` for the chart-verifier tests (since the helm setup in chart-verifier [doesn't enable any openshift APIs](https://github.com/redhat-certification/chart-verifier/blob/e2c03bd1a4aea20deb0a4a03ebfde254b1672050/pkg/chartverifier/checks/helm.go#L197)), and checks that the `images-are-certified` chart-verifier test passed.