### PR TITLE
Add openshift overrides

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,8 +16,7 @@ jobs:
       - image: docker.mirror.hashicorp.services/cimg/go:1.16
     environment:
       BATS_VERSION: "1.3.0"
-      # Note: the commit SHA is used here since the repo doesn't use release tags
-      CHART_VERIFIER_VERSION: "e2c03bd1a4aea20deb0a4a03ebfde254b1672050"
+      CHART_VERIFIER_VERSION: "1.0.0"
     steps:
       - checkout
       - run:

--- a/test/chart/verifier.bats
+++ b/test/chart/verifier.bats
@@ -30,7 +30,8 @@ setup_file() {
     $run_cmd verify $chart_src \
       --output json \
       --openshift-version $OPENSHIFT_VERSION \
-      --disable $DISABLED_TESTS 2>&1 | tee $VERIFY_OUTPUT
+      --disable $DISABLED_TESTS \
+      --chart-values values.openshift.yaml 2>&1 | tee $VERIFY_OUTPUT
 }
 
 teardown_file() {
@@ -75,12 +76,11 @@ teardown_file() {
     check_result contains-test
 }
 
+@test "images-are-certified" {
+    check_result images-are-certified
+}
+
 @test "chart-testing" {
     skip "Skipping since this test requires a kubernetes/openshift cluster"
     check_result chart-testing
-}
-
-@test "images-are-certified" {
-    skip "Skipping until this has been addressed"
-    check_result images-are-certified
 }

--- a/values.openshift.yaml
+++ b/values.openshift.yaml
@@ -1,0 +1,18 @@
+# These overrides are appropriate defaults for deploying this chart on OpenShift
+
+global:
+  openshift: true
+
+injector:
+  image:
+    repository: "registry.connect.redhat.com/hashicorp/vault-k8s"
+    tag: "0.10.1-ubi"
+
+  agentImage:
+    repository: "registry.connect.redhat.com/hashicorp/vault"
+    tag: "1.7.2-ubi"
+
+server:
+  image:
+    repository: "registry.connect.redhat.com/hashicorp/vault"
+    tag: "1.7.2-ubi"


### PR DESCRIPTION
Adds default overrides for OpenShift (values.openshift.yaml) and uses
them in the chart-verifier tests. Also updates chart-verifier to 1.0.0.

This is essentially an alternative to #538, and will require setting the overrides in values.yaml somewhere along the pipeline before the chart lands in the OpenShift helm chart repo.