### PR TITLE
fix(csi-ds): mountpoint-dir same mountpath in pod

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: vault
-version: 0.16.2
+version: 0.16.1
 appVersion: 1.8.3
 kubeVersion: ">= 1.14.0-0"
 description: Official HashiCorp Vault Chart


### PR DESCRIPTION
Fixes the mountpoint-dir overwrite introduced in https://github.com/hashicorp/vault-helm/pull/603

The mountppath inside the pod should be the same as on the node, or you'll end up with a `no such file or directory` error

```
  Warning  FailedMount  13m (x94 over 3h8m)    kubelet  MountVolume.SetUp failed for volume "mypod-vault" : rpc error: code = Unknown desc = failed to mount secrets store objects for pod default/mypod-6lv8db, err: rpc error: code = Unknown desc = error making mount request: secrets-store csi driver failed to write objectname-secret at /var/differentpath/var/lib/kubelet/pods/a9493f5e-ed2b-40c7-8f13-6f20eeb0134f/volumes/kubernetes.io~csi/mypod-vault/mount: open /var/differentpath/var/lib/kubelet/pods/a9493f5e-ed2b-40c7-8f13-6f20eeb0134f/volumes/kubernetes.io~csi/mypod-vault/mount/objectname-secret: no such file or directory
```

Signed-off-by: Toni Tauro <toni.tauro@adfinis.com>