### PR TITLE
Use imagePullSecrets as list containing only names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Improvements:
 * Add support for running the acceptance tests against a local `kind` cluster [GH-567](https://github.com/hashicorp/vault-helm/pull/567)
 * Add `server.ingress.activeService` to configure if the ingress should use the active service [GH-570](https://github.com/hashicorp/vault-helm/pull/570)
 * Add `server.route.activeService` to configure if the route should use the active service [GH-570](https://github.com/hashicorp/vault-helm/pull/570)
+* Use imagePullSecrets as list containing only names [GH-566](https://github.com/hashicorp/vault-helm/pull/566)
 
 
 ## 0.13.0 (June 17th, 2021)

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -623,3 +623,21 @@ Inject extra environment populated by secrets, if populated
 {{ "https" }}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Resolve imagePullSecrets value
+*/}}
+{{- define "vault.imagePullSecrets" -}}
+{{- if .Values.global.imagePullSecrets }}
+imagePullSecrets:
+{{- if .Values.global.imagePullSecretsAsListWithOnlyValues }}
+{{- range .Values.global.imagePullSecrets }}
+  - name: {{ . }}
+{{- end }}
+{{- else -}}
+{{- range .Values.global.imagePullSecrets }}
+  - {{ . | toYaml }}
+{{- end }}
+{{- end -}}
+{{- end -}}
+{{- end -}}

--- a/templates/csi-daemonset.yaml
+++ b/templates/csi-daemonset.yaml
@@ -78,7 +78,6 @@ spec:
          {{- toYaml .Values.csi.volumes | nindent 8}}
        {{- end }}
       {{- if .Values.global.imagePullSecrets }}
-      imagePullSecrets:
-        {{- toYaml .Values.global.imagePullSecrets | nindent 8 }}
+        {{- include "vault.imagePullSecrets" . | nindent 6 }}
       {{- end }}
 {{- end }}

--- a/templates/injector-deployment.yaml
+++ b/templates/injector-deployment.yaml
@@ -175,7 +175,6 @@ spec:
             secretName: "{{ .Values.injector.certs.secretName }}"
 {{- end }}
       {{- if .Values.global.imagePullSecrets }}
-      imagePullSecrets:
-        {{- toYaml .Values.global.imagePullSecrets | nindent 8 }}
+        {{- include "vault.imagePullSecrets" . | nindent 6 }}
       {{- end }}
 {{ end }}

--- a/templates/server-statefulset.yaml
+++ b/templates/server-statefulset.yaml
@@ -203,8 +203,7 @@ spec:
           {{ toYaml .Values.server.extraContainers | nindent 8}}
         {{- end }}
       {{- if .Values.global.imagePullSecrets }}
-      imagePullSecrets:
-        {{- toYaml .Values.global.imagePullSecrets | nindent 8 }}
+        {{- include "vault.imagePullSecrets" . | nindent 6 }}
       {{- end }}
   {{ template "vault.volumeclaims" . }}
 {{ end }}

--- a/values.yaml
+++ b/values.yaml
@@ -8,6 +8,11 @@ global:
   imagePullSecrets: []
   # imagePullSecrets:
   #   - name: image-pull-secret
+  # setting the below flag to true will accept imagePullSecrets as list containing only values.
+  # eg:
+  # imagePullSecrets:
+  #   - image-pull-secret
+  imagePullSecretsAsListWithOnlyValues: false
   # TLS for end-to-end encrypted transport
   tlsDisable: true
   # If deploying to OpenShift


### PR DESCRIPTION
While using vault chart in platform chart implementations, it's causing an error with the way imagePullSecrets is defined.
Most of the common chart implementations have imagePullSecrets to accepts only names as a list.
this pr won’t have any breaking change. We have added a flag that will accept imagePullSecret as list containing only names
Default way
```
   imagePullSecrets:
     - name: <secret_name>
```
will also accept
```
  imagePullSecrets:
    - <secret_name>
```
