### PR TITLE
Adding server.enterpriseLicense

### DIFF
--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -107,6 +107,7 @@ extra volumes the user may have specified (such as a secret with TLS).
         - name: vault-license
           secret:
             secretName: {{ .Values.server.enterpriseLicense.secretName }}
+            defaultMode: 0440
   {{- end }}
 {{- end -}}
 

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -103,6 +103,11 @@ extra volumes the user may have specified (such as a secret with TLS).
   {{- if .Values.server.volumes }}
     {{- toYaml .Values.server.volumes | nindent 8}}
   {{- end }}
+  {{- if (and .Values.server.enterpriseLicense.secretName .Values.server.enterpriseLicense.secretKey) }}
+        - name: vault-license
+          secret:
+            secretName: {{ .Values.server.enterpriseLicense.secretName }}
+  {{- end }}
 {{- end -}}
 
 {{/*
@@ -165,6 +170,11 @@ based on the mode configured.
   {{- end }}
   {{- if .Values.server.volumeMounts }}
     {{- toYaml .Values.server.volumeMounts | nindent 12}}
+  {{- end }}
+  {{- if (and .Values.server.enterpriseLicense.secretName .Values.server.enterpriseLicense.secretKey) }}
+            - name: vault-license
+              mountPath: /vault/license
+              readOnly: true
   {{- end }}
 {{- end -}}
 

--- a/templates/server-statefulset.yaml
+++ b/templates/server-statefulset.yaml
@@ -125,6 +125,10 @@ spec:
             - name: VAULT_LOG_FORMAT
               value: "{{ .Values.server.logFormat }}"
             {{- end }}
+            {{- if (and .Values.server.enterpriseLicense.secretName .Values.server.enterpriseLicense.secretKey) }}
+            - name: VAULT_LICENSE_PATH
+              value: /vault/license/{{ .Values.server.enterpriseLicense.secretKey }}
+            {{- end }}
             {{ template "vault.envs" . }}
             {{- include "vault.extraEnvironmentVars" .Values.server | nindent 12 }}
             {{- include "vault.extraSecretEnvironmentVars" .Values.server | nindent 12 }}

--- a/test/acceptance/server-ha-enterprise-dr.bats
+++ b/test/acceptance/server-ha-enterprise-dr.bats
@@ -11,8 +11,7 @@ load _helpers
     --set='injector.enabled=false' \
     --set='server.ha.enabled=true' \
     --set='server.ha.raft.enabled=true' \
-    --set='server.enterpriseLicense.secretName=vault-license' \
-    --set='server.enterpriseLicense.secretKey=license.hclic' .
+    --set='server.enterpriseLicense.secretName=vault-license' .
   wait_for_running "$(name_prefix)-east-0"
 
   # Sealed, not initialized
@@ -81,8 +80,7 @@ load _helpers
     --set='server.image.tag=1.7.2_ent' \
     --set='server.ha.enabled=true' \
     --set='server.ha.raft.enabled=true' \
-    --set='server.enterpriseLicense.secretName=vault-license' \
-    --set='server.enterpriseLicense.secretKey=license.hclic' .
+    --set='server.enterpriseLicense.secretName=vault-license' .
   wait_for_running "$(name_prefix)-west-0"
 
   # Sealed, not initialized
@@ -157,7 +155,7 @@ setup() {
   kubectl delete namespace acceptance --ignore-not-found=true
   kubectl create namespace acceptance
   kubectl config set-context --current --namespace=acceptance
-  kubectl create secret generic vault-license --from-literal license.hclic=$VAULT_LICENSE_CI
+  kubectl create secret generic vault-license --from-literal license=$VAULT_LICENSE_CI
 }
 
 #cleanup

--- a/test/acceptance/server-ha-enterprise-dr.bats
+++ b/test/acceptance/server-ha-enterprise-dr.bats
@@ -10,7 +10,9 @@ load _helpers
     --set='server.image.tag=1.7.2_ent' \
     --set='injector.enabled=false' \
     --set='server.ha.enabled=true' \
-    --set='server.ha.raft.enabled=true' .
+    --set='server.ha.raft.enabled=true' \
+    --set='server.enterpriseLicense.secretName=vault-license' \
+    --set='server.enterpriseLicense.secretKey=license.hclic' .
   wait_for_running "$(name_prefix)-east-0"
 
   # Sealed, not initialized
@@ -78,7 +80,9 @@ load _helpers
     --set='server.image.repository=hashicorp/vault-enterprise' \
     --set='server.image.tag=1.7.2_ent' \
     --set='server.ha.enabled=true' \
-    --set='server.ha.raft.enabled=true' .
+    --set='server.ha.raft.enabled=true' \
+    --set='server.enterpriseLicense.secretName=vault-license' \
+    --set='server.enterpriseLicense.secretKey=license.hclic' .
   wait_for_running "$(name_prefix)-west-0"
 
   # Sealed, not initialized
@@ -153,6 +157,7 @@ setup() {
   kubectl delete namespace acceptance --ignore-not-found=true
   kubectl create namespace acceptance
   kubectl config set-context --current --namespace=acceptance
+  kubectl create secret generic vault-license --from-literal license.hclic=$VAULT_LICENSE_CI
 }
 
 #cleanup

--- a/test/acceptance/server-ha-enterprise-perf.bats
+++ b/test/acceptance/server-ha-enterprise-perf.bats
@@ -11,8 +11,7 @@ load _helpers
     --set='server.image.tag=1.7.2_ent' \
     --set='server.ha.enabled=true' \
     --set='server.ha.raft.enabled=true' \
-    --set='server.enterpriseLicense.secretName=vault-license' \
-    --set='server.enterpriseLicense.secretKey=license.hclic' .
+    --set='server.enterpriseLicense.secretName=vault-license' .
   wait_for_running "$(name_prefix)-east-0"
 
   # Sealed, not initialized
@@ -81,8 +80,7 @@ load _helpers
     --set='server.image.tag=1.7.2_ent' \
     --set='server.ha.enabled=true' \
     --set='server.ha.raft.enabled=true' \
-    --set='server.enterpriseLicense.secretName=vault-license' \
-    --set='server.enterpriseLicense.secretKey=license.hclic' .
+    --set='server.enterpriseLicense.secretName=vault-license' .
   wait_for_running "$(name_prefix)-west-0"
 
   # Sealed, not initialized
@@ -155,7 +153,7 @@ setup() {
   kubectl delete namespace acceptance --ignore-not-found=true
   kubectl create namespace acceptance
   kubectl config set-context --current --namespace=acceptance
-  kubectl create secret generic vault-license --from-literal license.hclic=$VAULT_LICENSE_CI
+  kubectl create secret generic vault-license --from-literal license=$VAULT_LICENSE_CI
 }
 
 #cleanup

--- a/test/acceptance/server-ha-enterprise-perf.bats
+++ b/test/acceptance/server-ha-enterprise-perf.bats
@@ -10,7 +10,9 @@ load _helpers
     --set='server.image.repository=hashicorp/vault-enterprise' \
     --set='server.image.tag=1.7.2_ent' \
     --set='server.ha.enabled=true' \
-    --set='server.ha.raft.enabled=true' .
+    --set='server.ha.raft.enabled=true' \
+    --set='server.enterpriseLicense.secretName=vault-license' \
+    --set='server.enterpriseLicense.secretKey=license.hclic' .
   wait_for_running "$(name_prefix)-east-0"
 
   # Sealed, not initialized
@@ -78,7 +80,9 @@ load _helpers
     --set='server.image.repository=hashicorp/vault-enterprise' \
     --set='server.image.tag=1.7.2_ent' \
     --set='server.ha.enabled=true' \
-    --set='server.ha.raft.enabled=true' .
+    --set='server.ha.raft.enabled=true' \
+    --set='server.enterpriseLicense.secretName=vault-license' \
+    --set='server.enterpriseLicense.secretKey=license.hclic' .
   wait_for_running "$(name_prefix)-west-0"
 
   # Sealed, not initialized
@@ -151,6 +155,7 @@ setup() {
   kubectl delete namespace acceptance --ignore-not-found=true
   kubectl create namespace acceptance
   kubectl config set-context --current --namespace=acceptance
+  kubectl create secret generic vault-license --from-literal license.hclic=$VAULT_LICENSE_CI
 }
 
 #cleanup

--- a/values.schema.json
+++ b/values.schema.json
@@ -438,6 +438,17 @@
                 "enabled": {
                     "type": "boolean"
                 },
+                "enterpriseLicense": {
+                    "type": "object",
+                    "properties": {
+                        "secretKey": {
+                            "type": "string"
+                        },
+                        "secretName": {
+                            "type": "string"
+                        }
+                    }
+                },
                 "extraArgs": {
                     "type": "string"
                 },

--- a/values.yaml
+++ b/values.yaml
@@ -201,14 +201,14 @@ server:
   # [Enterprise Only] This value refers to a Kubernetes secret that you have
   # created that contains your enterprise license. If you are not using an
   # enterprise image or if you plan to introduce the license key via another
-  # route, then set these fields to empty (""). Requires Vault Enterprise 1.8 or
-  # later.
+  # route, then leave secretName blank ("") or set it to null.
+  # Requires Vault Enterprise 1.8 or later.
   enterpriseLicense:
     # The name of the Kubernetes secret that holds the enterprise license. The
     # secret must be in the same namespace that Vault is installed into.
     secretName: ""
     # The key within the Kubernetes secret that holds the enterprise license.
-    secretKey: ""
+    secretKey: "license"
 
   # Resource requests, limits, etc. for the server cluster placement. This
   # should map directly to the value of the resources field for a PodSpec.

--- a/values.yaml
+++ b/values.yaml
@@ -198,6 +198,17 @@ server:
   # If not set to true, Vault server will not be installed. See vault.mode in _helpers.tpl for implementation details
   enabled: true
 
+  # [Enterprise Only] This value refers to a Kubernetes secret that you have
+  # created that contains your enterprise license. If you are not using an
+  # enterprise image or if you plan to introduce the license key via another
+  # route, then set these fields to empty (""). Requires Vault 1.8 or later.
+  enterpriseLicense:
+    # The name of the Kubernetes secret that holds the enterprise license. The
+    # secret must be in the same namespace that Vault is installed into.
+    secretName: ""
+    # The key within the Kubernetes secret that holds the enterprise license.
+    secretKey: ""
+
   # Resource requests, limits, etc. for the server cluster placement. This
   # should map directly to the value of the resources field for a PodSpec.
   # By default no direct resource request is made.

--- a/values.yaml
+++ b/values.yaml
@@ -201,7 +201,8 @@ server:
   # [Enterprise Only] This value refers to a Kubernetes secret that you have
   # created that contains your enterprise license. If you are not using an
   # enterprise image or if you plan to introduce the license key via another
-  # route, then set these fields to empty (""). Requires Vault 1.8 or later.
+  # route, then set these fields to empty (""). Requires Vault Enterprise 1.8 or
+  # later.
   enterpriseLicense:
     # The name of the Kubernetes secret that holds the enterprise license. The
     # secret must be in the same namespace that Vault is installed into.


### PR DESCRIPTION
Sets up a vault-enterprise license for autoloading on
startup. Mounts an existing secret to /vault/license and sets
VAULT_LICENSE_PATH appropriately.

The UX will be similar to [consul-helm](https://www.consul.io/docs/k8s/installation/deployment-configurations/consul-enterprise).