### PR TITLE
Updating acceptance tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,6 +40,7 @@ else
 	-e GOOGLE_CREDENTIALS=${GOOGLE_CREDENTIALS} \
 	-e CLOUDSDK_CORE_PROJECT=${CLOUDSDK_CORE_PROJECT} \
 	-e KUBECONFIG=/helm-test/.kube/config \
+	-e VAULT_LICENSE_CI=${VAULT_LICENSE_CI} \
 	-w /helm-test \
 	$(TEST_IMAGE) \
 	make acceptance

--- a/test/README.md
+++ b/test/README.md
@@ -4,6 +4,8 @@
 
 The Makefile at the top level of this repo contains a few target that should help with running acceptance tests in your own GKE instance or in a kind cluster.
 
+Note that for the Vault Enterprise tests to pass, a `VAULT_LICENSE_CI` environment variable needs to be set to the contents of a valid Vault Enterprise license.
+
 ### Running in a GKE cluster
 
 * Set the `GOOGLE_CREDENTIALS` and `CLOUDSDK_CORE_PROJECT` variables at the top of the file. `GOOGLE_CREDENTIALS` should contain the local path to your Google Cloud Platform account credentials in JSON format. `CLOUDSDK_CORE_PROJECT` should be set to the ID of your GCP project.

--- a/test/terraform/main.tf
+++ b/test/terraform/main.tf
@@ -8,7 +8,7 @@ resource "random_id" "suffix" {
 
 data "google_container_engine_versions" "main" {
   location = "${var.zone}"
-  version_prefix = "1.18."
+  version_prefix = "1.19."
 }
 
 data "google_service_account" "gcpapi" {


### PR DESCRIPTION
GKE's stable K8s version is [now 1.19](https://cloud.google.com/kubernetes-engine/docs/release-notes#current_versions). Also adding `VAULT_LICENSE_CI` to
the `make test-acceptance` target to make it easier to run the
acceptance tests manually, and mentioned it in the test README.