### PR TITLE
feat(csi/providersDir): add configurable providersDir

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: vault
-version: 0.15.0
+version: 0.15.1
 appVersion: 1.8.1
 kubeVersion: ">= 1.14.0-0"
 description: Official HashiCorp Vault Chart

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: vault
-version: 0.15.1
+version: 0.15.0
 appVersion: 1.8.1
 kubeVersion: ">= 1.14.0-0"
 description: Official HashiCorp Vault Chart

--- a/templates/csi-daemonset.yaml
+++ b/templates/csi-daemonset.yaml
@@ -70,7 +70,7 @@ spec:
       volumes:
         - name: providervol
           hostPath:
-            path: "/etc/kubernetes/secrets-store-csi-providers"
+            path: {{ .Values.csi.daemonSet.providersDir }}
         - name: mountpoint-dir
           hostPath:
             path: /var/lib/kubelet/pods

--- a/templates/csi-daemonset.yaml
+++ b/templates/csi-daemonset.yaml
@@ -73,7 +73,7 @@ spec:
             path: {{ .Values.csi.daemonSet.providersDir }}
         - name: mountpoint-dir
           hostPath:
-            path: /var/lib/kubelet/pods
+            path: {{ .Values.csi.daemonSet.kubeletRootDir }}/pods
        {{- if .Values.csi.volumes }}
          {{- toYaml .Values.csi.volumes | nindent 8}}
        {{- end }}

--- a/test/unit/csi-daemonset.bats
+++ b/test/unit/csi-daemonset.bats
@@ -315,6 +315,68 @@ load _helpers
   [ "${actual}" = "{}" ]
 }
 
+@test "csi/daemonset: csi providersDir default" {
+  cd `chart_dir`
+
+  # Test that it defines it
+  local object=$(helm template \
+      --show-only templates/csi-daemonset.yaml  \
+      --set 'csi.enabled=true' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.volumes[] | select(.name == "providervol")' | tee /dev/stderr)
+
+  local actual=$(echo $object |
+      yq -r '.hostPath.path' | tee /dev/stderr)
+  [ "${actual}" = "/etc/kubernetes/secrets-store-csi-providers" ]
+}
+
+@test "csi/daemonset: csi kubeletRootDir default" {
+  cd `chart_dir`
+
+  # Test that it defines it
+  local object=$(helm template \
+      --show-only templates/csi-daemonset.yaml  \
+      --set 'csi.enabled=true' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.volumes[] | select(.name == "mountpoint-dir")' | tee /dev/stderr)
+
+  local actual=$(echo $object |
+      yq -r '.hostPath.path' | tee /dev/stderr)
+  [ "${actual}" = "/var/lib/kubelet/pods" ]
+}
+
+@test "csi/daemonset: csi providersDir override " {
+  cd `chart_dir`
+
+  # Test that it defines it
+  local object=$(helm template \
+      --show-only templates/csi-daemonset.yaml  \
+      --set 'csi.enabled=true' \
+      --set 'csi.daemonSet.providersDir=/alt/csi-prov-dir' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.volumes[] | select(.name == "providervol")' | tee /dev/stderr)
+
+  local actual=$(echo $object |
+      yq -r '.hostPath.path' | tee /dev/stderr)
+  [ "${actual}" = "/alt/csi-prov-dir" ]
+}
+
+@test "csi/daemonset: csi kubeletRootDir override" {
+  cd `chart_dir`
+
+  # Test that it defines it
+  local object=$(helm template \
+      --show-only templates/csi-daemonset.yaml  \
+      --set 'csi.enabled=true' \
+      --set 'csi.daemonSet.kubeletRootDir=/alt/kubelet-root' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.volumes[] | select(.name == "mountpoint-dir")' | tee /dev/stderr)
+
+  local actual=$(echo $object |
+      yq -r '.hostPath.path' | tee /dev/stderr)
+  [ "${actual}" = "/alt/kubelet-root/pods" ]
+}
+
 #--------------------------------------------------------------------
 # volumeMounts
 

--- a/values.schema.json
+++ b/values.schema.json
@@ -27,6 +27,9 @@
                         },
                         "providersDir": {
                           "type": "string"
+                        },
+                        "kubeletRootDir": {
+                          "type": "string"
                         }
                     }
                 },

--- a/values.schema.json
+++ b/values.schema.json
@@ -24,6 +24,9 @@
                                     "type": "string"
                                 }
                             }
+                        },
+                        "providersDir": {
+                          "type": "string"
                         }
                     }
                 },

--- a/values.yaml
+++ b/values.yaml
@@ -758,6 +758,7 @@ csi:
     # YAML-formatted multi-line templated string map of the annotations to apply
     # to the daemonSet.
     annotations: {}
+    # Provider host path (must match the CSI provider's path)
     providersDir: "/etc/kubernetes/secrets-store-csi-providers"
 
   pod:

--- a/values.yaml
+++ b/values.yaml
@@ -760,6 +760,8 @@ csi:
     annotations: {}
     # Provider host path (must match the CSI provider's path)
     providersDir: "/etc/kubernetes/secrets-store-csi-providers"
+    # Kubelet host path
+    kubeletRootDir: "/var/lib/kubelet"
 
   pod:
     # Extra annotations for the provider pods. This can either be YAML or a

--- a/values.yaml
+++ b/values.yaml
@@ -758,6 +758,7 @@ csi:
     # YAML-formatted multi-line templated string map of the annotations to apply
     # to the daemonSet.
     annotations: {}
+    providersDir: "/etc/kubernetes/secrets-store-csi-providers"
 
   pod:
     # Extra annotations for the provider pods. This can either be YAML or a


### PR DESCRIPTION
* Adds a configurable providersDir path for the Daemonset

Background: with https://github.com/kubernetes-sigs/secrets-store-csi-driver/pull/409/ the providersDir path has been made configurable for secrets-store-csi-driver, as not every single kubernetes distribution out there uses the same path. 

This is why we should also allow vault-helm to set providersDir accordingly. Default will remain `/etc/kubernetes/secrets-store-csi-providers`

Signed-off-by: Toni Tauro <toni.tauro@adfinis.com>
