### PR TITLE
Auto join nodes in HA mode using go-autodiscover's k8s provider

### DIFF
--- a/values.yaml
+++ b/values.yaml
@@ -623,6 +623,16 @@ server:
           path = "/vault/data"
           retry_join {
             auto_join = "provider=k8s label_selector=\"app.kubernetes.io/name={{ include "vault.name" . }},app.kubernetes.io/instance={{ .Release.Name }},component=server\",namespace={{ .Release.Namespace }}"
+            auto_join_scheme = "http"
+           
+            # Example configuration if using TLS
+            # auto_join_scheme = "https"
+            # leader_tls_servername = "vault"
+            # leader_ca_cert_file = "/vault/userconfig/vault-server-tls/vault.ca"
+            # leader_client_key_file = "/vault/userconfig/vault-server-tls/vault.key"
+            # leader_client_cert_file = "/vault/userconfig/vault-server-tls/vault.crt"
+           
+
           }
 
         }


### PR DESCRIPTION
After unsealing, seems to work fine!

```
Ch:(chan<- bool)(0xc0005ce070), LogOutput:io.Writer(nil), LogLevel:"DEBUG", Logger:(*hclog.interceptLogger)(0xc0000303f0), NoSnapshotRestoreOnStart:true, skipStartup:false}"
2021-10-13T14:52:52.691Z [INFO]  core: [DEBUG] discover-k8s: ignoring pod "vault-0", not ready state
2021-10-13T14:52:52.691Z [INFO]  core: [DEBUG] discover-k8s: ignoring pod "vault-1", not running: "Pending"
2021-10-13T14:52:52.691Z [INFO]  core: [DEBUG] discover-k8s: ignoring pod "vault-2", not running: "Pending"
2021-10-13T14:52:52.691Z [ERROR] core: failed to retry join raft cluster: retry=2s
2021-10-13T14:52:52.697Z [INFO]  storage.raft: initial configuration: index=1 servers="[{Suffrage:Voter ID:vault-0 Address:vault-0.vault-internal:8201}]"
2021-10-13T14:52:52.697Z [INFO]  storage.raft: entering follower state: follower="Node at vault-0 [Follower]" leader=
2021-10-13T14:52:54.693Z [INFO]  core: [DEBUG] discover: Using provider "k8s"
2021-10-13T14:52:54.709Z [INFO]  core: [DEBUG] discover-k8s: ignoring pod "vault-0", not ready state
2021-10-13T14:52:54.709Z [INFO]  core: [DEBUG] discover-k8s: ignoring pod "vault-1", not ready state
2021-10-13T14:52:54.709Z [INFO]  core: [DEBUG] discover-k8s: ignoring pod "vault-2", not running: "Pending"
2021-10-13T14:52:54.709Z [ERROR] core: failed to retry join raft cluster: retry=2s
2021-10-13T14:52:56.710Z [INFO]  core: [DEBUG] discover: Using provider "k8s"
2021-10-13T14:52:56.729Z [INFO]  core: [DEBUG] discover-k8s: ignoring pod "vault-0", not ready state
2021-10-13T14:52:56.730Z [INFO]  core: [DEBUG] discover-k8s: ignoring pod "vault-1", not ready state
2021-10-13T14:52:56.730Z [INFO]  core: [DEBUG] discover-k8s: ignoring pod "vault-2", not ready state
2021-10-13T14:52:56.730Z [ERROR] core: failed to retry join raft cluster: retry=2s
2021-10-13T14:52:58.730Z [INFO]  core: [DEBUG] discover: Using provider "k8s"
2021-10-13T14:52:58.752Z [INFO]  core: [DEBUG] discover-k8s: ignoring pod "vault-0", not ready state
2021-10-13T14:52:58.752Z [INFO]  core: [DEBUG] discover-k8s: ignoring pod "vault-1", not ready state
2021-10-13T14:52:58.752Z [INFO]  core: [DEBUG] discover-k8s: ignoring pod "vault-2", not ready state
2021-10-13T14:52:58.752Z [ERROR] core: failed to retry join raft cluster: retry=2s
2021-10-13T14:53:00.752Z [INFO]  core: [DEBUG] discover: Using provider "k8s"
2021-10-13T14:53:00.777Z [INFO]  core: [DEBUG] discover-k8s: ignoring pod "vault-0", not ready state
2021-10-13T14:53:00.777Z [INFO]  core: [DEBUG] discover-k8s: ignoring pod "vault-1", not ready state
2021-10-13T14:53:00.777Z [INFO]  core: [DEBUG] discover-k8s: ignoring pod "vault-2", not ready state
2021-10-13T14:53:00.777Z [ERROR] core: failed to retry join raft cluster: retry=2s
2021-10-13T14:53:02.124Z [WARN]  storage.raft: heartbeat timeout reached, starting election: last-leader=
2021-10-13T14:53:02.124Z [INFO]  storage.raft: entering candidate state: node="Node at vault-0 [Candidate]" term=2
2021-10-13T14:53:02.146Z [INFO]  storage.raft: election won: tally=1
2021-10-13T14:53:02.146Z [INFO]  storage.raft: entering leader state: leader="Node at vault-0 [Leader]"
2021-10-13T14:53:02.188Z [INFO]  core: security barrier initialized: stored=1 shares=5 threshold=3
2021-10-13T14:53:02.276Z [INFO]  core: post-unseal setup starting
2021-10-13T14:53:02.300Z [INFO]  core: loaded wrapping token key
2021-10-13T14:53:02.300Z [INFO]  core: successfully setup plugin catalog: plugin-directory=""
2021-10-13T14:53:02.300Z [INFO]  core: no mounts; adding default mount table
2021-10-13T14:53:02.316Z [INFO]  core: successfully mounted backend: type=cubbyhole path=cubbyhole/
2021-10-13T14:53:02.316Z [INFO]  core: successfully mounted backend: type=system path=sys/
2021-10-13T14:53:02.316Z [INFO]  core: successfully mounted backend: type=identity path=identity/
2021-10-13T14:53:02.365Z [INFO]  core: successfully enabled credential backend: type=token path=token/
```