### PR TITLE
injector: ability to set deployment update strategy

### DIFF
--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -309,6 +309,21 @@ Sets the injector node selector for pod placement
 {{- end -}}
 
 {{/*
+Sets the injector deployment update strategy
+*/}}
+{{- define "injector.strategy" -}}
+  {{- if .Values.injector.strategy }}
+  strategy:
+  {{- $tp := typeOf .Values.injector.strategy }}
+  {{- if eq $tp "string" }}
+    {{ tpl .Values.injector.strategy . | nindent 4 | trim }}
+  {{- else }}
+    {{- toYaml .Values.injector.strategy | nindent 4 }}
+  {{- end }}
+  {{- end }}
+{{- end -}}
+
+{{/*
 Sets extra pod annotations
 */}}
 {{- define "vault.annotations" -}}

--- a/templates/injector-deployment.yaml
+++ b/templates/injector-deployment.yaml
@@ -17,6 +17,7 @@ spec:
       app.kubernetes.io/name: {{ template "vault.name" . }}-agent-injector
       app.kubernetes.io/instance: {{ .Release.Name }}
       component: webhook
+  {{ template "injector.strategy" . }}
   template:
     metadata:
       labels:

--- a/test/unit/injector-deployment.bats
+++ b/test/unit/injector-deployment.bats
@@ -696,3 +696,32 @@ load _helpers
       yq -r 'map(select(.name=="AGENT_INJECT_TEMPLATE_CONFIG_EXIT_ON_RETRY_FAILURE")) | .[] .value' | tee /dev/stderr)
   [ "${value}" = "false" ]
 }
+
+@test "injector/deployment: strategy default" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/injector-deployment.yaml  \
+      . | tee /dev/stderr |
+      yq -r '.spec.strategy.rollingUpdate.maxUnavailable' | tee /dev/stderr)
+  [ "${actual}" = "25%" ]
+}
+
+@test "injector/deployment: strategy set as string" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/injector-deployment.yaml  \
+      --set="injector.strategy=testing"  \
+      . | tee /dev/stderr |
+      yq -r '.spec.strategy' | tee /dev/stderr)
+  [ "${actual}" = "testing" ]
+}
+
+@test "injector/deployment: strategy can be set as YAML" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/injector-deployment.yaml \
+      --set 'injector.strategy.rollingUpdate.maxUnavailable=1' \
+      . | tee /dev/stderr |
+      yq -r '.spec.strategy.rollingUpdate.maxUnavailable' | tee /dev/stderr)
+  [ "${actual}" = "1" ]
+}

--- a/values.yaml
+++ b/values.yaml
@@ -202,6 +202,13 @@ injector:
     # Extra annotations to attach to the injector service
     annotations: {}
 
+  # strategy for updating the deployment. This can be a multi-line string or a YAML map.
+  strategy: |
+    rollingUpdate:
+      maxSurge: 25%
+      maxUnavailable: 25%
+    type: RollingUpdate
+
 server:
   # If not set to true, Vault server will not be installed. See vault.mode in _helpers.tpl for implementation details
   enabled: true


### PR DESCRIPTION
I have a cluster with 2 worker nodes. When deploying the injector with 2 replicas, any updates that require a change to the deployment will cause the new pods to get stuck in a pending state due to the affinity settings. If the `.spec.strategy.rollingUpdate.maxUnavailable` is able to be set to `1` instead of `25%`, this problem can be avoided in my small clusters.