### PR TITLE
Added variables to server-route.yaml to make it more flexible about ssl

### DIFF
--- a/templates/server-route.yaml
+++ b/templates/server-route.yaml
@@ -27,7 +27,8 @@ spec:
   port:
     targetPort: 8200
   tls:
-    termination: passthrough
+    termination: {{ .Values.server.route.tls.termination }}
+    insecureEdgeTerminationPolicy: {{ .Values.server.route.tls.insecureEdgeTerminationPolicy }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/values.yaml
+++ b/values.yaml
@@ -294,6 +294,9 @@ server:
     labels: {}
     annotations: {}
     host: chart-example.local
+    tls:
+      termination: passthrough
+      # insecureEdgeTerminationPolicy: Redirect
 
   # authDelegator enables a cluster role binding to be attached to the service
   # account.  This cluster role binding can be used to setup Kubernetes auth


### PR DESCRIPTION
Using OpenShift.
I have some work to figure out that I can't use the default route tls configuration as `passthrough` because I wasn't using a valid certificate. Then my motivation to help other people that want to use this helm chart and have more flexibility to configure the tls using just the values.yaml.