### PR TITLE
Add imagePullSecrets on server test

### DIFF
--- a/templates/tests/server-test.yaml
+++ b/templates/tests/server-test.yaml
@@ -7,8 +7,7 @@ metadata:
   annotations:
     "helm.sh/hook": test
 spec:
-  imagePullSecrets:
-    {{- toYaml .Values.global.imagePullSecrets | nindent 8 }}
+  {{- include "imagePullSecrets" . | nindent 6 }}
   containers:
     - name: {{ .Release.Name }}-server-test
       image: {{ .Values.server.image.repository }}:{{ .Values.server.image.tag | default "latest" }}

--- a/templates/tests/server-test.yaml
+++ b/templates/tests/server-test.yaml
@@ -7,6 +7,8 @@ metadata:
   annotations:
     "helm.sh/hook": test
 spec:
+  imagePullSecrets:
+    {{- toYaml .Values.global.imagePullSecrets | nindent 8 }}
   containers:
     - name: {{ .Release.Name }}-server-test
       image: {{ .Values.server.image.repository }}:{{ .Values.server.image.tag | default "latest" }}

--- a/templates/tests/server-test.yaml
+++ b/templates/tests/server-test.yaml
@@ -7,7 +7,7 @@ metadata:
   annotations:
     "helm.sh/hook": test
 spec:
-  {{- include "imagePullSecrets" . | nindent 6 }}
+  {{- include "imagePullSecrets" . | nindent 2 }}
   containers:
     - name: {{ .Release.Name }}-server-test
       image: {{ .Values.server.image.repository }}:{{ .Values.server.image.tag | default "latest" }}


### PR DESCRIPTION
When deploying Vault on a private cluster and a private secured repository, server-test pull image fails cause of credentials

I propose  to add imagePullSecrets on the pod