### PR TITLE
use vault-helm-test:0.2.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ jobs:
   bats-unit-test:
     docker:
       # This image is built from test/docker/Test.dockerfile
-      - image: docker.mirror.hashicorp.services/hashicorpdev/vault-helm-test:0.1.0
+      - image: docker.mirror.hashicorp.services/hashicorpdev/vault-helm-test:0.2.0
     steps:
       - checkout
       - run: bats ./test/unit -t
@@ -36,7 +36,7 @@ jobs:
   acceptance:
     docker:
       # This image is build from test/docker/Test.dockerfile
-      - image: docker.mirror.hashicorp.services/hashicorpdev/vault-helm-test:0.1.0
+      - image: docker.mirror.hashicorp.services/hashicorpdev/vault-helm-test:0.2.0
 
     steps:
       - checkout


### PR DESCRIPTION
Updates include bats 1.3.0 and helm 3.6.0.

Tested acceptance testing with these commands:

```shell
make test-provision TEST_IMAGE=hashicorpdev/vault-helm-test:0.2.0
make test-acceptance TEST_IMAGE=hashicorpdev/vault-helm-test:0.2.0
make test-destroy TEST_IMAGE=hashicorpdev/vault-helm-test:0.2.0
```