### PR TITLE
add configuration for active/standy services for server

### DIFF
--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -398,6 +398,34 @@ Sets extra vault server Service annotations
 {{- end -}}
 
 {{/*
+Sets extra vault server Service (active) annotations
+*/}}
+{{- define "vault.service.active.annotations" -}}
+  {{- if .Values.server.service.active.annotations }}
+    {{- $tp := typeOf .Values.server.service.active.annotations }}
+    {{- if eq $tp "string" }}
+      {{- tpl .Values.server.service.active.annotations . | nindent 4 }}
+    {{- else }}
+      {{- toYaml .Values.server.service.active.annotations | nindent 4 }}
+    {{- end }}
+  {{- end }}
+{{- end -}}
+
+{{/*
+Sets extra vault server Service annotations
+*/}}
+{{- define "vault.service.standby.annotations" -}}
+  {{- if .Values.server.service.standby.annotations }}
+    {{- $tp := typeOf .Values.server.service.standby.annotations }}
+    {{- if eq $tp "string" }}
+      {{- tpl .Values.server.service.standby.annotations . | nindent 4 }}
+    {{- else }}
+      {{- toYaml .Values.server.service.standby.annotations | nindent 4 }}
+    {{- end }}
+  {{- end }}
+{{- end -}}
+
+{{/*
 Sets PodSecurityPolicy annotations
 */}}
 {{- define "vault.psp.annotations" -}}

--- a/templates/server-ha-active-service.yaml
+++ b/templates/server-ha-active-service.yaml
@@ -13,12 +13,16 @@ metadata:
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
   annotations:
-{{ template "vault.service.annotations" .}}
+{{ template "vault.service.active.annotations" .}}
 spec:
-  {{- if .Values.server.service.type}}
+  {{- if .Values.server.service.active.type}}
+  type: {{ .Values.server.service.active.type }}
+  {{- else if .Values.server.service.type }}
   type: {{ .Values.server.service.type }}
   {{- end}}
-  {{- if .Values.server.service.clusterIP }}
+  {{- if .Values.server.service.active.clusterIP }}
+  clusterIP: {{ .Values.server.service.active.clusterIP }}
+  {{- else if .Values.server.service.clusterIP }}
   clusterIP: {{ .Values.server.service.clusterIP }}
   {{- end }}
   publishNotReadyAddresses: true
@@ -26,7 +30,9 @@ spec:
     - name: {{ include "vault.scheme" . }}
       port: {{ .Values.server.service.port }}
       targetPort: {{ .Values.server.service.targetPort }}
-      {{- if and (.Values.server.service.nodePort) (eq (.Values.server.service.type | toString) "NodePort") }}
+      {{- if and (.Values.server.service.active.nodePort) (eq (.Values.server.service.active.type | toString) "NodePort") }}
+      nodePort: {{ .Values.server.service.active.nodePort }}
+      {{- else if and (.Values.server.service.nodePort) (eq (.Values.server.service.type | toString) "NodePort") }}
       nodePort: {{ .Values.server.service.nodePort }}
       {{- end }}
     - name: https-internal

--- a/templates/server-ha-standby-service.yaml
+++ b/templates/server-ha-standby-service.yaml
@@ -13,12 +13,16 @@ metadata:
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
   annotations:
-{{ template "vault.service.annotations" .}}
+{{ template "vault.service.standby.annotations" .}}
 spec:
-  {{- if .Values.server.service.type}}
+  {{- if .Values.server.service.standby.type}}
+  type: {{ .Values.server.service.standby.type }}
+  {{- else if .Values.server.service.type }}
   type: {{ .Values.server.service.type }}
   {{- end}}
-  {{- if .Values.server.service.clusterIP }}
+  {{- if .Values.server.service.standby.clusterIP }}
+  clusterIP: {{ .Values.server.service.standby.clusterIP }}
+  {{- else if .Values.server.service.clusterIP }}
   clusterIP: {{ .Values.server.service.clusterIP }}
   {{- end }}
   publishNotReadyAddresses: true
@@ -26,7 +30,9 @@ spec:
     - name: {{ include "vault.scheme" . }}
       port: {{ .Values.server.service.port }}
       targetPort: {{ .Values.server.service.targetPort }}
-      {{- if and (.Values.server.service.nodePort) (eq (.Values.server.service.type | toString) "NodePort") }}
+      {{- if and (.Values.server.service.standby.nodePort) (eq (.Values.server.service.standby.type | toString) "NodePort") }}
+      nodePort: {{ .Values.server.service.standby.nodePort }}
+      {{- else if and (.Values.server.service.nodePort) (eq (.Values.server.service.type | toString) "NodePort") }}
       nodePort: {{ .Values.server.service.nodePort }}
       {{- end }}
     - name: https-internal

