### PR TITLE
Vault Injector Web Hook should be registered before deployment of the dependent pods

### DIFF
--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -99,6 +99,7 @@ extra volumes the user may have specified (such as a secret with TLS).
             secretName: {{ .name }}
           {{- end }}
             defaultMode: {{ .defaultMode | default 420 }}
+            optional: {{ .optional | default "false" }}
   {{- end }}
   {{- if .Values.server.volumes }}
     {{- toYaml .Values.server.volumes | nindent 8}}

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -577,3 +577,18 @@ Inject extra environment populated by secrets, if populated
 {{ "https" }}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Sets mutating web hook annotations
+*/}}
+{{- define "webhook.annotations" -}}
+  {{- if .Values.injector.webhook.annotations }}
+  annotations:
+      {{- $tp := typeOf .Values.injector.webhook.annotations }}
+      {{- if eq $tp "string" }}
+        {{- tpl .Values.injector.webhook.annotations . | nindent 4 }}
+      {{- else }}
+        {{- toYaml .Values.injector.webhook.annotations | nindent 4 }}
+      {{- end }}
+  {{- end }}
+{{- end -}}

--- a/templates/injector-mutating-webhook.yaml
+++ b/templates/injector-mutating-webhook.yaml
@@ -11,6 +11,7 @@ metadata:
     app.kubernetes.io/name: {{ include "vault.name" . }}-agent-injector
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
+  {{ template "webhook.annotations" . }}  
 webhooks:
   - name: vault.hashicorp.com
     sideEffects: None

--- a/test/unit/injector-mutating-webhook.bats
+++ b/test/unit/injector-mutating-webhook.bats
@@ -121,3 +121,23 @@ load _helpers
 
   [ "${actual}" = "\"Fail\"" ]
 }
+
+@test "injector/MutatingWebhookConfiguration: annotations empty by default" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/injector-mutating-webhook.yaml  \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.metadata.annotations.foo' | tee /dev/stderr)
+  [ "${actual}" = "null" ]
+}
+
+@test "injector/MutatingWebhookConfiguration: specify annotations" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/injector-mutating-webhook.yaml  \
+      --set 'injector.webhook.annotations=foo: bar' \
+      . | tee /dev/stderr |
+      yq -r '.metadata.annotations.foo' | tee /dev/stderr)
+
+  [ "${actual}" = "bar" ]
+}

--- a/values.yaml
+++ b/values.yaml
@@ -374,6 +374,7 @@ server:
     # - type: secret (or "configMap")
     #   name: my-secret
     #   path: null # default is `/vault/userconfig`
+    #   optional: if need to mount configMap as optional # default is false
 
   # volumes is a list of volumes made available to all containers. These are rendered
   # via toYaml rather than pre-processed like the extraVolumes value.

--- a/values.yaml
+++ b/values.yaml
@@ -194,6 +194,15 @@ injector:
     # Extra annotations to attach to the injector service
     annotations: {}
 
+  webhook:
+    #example
+    #annotations:
+    #  helm.sh/hook: "pre-install,pre-upgrade"
+    #  helm.sh/hook-weight: "0"
+    annotations: {}
+
+
+
 server:
   # If not set to true, Vault server will not be installed. See vault.mode in _helpers.tpl for implementation details
   enabled: true


### PR DESCRIPTION
Issue:  If vault webhook is not registered before deployment of a dependent pod, then vault(init/side-car) containers will not be added to the pod.

As helm doesn't guarantee the order of creation of webhook, there is a race condition where the dependent pod gets deployed before the webhook and hence sidecar injection failed.

In this case, the vault has to be installed as a separate chart. To avoid that, adding annotations to the webhook making sure that it gets created first.

Solution:  Added helm hook annotations to register the webhook during pre-installation/pre-upgrade steps.