### PR TITLE
Add flag to enable injector network policy

### DIFF
--- a/templates/injector-network-policy.yaml
+++ b/templates/injector-network-policy.yaml
@@ -1,4 +1,4 @@
-{{- if and (eq (.Values.injector.enabled | toString) "true" ) (eq (.Values.global.enabled | toString) "true") (eq (.Values.global.openshift | toString) "true") }}
+{{- if eq (.Values.injector.networkPolicy.enabled | toString) "true"  }}
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:

--- a/values.yaml
+++ b/values.yaml
@@ -27,6 +27,9 @@ injector:
   # True if you want to enable vault agent injection.
   enabled: true
 
+  networkPolicy:
+    enabled: false
+
   replicas: 1
 
   # Configures the port the injector should listen on


### PR DESCRIPTION
Network policy for injector was comparing three conditions with `and` predicate and that includes Openshift as well. I added a separate flag similar to server network policy to be independent of Openshift.

Signed-off-by: Majid Azimi <s.azimigehraz@reply.de>