--- a/test/unit/server-ha-active-service.bats
+++ b/test/unit/server-ha-active-service.bats
@@ -7,7 +7,7 @@ load _helpers
   local actual=$(helm template \
       --show-only templates/server-ha-active-service.yaml \
       --set 'server.ha.enabled=true' \
-      --set 'server.service.annotations=vaultIsAwesome: true' \
+      --set 'server.service.active.annotations=vaultIsAwesome: true' \
       . | tee /dev/stderr |
       yq -r '.metadata.annotations["vaultIsAwesome"]' | tee /dev/stderr)
   [ "${actual}" = "true" ]

--- a/test/unit/server-ha-standby-service.bats
+++ b/test/unit/server-ha-standby-service.bats
@@ -7,7 +7,7 @@ load _helpers
   local actual=$(helm template \
       --show-only templates/server-ha-standby-service.yaml \
       --set 'server.ha.enabled=true' \
-      --set 'server.service.annotations=vaultIsAwesome: true' \
+      --set 'server.service.standby.annotations=vaultIsAwesome: true' \
       . | tee /dev/stderr |
       yq -r '.metadata.annotations["vaultIsAwesome"]' | tee /dev/stderr)
   [ "${actual}" = "true" ]
@@ -18,7 +18,7 @@ load _helpers
   local actual=$(helm template \
       --show-only templates/server-ha-standby-service.yaml \
       --set 'server.ha.enabled=true' \
-      --set 'server.service.annotations.vaultIsAwesome=true' \
+      --set 'server.service.standby.annotations.vaultIsAwesome=true' \
       . | tee /dev/stderr |
       yq -r '.metadata.annotations["vaultIsAwesome"]' | tee /dev/stderr)
   [ "${actual}" = "true" ]

--- a/values.schema.json
+++ b/values.schema.json
@@ -685,6 +685,28 @@
                         },
                         "targetPort": {
                             "type": "integer"
+                        },
+                        "active": {
+                            "type": "object",
+                            "properties": {
+                                "annotations": {
+                                    "type": [
+                                        "object",
+                                        "string"
+                                    ]
+                                }
+                            }
+                        },
+                        "standby": {
+                            "type": "object",
+                            "properties": {
+                                "annotations": {
+                                    "type": [
+                                        "object",
+                                        "string"
+                                    ]
+                                }
+                            }
                         }
                     }
                 },

--- a/values.yaml
+++ b/values.yaml
@@ -459,6 +459,52 @@ server:
     # to the service.
     annotations: {}
 
+    # Enables a headless service that contains the active pod only
+    active:
+      # clusterIP controls whether a Cluster IP address is attached to the
+      # Vault service within Kubernetes.  By default the Vault service will
+      # be given a Cluster IP address, set to None to disable.  When disabled
+      # Kubernetes will create a "headless" service.  Headless services can be
+      # used to communicate with pods directly through DNS instead of a round robin
+      # load balancer.
+      # clusterIP: None
+
+      # Configures the service type for the active Vault service.  Can be ClusterIP
+      # or NodePort.
+      #type: ClusterIP
+
+      # If type is set to "NodePort", a specific nodePort value can be configured,
+      # will be random if left blank.
+      #nodePort: 30000
+
+      # Extra annotations for the service definition. This can either be YAML or a
+      # YAML-formatted multi-line templated string map of the annotations to apply
+      # to the service.
+      annotations: {}
+
+    # Enables a headless service that contains standby pods only
+    standby:
+      # clusterIP controls whether a Cluster IP address is attached to the
+      # Vault service within Kubernetes.  By default the Vault service will
+      # be given a Cluster IP address, set to None to disable.  When disabled
+      # Kubernetes will create a "headless" service.  Headless services can be
+      # used to communicate with pods directly through DNS instead of a round robin
+      # load balancer.
+      # clusterIP: None
+
+      # Configures the service type for the standby Vault service.  Can be ClusterIP
+      # or NodePort.
+      #type: ClusterIP
+
+      # If type is set to "NodePort", a specific nodePort value can be configured,
+      # will be random if left blank.
+      #nodePort: 30000
+
+      # Extra annotations for the service definition. This can either be YAML or a
+      # YAML-formatted multi-line templated string map of the annotations to apply
+      # to the service.
+      annotations: {}
+
   # This configures the Vault Statefulset to create a PVC for data
   # storage when using the file or raft backend storage engines.
   # See https://www.vaultproject.io/docs/configuration/storage/index.html to know more


### PR DESCRIPTION
Currently there is no ability to configure services for active and standby services, as they inherit their settings from the main server service configuration. This is a problem, for example, when you need to attach different annotations to the different services. Instead of just allowing for setting of annotations, I opted to allow configuring the services for more flexibility.