### PR TITLE
injector: add templateConfig.exitOnRetryFailure annotation

### DIFF
--- a/templates/injector-deployment.yaml
+++ b/templates/injector-deployment.yaml
@@ -107,6 +107,8 @@ spec:
               value: "{{ .Values.injector.agentDefaults.memLimit }}"
             - name: AGENT_INJECT_DEFAULT_TEMPLATE
               value: "{{ .Values.injector.agentDefaults.template }}"
+            - name: AGENT_INJECT_TEMPLATE_CONFIG_EXIT_ON_RETRY_FAILURE
+              value: "{{ .Values.injector.agentDefaults.templateConfig.exitOnRetryFailure }}"
             {{- include "vault.extraEnvironmentVars" .Values.injector | nindent 12 }}
           args:
             - agent-inject

--- a/test/unit/injector-deployment.bats
+++ b/test/unit/injector-deployment.bats
@@ -640,3 +640,28 @@ load _helpers
       yq -r 'map(select(.name=="AGENT_INJECT_DEFAULT_TEMPLATE")) | .[] .value' | tee /dev/stderr)
   [ "${value}" = "json" ]
 }
+
+@test "injector/deployment: agent default template_config.exit_on_retry_failure" {
+  cd `chart_dir`
+  local object=$(helm template \
+      --show-only templates/injector-deployment.yaml  \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.containers[0].env' | tee /dev/stderr)
+
+  local value=$(echo $object |
+      yq -r 'map(select(.name=="AGENT_INJECT_TEMPLATE_CONFIG_EXIT_ON_RETRY_FAILURE")) | .[] .value' | tee /dev/stderr)
+  [ "${value}" = "true" ]
+}
+
+@test "injector/deployment: can set agent template_config.exit_on_retry_failure" {
+  cd `chart_dir`
+  local object=$(helm template \
+      --show-only templates/injector-deployment.yaml  \
+      --set='injector.agentDefaults.templateConfig.exitOnRetryFailure=false' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.containers[0].env' | tee /dev/stderr)
+
+  local value=$(echo $object |
+      yq -r 'map(select(.name=="AGENT_INJECT_TEMPLATE_CONFIG_EXIT_ON_RETRY_FAILURE")) | .[] .value' | tee /dev/stderr)
+  [ "${value}" = "false" ]
+}

--- a/values.schema.json
+++ b/values.schema.json
@@ -186,6 +186,14 @@
                         },
                         "template": {
                             "type": "string"
+                        },
+                        "templateConfig": {
+                            "type": "object",
+                            "properties": {
+                                "exitOnRetryFailure": {
+                                    "type": "boolean"
+                                }
+                            }
                         }
                     }
                 },

--- a/values.yaml
+++ b/values.yaml
@@ -75,6 +75,10 @@ injector:
     # Possible values include: "json" and "map".
     template: "map"
 
+    # Default values within Agent's template_config stanza.
+    templateConfig:
+      exitOnRetryFailure: true
+
   # Mount Path of the Vault Kubernetes Auth Method.
   authPath: "auth/kubernetes"
 


### PR DESCRIPTION
This PR adds `templateConfig.exitOnRetryFailure` annotation to the Helm chart in order to make the new parameter introduced in https://github.com/hashicorp/vault-k8s/pull/267 globally configurable.

We should hold off on merging this until the next vault-k8s release that contains the new param on agent-inject has shipped though.