### PR TITLE
Added ability to specify resources for Leader Elector container in Injector deployment 

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: vault
-version: 0.14.0
+version: 0.15.0
 appVersion: 1.8.0
 kubeVersion: ">= 1.14.0-0"
 description: Official HashiCorp Vault Chart

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -536,6 +536,16 @@ Sets the container resources if the user has set any.
 {{/*
 Sets the container resources if the user has set any.
 */}}
+{{- define "injector.leaderElector.resources" -}}
+  {{- if .Values.injector.leaderElector.resources -}}
+          resources:
+{{ toYaml .Values.injector.leaderElector.resources | indent 12}}
+  {{ end }}
+{{- end -}}
+
+{{/*
+Sets the container resources if the user has set any.
+*/}}
 {{- define "csi.resources" -}}
   {{- if .Values.csi.resources -}}
           resources:

--- a/templates/injector-deployment.yaml
+++ b/templates/injector-deployment.yaml
@@ -147,6 +147,7 @@ spec:
             - --election-namespace={{ .Release.Namespace }}
             - --http=0.0.0.0:4040
             - --ttl={{ .Values.injector.leaderElector.ttl }}
+          {{ template "injector.leaderElector.resources" . }}
           livenessProbe:
             httpGet:
               path: /

--- a/values.yaml
+++ b/values.yaml
@@ -41,6 +41,14 @@ injector:
       repository: "gcr.io/google_containers/leader-elector"
       tag: "0.4"
     ttl: 60s
+    resources: {}
+    # resources:
+    #   requests:
+    #     memory: 128Mi
+    #     cpu: 100m
+    #   limits:
+    #     memory: 128Mi
+    #     cpu: 100m
 
   # If true, will enable a node exporter metrics endpoint at /metrics.
   metrics:


### PR DESCRIPTION
Added ability to specify resources for Leader Elector container in Injector deployment  (enhancement based on issue #524 - https://github.com/hashicorp/vault-helm/issues/524).