### PR TITLE
Add support for nodePort for `vault-active` and `vault-standby` services

### DIFF
--- a/templates/server-ha-active-service.yaml
+++ b/templates/server-ha-active-service.yaml
@@ -26,8 +26,8 @@ spec:
     - name: {{ include "vault.scheme" . }}
       port: {{ .Values.server.service.port }}
       targetPort: {{ .Values.server.service.targetPort }}
-      {{- if and (.Values.server.service.nodePort) (eq (.Values.server.service.type | toString) "NodePort") }}
-      nodePort: {{ .Values.server.service.nodePort }}
+      {{- if and (.Values.server.service.activeNodePort) (eq (.Values.server.service.type | toString) "NodePort") }}
+      nodePort: {{ .Values.server.service.activeNodePort }}
       {{- end }}
     - name: https-internal
       port: 8201

--- a/templates/server-ha-standby-service.yaml
+++ b/templates/server-ha-standby-service.yaml
@@ -26,8 +26,8 @@ spec:
     - name: {{ include "vault.scheme" . }}
       port: {{ .Values.server.service.port }}
       targetPort: {{ .Values.server.service.targetPort }}
-      {{- if and (.Values.server.service.nodePort) (eq (.Values.server.service.type | toString) "NodePort") }}
-      nodePort: {{ .Values.server.service.nodePort }}
+      {{- if and (.Values.server.service.standbyNodePort) (eq (.Values.server.service.type | toString) "NodePort") }}
+      nodePort: {{ .Values.server.service.standbyNodePort }}
       {{- end }}
     - name: https-internal
       port: 8201

--- a/test/unit/server-ha-active-service.bats
+++ b/test/unit/server-ha-active-service.bats
@@ -119,7 +119,7 @@ load _helpers
       --show-only templates/server-ha-active-service.yaml \
       --set 'server.ha.enabled=true' \
       --set 'server.service.type=NodePort' \
-      --set 'server.service.nodePort=30009' \
+      --set 'server.service.activeNodePort=30009' \
       . | tee /dev/stderr |
       yq -r '.spec.ports[0].nodePort' | tee /dev/stderr)
   [ "${actual}" = "30009" ]
@@ -130,7 +130,7 @@ load _helpers
   local actual=$(helm template \
       --show-only templates/server-ha-active-service.yaml \
       --set 'server.ha.enabled=true' \
-      --set 'server.service.nodePort=30009' \
+      --set 'server.service.activeNodePort=30009' \
       . | tee /dev/stderr |
       yq -r '.spec.ports[0].nodePort' | tee /dev/stderr)
   [ "${actual}" = "null" ]

--- a/test/unit/server-ha-standby-service.bats
+++ b/test/unit/server-ha-standby-service.bats
@@ -130,7 +130,7 @@ load _helpers
       --show-only templates/server-ha-standby-service.yaml \
       --set 'server.ha.enabled=true' \
       --set 'server.service.type=NodePort' \
-      --set 'server.service.nodePort=30009' \
+      --set 'server.service.standbyNodePort=30009' \
       . | tee /dev/stderr |
       yq -r '.spec.ports[0].nodePort' | tee /dev/stderr)
   [ "${actual}" = "30009" ]
@@ -141,7 +141,7 @@ load _helpers
   local actual=$(helm template \
       --show-only templates/server-ha-standby-service.yaml \
       --set 'server.ha.enabled=true' \
-      --set 'server.service.nodePort=30009' \
+      --set 'server.service.standbyNodePort=30009' \
       . | tee /dev/stderr |
       yq -r '.spec.ports[0].nodePort' | tee /dev/stderr)
   [ "${actual}" = "null" ]

--- a/values.yaml
+++ b/values.yaml
@@ -475,6 +475,16 @@ server:
     # will be random if left blank.
     #nodePort: 30000
 
+    # When HA mode is enabled
+    # If type is set to "NodePort", a specific nodePort value can be configured,
+    # will be random if left blank.
+    #activeNodePort: 30001
+
+    # When HA mode is enabled
+    # If type is set to "NodePort", a specific nodePort value can be configured,
+    # will be random if left blank.
+    #standbyNodePort: 30002
+
     # Port on which Vault server is listening
     port: 8200
     # Target port to which the service should be mapped to


### PR DESCRIPTION
When using `ha.enabled = true` and `service.nodePort = 30001` in conjunction, the ports clash because it can only be allocated to a single service (`vault`), therefore it can't also be allocated to the `vault-active` and `vault-standby` service:

```
Error: cannot patch "vault-standby" with kind Service: Service "vault-standby" is invalid: spec.ports[0].nodePort: Invalid value: 30001: provided port is already allocated && cannot patch "vault" with kind Service: Service "vault" is invalid: spec.ports[0].nodePort: Invalid value: 30001: provided port is already allocated
```