### PR TITLE
Update csi provider to support OpenShift

### DIFF
--- a/templates/NOTES.txt
+++ b/templates/NOTES.txt
@@ -12,3 +12,18 @@ Your release is named {{ .Release.Name }}. To learn more about the release, try:
   $ helm status {{ .Release.Name }}
   $ helm get manifest {{ .Release.Name }}
 
+{{ if and .Values.global.openshift .Values.csi.enabled }}
+Check that the {{ template "vault.fullname" . }}-csi-provider DaemonSet has
+the correct number of Pods running:
+
+$ kubectl -n {{ .Release.Namespace }} get daemonset {{ template "vault.fullname" . }}-csi-provider
+
+NAME                 DESIRED   CURRENT   READY   UP-TO-DATE   AVAILABLE   NODE SELECTOR   AGE
+{{ template "vault.fullname" . }}-csi-provider   2         2         2       2            2           <none>          17m
+
+If not ask your OpenShift Administrator to apply the `privileged`
+Security Context Control like so:
+
+$ oc adm policy add-scc-to-user privileged \
+   system:serviceaccount:{{ .Release.Namespace }}:{{ template "vault.fullname" . }}-csi-provider
+{{ end }}

--- a/templates/csi-daemonset.yaml
+++ b/templates/csi-daemonset.yaml
@@ -67,6 +67,10 @@ spec:
             periodSeconds: {{ .Values.csi.readinessProbe.periodSeconds }}
             successThreshold: {{ .Values.csi.readinessProbe.successThreshold }}
             timeoutSeconds: {{ .Values.csi.readinessProbe.timeoutSeconds }}
+          {{- if .Values.global.openshift }}
+          securityContext:
+            privileged: true
+          {{- end }}
       volumes:
         - name: providervol
           hostPath:


### PR DESCRIPTION
OpenShift requires the Pod to be privileged to run as a user to be able
to write data to the host volume.  It also requires an SCC to applied
by the OpenShift administrator as noted in NOTES.

Signed-off-by: Paul Czarkowski <username.taken@gmail.com>