### PR TITLE
Added webhook-certs volume mount to sidecar injector

### DIFF
--- a/templates/injector-deployment.yaml
+++ b/templates/injector-deployment.yaml
@@ -167,10 +167,6 @@ spec:
             timeoutSeconds: 5
         {{- end }}
 {{- if .Values.injector.certs.secretName }}
-          volumeMounts:
-            - name: webhook-certs
-              mountPath: /etc/webhook/certs
-              readOnly: true
       volumes:
         - name: webhook-certs
           secret:

--- a/templates/injector-deployment.yaml
+++ b/templates/injector-deployment.yaml
@@ -131,6 +131,12 @@ spec:
             periodSeconds: 2
             successThreshold: 1
             timeoutSeconds: 5
+{{- if .Values.injector.certs.secretName }}
+          volumeMounts:
+            - name: webhook-certs
+              mountPath: /etc/webhook/certs
+              readOnly: true
+{{- end }}
         {{- if and (eq (.Values.injector.leaderElector.enabled | toString) "true") (gt (.Values.injector.replicas | int) 1) }}
         - name: leader-elector
           image: {{ .Values.injector.leaderElector.image.repository }}:{{ .Values.injector.leaderElector.image.tag }}


### PR DESCRIPTION
This PR adds the `webhook-certs` volume mount to sidecar injector.
Without it, the agent injector can't access the TLS certificate files.