### PR TITLE
Update chart verifier

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,7 @@ jobs:
       - image: docker.mirror.hashicorp.services/cimg/go:1.16
     environment:
       BATS_VERSION: "1.3.0"
-      CHART_VERIFIER_VERSION: "1.0.0"
+      CHART_VERIFIER_VERSION: "1.2.1"
     steps:
       - checkout
       - run:

--- a/test/chart/verifier.bats
+++ b/test/chart/verifier.bats
@@ -6,8 +6,7 @@ setup_file() {
     cd `chart_dir`
     export VERIFY_OUTPUT="/$BATS_RUN_TMPDIR/verify.json"
     export CHART_VOLUME=vault-helm-chart-src
-    # Note: currently `latest` is the only tag available in the chart-verifier repo.
-    local IMAGE="quay.io/redhat-certification/chart-verifier:latest"
+    local IMAGE="quay.io/redhat-certification/chart-verifier:1.2.1"
     # chart-verifier requires an openshift version if a cluster isn't available
     local OPENSHIFT_VERSION="4.8"
     local DISABLED_TESTS="chart-testing"
@@ -24,7 +23,7 @@ setup_file() {
         # Make sure we have the latest version of chart-verifier
         docker pull $IMAGE
         # Start chart-verifier using this volume
-        run_cmd="docker run --rm --volumes-from $CHART_VOLUME $IMAGE"
+        run_cmd="docker run --rm --volumes-from $CHART_VOLUME -w $chart_src $IMAGE"
     fi
 
     $run_cmd verify $chart_src \

--- a/test/chart/verifier.bats
+++ b/test/chart/verifier.bats
@@ -9,7 +9,7 @@ setup_file() {
     # Note: currently `latest` is the only tag available in the chart-verifier repo.
     local IMAGE="quay.io/redhat-certification/chart-verifier:latest"
     # chart-verifier requires an openshift version if a cluster isn't available
-    local OPENSHIFT_VERSION="4.7"
+    local OPENSHIFT_VERSION="4.8"
     local DISABLED_TESTS="chart-testing"
 
     local run_cmd="chart-verifier"
@@ -41,46 +41,46 @@ teardown_file() {
 }
 
 @test "has-kubeversion" {
-    check_result has-kubeversion
+    check_result v1.0/has-kubeversion
 }
 
 @test "is-helm-v3" {
-    check_result is-helm-v3
+    check_result v1.0/is-helm-v3
 }
 
 @test "not-contains-crds" {
-    check_result not-contains-crds
+    check_result v1.0/not-contains-crds
 }
 
 @test "helm-lint" {
-    check_result helm-lint
+    check_result v1.0/helm-lint
 }
 
 @test "not-contain-csi-objects" {
-    check_result not-contain-csi-objects
+    check_result v1.0/not-contain-csi-objects
 }
 
 @test "has-readme" {
-    check_result has-readme
+    check_result v1.0/has-readme
 }
 
 @test "contains-values" {
-    check_result contains-values
+    check_result v1.0/contains-values
 }
 
 @test "contains-values-schema" {
-    check_result contains-values-schema
+    check_result v1.0/contains-values-schema
 }
 
 @test "contains-test" {
-    check_result contains-test
+    check_result v1.0/contains-test
 }
 
 @test "images-are-certified" {
-    check_result images-are-certified
+    check_result v1.0/images-are-certified
 }
 
 @test "chart-testing" {
     skip "Skipping since this test requires a kubernetes/openshift cluster"
-    check_result chart-testing
+    check_result v1.0/chart-testing
 }


### PR DESCRIPTION
Updates the version of [chart-verifier](https://github.com/redhat-certification/chart-verifier) in use in CI to 1.2.1. 

The tests it runs appear to all be the same, just with slightly different output/names.

The tests can be run locally with bats by using the chart-verifier docker image:

```console
USE_DOCKER=true bats test/chart/verifier.bats
```

Or by installing the chart-verifier binary and running the tests:

```console
go get github.com/redhat-certification/chart-verifier@1.2.1

bats test/chart/verifier.bats
```