### PR TITLE
fix missing dataStorage when ha_storage:raft is enabled

### DIFF
--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -154,7 +154,7 @@ based on the mode configured.
             - name: audit
               mountPath: {{ .Values.server.auditStorage.mountPath }}
   {{ end }}
-  {{ if or (eq .mode "standalone") (and (eq .mode "ha") (eq (.Values.server.ha.raft.enabled | toString) "true"))  }}
+  {{ if or (eq .mode "standalone") (eq .mode "ha") }}
     {{ if eq (.Values.server.dataStorage.enabled | toString) "true" }}
             - name: data
               mountPath: {{ .Values.server.dataStorage.mountPath }}
@@ -187,7 +187,7 @@ storage might be desired by the user.
 {{- define "vault.volumeclaims" -}}
   {{- if and (ne .mode "dev") (or .Values.server.dataStorage.enabled .Values.server.auditStorage.enabled) }}
   volumeClaimTemplates:
-      {{- if and (eq (.Values.server.dataStorage.enabled | toString) "true") (or (eq .mode "standalone") (eq (.Values.server.ha.raft.enabled | toString ) "true" )) }}
+      {{- if and (eq (.Values.server.dataStorage.enabled | toString) "true") (or (eq .mode "standalone") (eq .mode "ha")) }}
     - metadata:
         name: data
         {{- include "vault.dataVolumeClaim.annotations" . | nindent 6 }}

--- a/test/unit/server-ha-statefulset.bats
+++ b/test/unit/server-ha-statefulset.bats
@@ -452,14 +452,14 @@ load _helpers
 #--------------------------------------------------------------------
 # storage class
 
-@test "server/ha-StatefulSet: no storage by default" {
+@test "server/ha-StatefulSet: one storage by default" {
   cd `chart_dir`
   local actual=$(helm template \
       --show-only templates/server-statefulset.yaml  \
       --set 'server.ha.enabled=true' \
       . | tee /dev/stderr |
       yq -r '.spec.volumeClaimTemplates | length' | tee /dev/stderr)
-  [ "${actual}" = "0" ]
+  [ "${actual}" = "1" ]
 }
 
 

--- a/test/unit/server-ha-statefulset.bats
+++ b/test/unit/server-ha-statefulset.bats
@@ -519,7 +519,7 @@ load _helpers
       yq -r '.spec.template.spec.containers[0].volumeMounts[] | select(.name == "audit")' | tee /dev/stderr)
 }
 
-@test "server/ha-StatefulSet: no data storage" {
+@test "server/ha-StatefulSet: count data storage" {
   cd `chart_dir`
   local actual=$(helm template \
       --show-only templates/server-statefulset.yaml  \
@@ -528,7 +528,7 @@ load _helpers
       --set 'server.dataStorage.enabled=true' \
       . | tee /dev/stderr |
       yq -r '.spec.volumeClaimTemplates | length' | tee /dev/stderr)
-  [ "${actual}" = "0" ]
+  [ "${actual}" = "1" ]
 
   local actual=$(helm template \
       --show-only templates/server-statefulset.yaml  \
@@ -537,7 +537,7 @@ load _helpers
       --set 'server.dataStorage.enabled=true' \
       . | tee /dev/stderr |
       yq -r '.spec.volumeClaimTemplates | length' | tee /dev/stderr)
-  [ "${actual}" = "1" ]
+  [ "${actual}" = "2" ]
 }
 
 @test "server/ha-StatefulSet: tolerations not set by default" {

--- a/test/unit/server-ha-statefulset.bats
+++ b/test/unit/server-ha-statefulset.bats
@@ -463,7 +463,7 @@ load _helpers
 }
 
 
-@test "server/ha-StatefulSet: cant set data storage" {
+@test "server/ha-StatefulSet: can set data storageClass" {
   cd `chart_dir`
   local actual=$(helm template \
       --show-only templates/server-statefulset.yaml  \
@@ -471,11 +471,11 @@ load _helpers
       --set 'server.dataStorage.enabled=true' \
       --set 'server.dataStorage.storageClass=foo' \
       . | tee /dev/stderr |
-      yq -r '.spec.volumeClaimTemplates' | tee /dev/stderr)
-  [ "${actual}" = "null" ]
+      yq -r '.spec.volumeClaimTemplates[0].spec.storageClassName' | tee /dev/stderr)
+  [ "${actual}" = "foo" ]
 }
 
-@test "server/ha-StatefulSet: can set storageClass" {
+@test "server/ha-StatefulSet: can set audit storageClass" {
   cd `chart_dir`
   local actual=$(helm template \
       --show-only templates/server-statefulset.yaml  \


### PR DESCRIPTION
When using Integrated Storage for HA Coordination as explained here:
https://learn.hashicorp.com/tutorials/vault/raft-ha-storage

Helm configuration need to be something like:
```
server:
  ha:
    enabled: true
    config: |
      ui = true

      listener "tcp" {
        tls_disable = 1
        address = "[::]:8200"
        cluster_address = "[::]:8201"
      }
      
      ha_storage "raft" {
        path = "/vault/ha_data"
        node_id = "HOSTNAME"       
      }

      storage "s3" {
        bucket     = "BUCKET_NAME"
      }

      api_addr = "[::]:8200"
      cluster_addr = "[::]:8201"

  dataStorage:
    enabled: true
    mountPath: "/vault/ha_data"
```

however, in the current template, dataStorage will only be added if **ha.raft.enabled** is **true**,
and since ha_storage need to be added in the **config** so dataStorage will not be created.

Removing the raft condition `(eq (.Values.server.ha.raft.enabled | toString) "true"))` will fix the issue