### PR TITLE
Allow injector network policy not only for OpenShift

### DIFF
--- a/templates/injector-network-policy.yaml
+++ b/templates/injector-network-policy.yaml
@@ -1,4 +1,4 @@
-{{- if and (eq (.Values.injector.enabled | toString) "true" ) (eq (.Values.global.enabled | toString) "true") (eq (.Values.global.openshift | toString) "true") }}
+{{- if and (eq (.Values.injector.enabled | toString) "true" ) (eq (.Values.injector.networkPolicy.enabled | toString) "true") }}
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:

--- a/templates/injector-network-policy.yaml
+++ b/templates/injector-network-policy.yaml
@@ -13,9 +13,7 @@ spec:
       app.kubernetes.io/instance: {{ .Release.Name }}
       component: webhook
   ingress:
-    - from:
-        - namespaceSelector: {}
-      ports:
-      - port: 8080
-        protocol: TCP
+{{- if .Values.injector.networkPolicy.ingress }}
+{{- toYaml .Values.injector.networkPolicy.ingress | nindent 4 }}
+{{ end }}
 {{ end }}

--- a/values.yaml
+++ b/values.yaml
@@ -198,6 +198,16 @@ injector:
   service:
     # Extra annotations to attach to the injector service
     annotations: {}
+  networkPolicy:
+    enabled: false
+    egress: [ ]
+    # egress:
+    # - to:
+    #   - ipBlock:
+    #       cidr: 10.0.0.0/24
+    #   ports:
+    #   - protocol: TCP
+    #     port: 8080
 
 server:
   # If not set to true, Vault server will not be installed. See vault.mode in _helpers.tpl for implementation details


### PR DESCRIPTION
Injector NetwokPolicy can be enabled when running not in OpenShift and
without global.enabled set to true.

For example EKS with NetworkPolicy turned on but vault server hosted
outside kubernetes cluster.