### PR TITLE
Update acceptance tests to use the new stable GKE version 1.18.x

### DIFF
--- a/test/terraform/main.tf
+++ b/test/terraform/main.tf
@@ -8,7 +8,7 @@ resource "random_id" "suffix" {
 
 data "google_container_engine_versions" "main" {
   location = "${var.zone}"
-  version_prefix = "1.17."
+  version_prefix = "1.18."
 }
 
 data "google_service_account" "gcpapi" {


### PR DESCRIPTION
Google recently moved the GKE stable channel from 1.17.x to 1.18.x which broke our acceptance tests. So let's update the 
tests!

Fixes: https://app.circleci.com/pipelines/github/hashicorp/vault-helm/882/workflows/a798dc39-75aa-4a9e-83bc-9d36b73dfee0/jobs/1225

Successful local test run using 1.18:

```
make test-acceptance CLOUDSDK_CORE_PROJECT=xxxxxxx                                                                                                                                                                                
gcloud auth activate-service-account --key-file=vault-helm-test.json
Activated service account credentials for: [xxxxxxx]
bats test/acceptance

1..11
ok 1 csi: testing deployment
ok 2 helm/test: running helm test
ok 3 injector: testing leader elector
ok 4 injector: testing deployment
ok 5 server/annotations: testing yaml and yaml-formatted string formats
ok 6 server/dev: testing deployment
ok 7 server/ha-enterprise-raft: testing DR deployment
ok 8 server/ha-enterprise-raft: testing performance replica deployment
ok 9 server/ha-raft: testing deployment
ok 10 server/ha: testing deployment
ok 11 server/standalone: testing deployment
