### PR TITLE
vault-helm 0.17.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## Unreleased
 
+## 0.17.0 (October 21st, 2021)
+
+CHANGES:
+* Vault image default 1.8.4
+* Vault K8s image default 0.14.0
+
 Improvements:
 * Support Ingress stable networking API [GH-590](https://github.com/hashicorp/vault-helm/pull/590)
 * Support setting the `externalTrafficPolicy` for `LoadBalancer` and `NodePort` service types [GH-626](https://github.com/hashicorp/vault-helm/pull/626)

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: vault
-version: 0.16.1
-appVersion: 1.8.3
+version: 0.17.0
+appVersion: 1.8.4
 kubeVersion: ">= 1.14.0-0"
 description: Official HashiCorp Vault Chart
 home: https://www.vaultproject.io

--- a/test/acceptance/server-ha-enterprise-dr.bats
+++ b/test/acceptance/server-ha-enterprise-dr.bats
@@ -7,7 +7,7 @@ load _helpers
 
   helm install "$(name_prefix)-east" \
     --set='server.image.repository=hashicorp/vault-enterprise' \
-    --set='server.image.tag=1.8.3_ent' \
+    --set='server.image.tag=1.8.4_ent' \
     --set='injector.enabled=false' \
     --set='server.ha.enabled=true' \
     --set='server.ha.raft.enabled=true' \
@@ -77,7 +77,7 @@ load _helpers
   helm install "$(name_prefix)-west" \
     --set='injector.enabled=false' \
     --set='server.image.repository=hashicorp/vault-enterprise' \
-    --set='server.image.tag=1.8.3_ent' \
+    --set='server.image.tag=1.8.4_ent' \
     --set='server.ha.enabled=true' \
     --set='server.ha.raft.enabled=true' \
     --set='server.enterpriseLicense.secretName=vault-license' .

--- a/test/acceptance/server-ha-enterprise-perf.bats
+++ b/test/acceptance/server-ha-enterprise-perf.bats
@@ -8,7 +8,7 @@ load _helpers
   helm install "$(name_prefix)-east" \
     --set='injector.enabled=false' \
     --set='server.image.repository=hashicorp/vault-enterprise' \
-    --set='server.image.tag=1.8.3_ent' \
+    --set='server.image.tag=1.8.4_ent' \
     --set='server.ha.enabled=true' \
     --set='server.ha.raft.enabled=true' \
     --set='server.enterpriseLicense.secretName=vault-license' .
@@ -77,7 +77,7 @@ load _helpers
   helm install "$(name_prefix)-west" \
     --set='injector.enabled=false' \
     --set='server.image.repository=hashicorp/vault-enterprise' \
-    --set='server.image.tag=1.8.3_ent' \
+    --set='server.image.tag=1.8.4_ent' \
     --set='server.ha.enabled=true' \
     --set='server.ha.raft.enabled=true' \
     --set='server.enterpriseLicense.secretName=vault-license' .

--- a/values.openshift.yaml
+++ b/values.openshift.yaml
@@ -6,13 +6,13 @@ global:
 injector:
   image:
     repository: "registry.connect.redhat.com/hashicorp/vault-k8s"
-    tag: "0.13.1-ubi"
+    tag: "0.14.0-ubi"
 
   agentImage:
     repository: "registry.connect.redhat.com/hashicorp/vault"
-    tag: "1.8.3-ubi"
+    tag: "1.8.4-ubi"
 
 server:
   image:
     repository: "registry.connect.redhat.com/hashicorp/vault"
-    tag: "1.8.3-ubi"
+    tag: "1.8.4-ubi"

--- a/values.yaml
+++ b/values.yaml
@@ -59,7 +59,7 @@ injector:
   # image sets the repo and tag of the vault-k8s image to use for the injector.
   image:
     repository: "hashicorp/vault-k8s"
-    tag: "0.13.1"
+    tag: "0.14.0"
     pullPolicy: IfNotPresent
 
   # agentImage sets the repo and tag of the Vault image to use for the Vault Agent
@@ -67,7 +67,7 @@ injector:
   # required.
   agentImage:
     repository: "hashicorp/vault"
-    tag: "1.8.3"
+    tag: "1.8.4"
 
   # The default values for the injected Vault Agent containers.
   agentDefaults:
@@ -230,7 +230,7 @@ server:
 
   image:
     repository: "hashicorp/vault"
-    tag: "1.8.3"
+    tag: "1.8.4"
     # Overrides the default Image Pull Policy
     pullPolicy: IfNotPresent
 


### PR DESCRIPTION
CHANGES:
* Vault image default 1.8.4
* Vault K8s image default 0.14.0

Improvements:
* Support Ingress stable networking API [GH-590](https://github.com/hashicorp/vault-helm/pull/590)
* Support setting the `externalTrafficPolicy` for `LoadBalancer` and `NodePort` service types [GH-626](https://github.com/hashicorp/vault-helm/pull/626)
* Support setting ingressClassName on server Ingress [GH-630](https://github.com/hashicorp/vault-helm/pull/630)

Bugs:
* Ensure `kubeletRootDir` volume path and mounts are the same when `csi.daemonSet.kubeletRootDir` is overridden [GH-628](https://github.com/hashicorp/vault-helm/pull/628)