### PR TITLE
Add ingress/route configurable to specify active/general service

### DIFF
--- a/templates/server-ingress.yaml
+++ b/templates/server-ingress.yaml
@@ -4,7 +4,7 @@
 {{- if .Values.server.ingress.enabled -}}
 {{- $extraPaths := .Values.server.ingress.extraPaths -}}
 {{- $serviceName := include "vault.fullname" . -}}
-{{- if and (eq .mode "ha" ) (eq (.Values.server.service.enabled | toString) "true" ) (eq (.Values.global.enabled | toString) "true") }}
+{{- if and (eq .mode "ha" ) (eq (.Values.server.service.enabled | toString) "true" ) (eq (.Values.global.enabled | toString) "true") (eq (.Values.server.ingress.activeService | toString) "true") }}
 {{- $serviceName = printf "%s-%s" $serviceName "active" -}}
 {{- end }}
 {{- $servicePort := .Values.server.service.port -}}

--- a/templates/server-route.yaml
+++ b/templates/server-route.yaml
@@ -2,7 +2,7 @@
 {{- if ne .mode "external" }}
 {{- if .Values.server.route.enabled -}}
 {{- $serviceName := include "vault.fullname" . -}}
-{{- if eq .mode "ha" }}
+{{- if and (eq .mode "ha" ) (eq (.Values.server.route.activeService | toString) "true") }}
 {{- $serviceName = printf "%s-%s" $serviceName "active" -}}
 {{- end }}
 kind: Route

--- a/test/unit/server-ingress.bats
+++ b/test/unit/server-ingress.bats
@@ -131,7 +131,7 @@ load _helpers
   [ "${actual}" = "nginx" ]
 }
 
-@test "server/ingress: uses active service when ha - yaml" {
+@test "server/ingress: uses active service when ha by default - yaml" {
   cd `chart_dir`
 
   local actual=$(helm template \
@@ -145,12 +145,42 @@ load _helpers
   [ "${actual}" = "RELEASE-NAME-vault-active" ]
 }
 
+@test "server/ingress: uses regular service when configured with ha - yaml" {
+  cd `chart_dir`
+
+  local actual=$(helm template \
+      --show-only templates/server-ingress.yaml \
+      --set 'server.ingress.enabled=true' \
+      --set 'server.ingress.activeService=false' \
+      --set 'server.dev.enabled=false' \
+      --set 'server.ha.enabled=true' \
+      --set 'server.service.enabled=true' \
+      . | tee /dev/stderr |
+      yq -r '.spec.rules[0].http.paths[0].backend.serviceName' | tee /dev/stderr)
+  [ "${actual}" = "RELEASE-NAME-vault" ]
+}
+
 @test "server/ingress: uses regular service when not ha - yaml" {
   cd `chart_dir`
 
   local actual=$(helm template \
       --show-only templates/server-ingress.yaml \
       --set 'server.ingress.enabled=true' \
+      --set 'server.dev.enabled=false' \
+      --set 'server.ha.enabled=false' \
+      --set 'server.service.enabled=true' \
+      . | tee /dev/stderr |
+      yq -r '.spec.rules[0].http.paths[0].backend.serviceName' | tee /dev/stderr)
+  [ "${actual}" = "RELEASE-NAME-vault" ]
+}
+
+@test "server/ingress: uses regular service when not ha and activeService is true- yaml" {
+  cd `chart_dir`
+
+  local actual=$(helm template \
+      --show-only templates/server-ingress.yaml \
+      --set 'server.ingress.enabled=true' \
+      --set 'server.ingress.activeService=true' \
       --set 'server.dev.enabled=false' \
       --set 'server.ha.enabled=false' \
       --set 'server.service.enabled=true' \

--- a/test/unit/server-ingress.bats
+++ b/test/unit/server-ingress.bats
@@ -174,7 +174,7 @@ load _helpers
   [ "${actual}" = "RELEASE-NAME-vault" ]
 }
 
-@test "server/ingress: uses regular service when not ha and activeService is true- yaml" {
+@test "server/ingress: uses regular service when not ha and activeService is true - yaml" {
   cd `chart_dir`
 
   local actual=$(helm template \

--- a/test/unit/server-route.bats
+++ b/test/unit/server-route.bats
@@ -102,7 +102,20 @@ load _helpers
   [ "${actual}" = "RELEASE-NAME-vault" ]
 }
 
-@test "server/route: OpenShift - route points to active service by when HA" {
+@test "server/route: OpenShift - route points to main service when not ha and activeService is true" {
+  cd `chart_dir`
+
+  local actual=$(helm template \
+      --show-only templates/server-route.yaml \
+      --set 'global.openshift=true' \
+      --set 'server.route.enabled=true' \
+      --set 'server.route.activeService=true' \
+      . | tee /dev/stderr |
+      yq -r '.spec.to.name' | tee /dev/stderr)
+  [ "${actual}" = "RELEASE-NAME-vault" ]
+}
+
+@test "server/route: OpenShift - route points to active service by when HA by default" {
   cd `chart_dir`
 
   local actual=$(helm template \
@@ -113,4 +126,18 @@ load _helpers
       . | tee /dev/stderr |
       yq -r '.spec.to.name' | tee /dev/stderr)
   [ "${actual}" = "RELEASE-NAME-vault-active" ]
+}
+
+@test "server/route: OpenShift - route points to general service by when HA when configured" {
+  cd `chart_dir`
+
+  local actual=$(helm template \
+      --show-only templates/server-route.yaml \
+      --set 'global.openshift=true' \
+      --set 'server.route.enabled=true' \
+      --set 'server.route.activeService=false' \
+      --set 'server.ha.enabled=true' \
+      . | tee /dev/stderr |
+      yq -r '.spec.to.name' | tee /dev/stderr)
+  [ "${actual}" = "RELEASE-NAME-vault" ]
 }

--- a/values.schema.json
+++ b/values.schema.json
@@ -564,6 +564,9 @@
                 "ingress": {
                     "type": "object",
                     "properties": {
+                        "activeService": {
+                            "type": "boolean"
+                        },
                         "annotations": {
                             "type": [
                                 "object",
@@ -686,6 +689,9 @@
                 "route": {
                     "type": "object",
                     "properties": {
+                        "activeService": {
+                            "type": "boolean"
+                        },
                         "annotations": {
                             "type": [
                                 "object",

--- a/values.yaml
+++ b/values.yaml
@@ -259,6 +259,10 @@ server:
       #   or
       # kubernetes.io/ingress.class: nginx
       # kubernetes.io/tls-acme: "true"
+
+    # When HA mode is enabled and K8s service registration is being used,
+    # configure the ingress to point to the Vault active service.
+    activeService: true
     hosts:
       - host: chart-example.local
         paths: []
@@ -277,6 +281,11 @@ server:
   # The created route will be of type passthrough
   route:
     enabled: false
+
+    # When HA mode is enabled and K8s service registration is being used,
+    # configure the route to point to the Vault active service.
+    activeService: true
+
     labels: {}
     annotations: {}
     host: chart-example.local


### PR DESCRIPTION
Currently when using ingress/routes, if HA mode is enabled, these services will always point to the active service. There are use cases, such as performance standbys, where the ingress should instead point to the general Vault service instead. 

This adds two new boolean configs `server.ingress.activeService` and `server.route.activeService` to make this configurable.