### PR TITLE
Move the volumeMounts section back to the right position again.

### DIFF
--- a/templates/injector-deployment.yaml
+++ b/templates/injector-deployment.yaml
@@ -137,6 +137,12 @@ spec:
             periodSeconds: 2
             successThreshold: 1
             timeoutSeconds: 5
+{{- if .Values.injector.certs.secretName }}
+          volumeMounts:
+            - name: webhook-certs
+              mountPath: /etc/webhook/certs
+              readOnly: true
+{{- end }}
         {{- if and (eq (.Values.injector.leaderElector.enabled | toString) "true") (gt (.Values.injector.replicas | int) 1) (eq (.Values.injector.leaderElector.useContainer | toString) "true") }}
         - name: leader-elector
           image: {{ .Values.injector.leaderElector.image.repository }}:{{ .Values.injector.leaderElector.image.tag }}
@@ -166,12 +172,6 @@ spec:
             successThreshold: 1
             timeoutSeconds: 5
         {{- end }}
-{{- if .Values.injector.certs.secretName }}
-          volumeMounts:
-            - name: webhook-certs
-              mountPath: /etc/webhook/certs
-              readOnly: true
-{{- end }}
 {{- if .Values.injector.certs.secretName }}
       volumes:
         - name: webhook-certs


### PR DESCRIPTION
The commit:
d27121 Added webhook-certs volume mount to sidecar injector (#545)
had it fixed correctly in the past.

But by the short-term decision to take the leader elector container out then back in has "probably" led to this circumstance during copy&paste that the volumemount has moved down again.

see changes how it came to this small error.
remove leader-elector: d31f94 Support vault-k8s internal leader election (#568)
bring leader-elector back: 5a864f Adding support for the old leader-elector (#607)