### PR TITLE
Add server.ingress.ingressClassName

### DIFF
--- a/templates/server-ingress.yaml
+++ b/templates/server-ingress.yaml
@@ -37,6 +37,9 @@ spec:
       secretName: {{ .secretName }}
   {{- end }}
 {{- end }}
+{{- if .Values.server.ingress.ingressClassName }}
+  ingressClassName: {{ .Values.server.ingress.ingressClassName }}
+{{- end }}
   rules:
   {{- range .Values.server.ingress.hosts }}
     - host: {{ .host | quote }}

--- a/test/unit/server-ingress.bats
+++ b/test/unit/server-ingress.bats
@@ -131,6 +131,18 @@ load _helpers
   [ "${actual}" = "nginx" ]
 }
 
+@test "server/ingress: ingressClassName added to object spec - string" {
+  cd `chart_dir`
+
+  local actual=$(helm template \
+      --show-only templates/server-ingress.yaml \
+      --set 'server.ingress.enabled=true' \
+      --set server.ingress.ingressClassName=nginx \
+      . | tee /dev/stderr |
+      yq -r '.spec.ingressClassName' | tee /dev/stderr)
+  [ "${actual}" = "nginx" ]
+}
+
 @test "server/ingress: uses active service when ha by default - yaml" {
   cd `chart_dir`
 

--- a/values.schema.json
+++ b/values.schema.json
@@ -593,6 +593,9 @@
                                 }
                             }
                         },
+                        "ingressClassName": {
+                            "type": "string"
+                        },
                         "labels": {
                             "type": "object"
                         },

--- a/values.yaml
+++ b/values.yaml
@@ -261,6 +261,10 @@ server:
       # kubernetes.io/ingress.class: nginx
       # kubernetes.io/tls-acme: "true"
 
+    # Optionally use ingressClassName instead of deprecated annotation.
+    # See: https://kubernetes.io/docs/concepts/services-networking/ingress/#deprecated-annotation
+    ingressClassName: ~
+
     # When HA mode is enabled and K8s service registration is being used,
     # configure the ingress to point to the Vault active service.
     activeService: true


### PR DESCRIPTION
Support "ingressClassName" field for ingress resources to move away from deprecated annotation
#542 

(See: [https://kubernetes.io/docs/concepts/services-networking/ingress/#deprecated-annotation](https://kubernetes.io/docs/concepts/services-networking/ingress/#deprecated-annotation))

Results of unit tests:
```shell
$ docker run -it --rm -v "${PWD}:/test" vault-helm-test bats /test/test/unit -f "ingressClassName"
1..1
ok 1 server/ingress: ingressClassName added to object spec - string
```