### PR TITLE
Implemented support for topology spread constraints

### DIFF
--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -249,6 +249,37 @@ Sets the injector affinity for pod placement
 {{- end -}}
 
 {{/*
+Sets the topologySpreadConstraints when running in standalone and HA modes.
+*/}}
+{{- define "vault.topologySpreadConstraints" -}}
+  {{- if and (ne .mode "dev") .Values.server.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{ $tp := typeOf .Values.server.topologySpreadConstraints }}
+        {{- if eq $tp "string" }}
+          {{- tpl .Values.server.topologySpreadConstraints . | nindent 8 | trim }}
+        {{- else }}
+          {{- toYaml .Values.server.topologySpreadConstraints | nindent 8 }}
+        {{- end }}
+  {{ end }}
+{{- end -}}
+
+
+{{/*
+Sets the injector topologySpreadConstraints for pod placement
+*/}}
+{{- define "injector.topologySpreadConstraints" -}}
+  {{- if .Values.injector.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{ $tp := typeOf .Values.injector.topologySpreadConstraints }}
+        {{- if eq $tp "string" }}
+          {{- tpl .Values.injector.topologySpreadConstraints . | nindent 8 | trim }}
+        {{- else }}
+          {{- toYaml .Values.injector.topologySpreadConstraints | nindent 8 }}
+        {{- end }}
+  {{ end }}
+{{- end -}}
+
+{{/*
 Sets the toleration for pod placement when running in standalone and HA modes.
 */}}
 {{- define "vault.tolerations" -}}

--- a/templates/injector-deployment.yaml
+++ b/templates/injector-deployment.yaml
@@ -29,6 +29,7 @@ spec:
       {{ template "injector.annotations" . }}
     spec:
       {{ template "injector.affinity" . }}
+      {{ template "injector.topologySpreadConstraints" . }}
       {{ template "injector.tolerations" . }}
       {{ template "injector.nodeselector" . }}
       {{- if .Values.injector.priorityClassName }}

--- a/templates/server-statefulset.yaml
+++ b/templates/server-statefulset.yaml
@@ -36,6 +36,7 @@ spec:
       {{ template "vault.annotations" . }}
     spec:
       {{ template "vault.affinity" . }}
+      {{ template "vault.topologySpreadConstraints" . }}
       {{ template "vault.tolerations" . }}
       {{ template "vault.nodeselector" . }}
       {{- if .Values.server.priorityClassName }}

--- a/values.yaml
+++ b/values.yaml
@@ -175,6 +175,10 @@ injector:
               component: webhook
           topologyKey: kubernetes.io/hostname
 
+  # Topology settings for injector pods
+  # ref: https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/
+  topologySpreadConstraints: []
+
   # Toleration Settings for injector pods
   # This should be either a multi-line string or YAML matching the Toleration array
   # in a PodSpec.
@@ -429,6 +433,10 @@ server:
               app.kubernetes.io/instance: "{{ .Release.Name }}"
               component: server
           topologyKey: kubernetes.io/hostname
+
+  # Topology settings for server pods
+  # ref: https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/
+  topologySpreadConstraints: []
 
   # Toleration Settings for server pods
   # This should be either a multi-line string or YAML matching the Toleration array

--- a/values.yaml
+++ b/values.yaml
@@ -177,6 +177,8 @@ injector:
 
   # Topology settings for injector pods
   # ref: https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/
+  # This should be either a multi-line string or YAML matching the topologySpreadConstraints array
+  # in a PodSpec.
   topologySpreadConstraints: []
 
   # Toleration Settings for injector pods

--- a/values.yaml
+++ b/values.yaml
@@ -436,6 +436,8 @@ server:
 
   # Topology settings for server pods
   # ref: https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/
+  # This should be either a multi-line string or YAML matching the topologySpreadConstraints array
+  # in a PodSpec.
   topologySpreadConstraints: []
 
   # Toleration Settings for server pods


### PR DESCRIPTION
This PR includes support for topologyspreadconstraints as an alternative to podantiaffinity. 

## Testing
```
cat ./testvalues.yaml && helm install vault . --values ./testvalues.yaml && kubectl get pods -oyaml | grep topology
server:
  affinity: ""
  topologySpreadConstraints:
    - maxSkew: 1
      topologyKey: "kubernetes.io/hostname"
      whenUnsatisfiable: DoNotSchedule
      labelSelector:
        matchLabels:
          app.kubernetes.io/name: vault
injector:
  affinity: ""
  topologySpreadConstraints:
    - maxSkew: 1
      topologyKey: "kubernetes.io/hostname"
      whenUnsatisfiable: DoNotSchedule
      labelSelector:
        matchLabels:
          app.kubernetes.io/name: vault-agent-injector
NAME: vault
LAST DEPLOYED: Fri Sep 17 16:52:21 2021
NAMESPACE: default
STATUS: deployed
REVISION: 1
NOTES:
Thank you for installing HashiCorp Vault!

Now that you have deployed Vault, you should look over the docs on using
Vault with Kubernetes available here:

https://www.vaultproject.io/docs/


Your release is named vault. To learn more about the release, try:

  $ helm status vault
  $ helm get manifest vault
    topologySpreadConstraints:
      topologyKey: kubernetes.io/hostname
    topologySpreadConstraints:
      topologyKey: kubernetes.io/hostname
```

## Questions

Please let me know if there are additional steps I need to take.
- Do I need to regenerate values.schema.json
- Do I need to add topology specific tests?

Make test failed for me with
```
ERROR: (gcloud.auth.activate-service-account) Unable to read file [vault-helm-test.json]: [Errno 2] No such file or directory: 'vault-helm-test.json'
make: *** [Makefile:71: acceptance] Error 1
make: *** [test-acceptance] Error 2
```