### PR TITLE
Add injector.webhookAnnotations chart option

### DIFF
--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -354,6 +354,21 @@ Sets extra injector service annotations
 {{- end -}}
 
 {{/*
+Sets extra injector webhook annotations
+*/}}
+{{- define "injector.webhookAnnotations" -}}
+  {{- if .Values.injector.webhookAnnotations }}
+  annotations:
+    {{- $tp := typeOf .Values.injector.webhookAnnotations }}
+    {{- if eq $tp "string" }}
+      {{- tpl .Values.injector.webhookAnnotations . | nindent 4 }}
+    {{- else }}
+      {{- toYaml .Values.injector.webhookAnnotations | nindent 4 }}
+    {{- end }}
+  {{- end }}
+{{- end -}}
+
+{{/*
 Sets extra ui service annotations
 */}}
 {{- define "vault.ui.annotations" -}}

--- a/templates/injector-mutating-webhook.yaml
+++ b/templates/injector-mutating-webhook.yaml
@@ -11,6 +11,7 @@ metadata:
     app.kubernetes.io/name: {{ include "vault.name" . }}-agent-injector
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
+  {{- template "injector.webhookAnnotations" . }}
 webhooks:
   - name: vault.hashicorp.com
     sideEffects: None

--- a/test/unit/injector-mutating-webhook.bats
+++ b/test/unit/injector-mutating-webhook.bats
@@ -121,3 +121,35 @@ load _helpers
 
   [ "${actual}" = "\"Fail\"" ]
 }
+
+#--------------------------------------------------------------------
+# annotations
+
+@test "injector/MutatingWebhookConfiguration: default annotations" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/injector-mutating-webhook.yaml \
+      . | tee /dev/stderr |
+      yq -r '.metadata.annotations' | tee /dev/stderr)
+  [ "${actual}" = "null" ]
+}
+
+@test "injector/MutatingWebhookConfiguration: specify annotations yaml" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/injector-mutating-webhook.yaml \
+      --set 'injector.webhookAnnotations.foo=bar' \
+      . | tee /dev/stderr |
+      yq -r '.metadata.annotations.foo' | tee /dev/stderr)
+  [ "${actual}" = "bar" ]
+}
+
+@test "injector/MutatingWebhookConfiguration: specify annotations yaml string" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/injector-mutating-webhook.yaml \
+      --set 'injector.webhookAnnotations=foo: bar' \
+      . | tee /dev/stderr |
+      yq -r '.metadata.annotations.foo' | tee /dev/stderr)
+  [ "${actual}" = "bar" ]
+}

--- a/values.schema.json
+++ b/values.schema.json
@@ -357,6 +357,12 @@
                         "array",
                         "string"
                     ]
+                },
+                "webhookAnnotations": {
+                    "type": [
+                        "object",
+                        "string"
+                    ]
                 }
             }
         },

--- a/values.yaml
+++ b/values.yaml
@@ -119,6 +119,9 @@ injector:
   #
   failurePolicy: Ignore
 
+  # Extra annotations to attach to the webhook
+  webhookAnnotations: {}
+
   certs:
     # secretName is the name of the secret that has the TLS certificate and
     # private key to serve the injector webhook. If this is null, then the
@@ -126,9 +129,10 @@ injector:
     # a service account to the injector to generate its own certificates.
     secretName: null
 
-    # caBundle is a base64-encoded PEM-encoded certificate bundle for the
-    # CA that signed the TLS certificate that the webhook serves. This must
-    # be set if secretName is non-null.
+    # caBundle is a base64-encoded PEM-encoded certificate bundle for the CA
+    # that signed the TLS certificate that the webhook serves. This must be set
+    # if secretName is non-null, unless an external service like cert-manager is
+    # keeping the caBundle updated.
     caBundle: ""
 
     # certName and keyName are the names of the files within the secret for


### PR DESCRIPTION
Allows setting annotations on the mutating webhook config.

For example, if cert-manager is managing the certificates for vault-k8s, that would require [setting the CA cert in the chart values (`injector.certs.caBundle`)](https://www.vaultproject.io/docs/platform/k8s/helm/examples/injector-tls-cert-manager#configuration). But, if the [`cert-manager.io/inject-ca-from: <namespace>/<secret>` annotation](https://cert-manager.io/docs/concepts/ca-injector/) is set on the mutating webhook config, cert-manager will keep the mutating webhook config updated with the CA from the Secret.