### PR TITLE
vault-helm 0.18.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,14 @@
 ## Unreleased
 
+## 0.18.0 (November 17th, 2021)
+
 CHANGES:
 * Removed support for deploying a leader-elector container with the [vault-k8s injector](https://github.com/hashicorp/vault-k8s) injector since vault-k8s now uses an internal mechanism to determine leadership [GH-649](https://github.com/hashicorp/vault-helm/pull/649)
+* Vault image default 1.9.0
+* Vault K8s image default 0.14.1
 
 Improvements:
-* Added templateConfig.staticSecretRenderInterval annotation for the injector [GH-621](https://github.com/hashicorp/vault-helm/pull/621)
+* Added templateConfig.staticSecretRenderInterval chart option for the injector [GH-621](https://github.com/hashicorp/vault-helm/pull/621)
 
 ## 0.17.1 (October 25th, 2021)
 
@@ -52,7 +56,7 @@ Improvements:
 ## 0.14.0 (July 28th, 2021)
 
 Features:
-* Added templateConfig.exitOnRetryFailure annotation for the injector [GH-560](https://github.com/hashicorp/vault-helm/pull/560)
+* Added templateConfig.exitOnRetryFailure chart option for the injector [GH-560](https://github.com/hashicorp/vault-helm/pull/560)
 
 Improvements:
 * Support configuring pod tolerations, pod affinity, and node selectors as YAML [GH-565](https://github.com/hashicorp/vault-helm/pull/565)

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: vault
-version: 0.17.1
-appVersion: 1.8.4
+version: 0.18.0
+appVersion: 1.9.0
 kubeVersion: ">= 1.14.0-0"
 description: Official HashiCorp Vault Chart
 home: https://www.vaultproject.io

--- a/test/acceptance/server-ha-enterprise-dr.bats
+++ b/test/acceptance/server-ha-enterprise-dr.bats
@@ -7,7 +7,7 @@ load _helpers
 
   helm install "$(name_prefix)-east" \
     --set='server.image.repository=hashicorp/vault-enterprise' \
-    --set='server.image.tag=1.8.4_ent' \
+    --set='server.image.tag=1.9.0_ent' \
     --set='injector.enabled=false' \
     --set='server.ha.enabled=true' \
     --set='server.ha.raft.enabled=true' \
@@ -77,7 +77,7 @@ load _helpers
   helm install "$(name_prefix)-west" \
     --set='injector.enabled=false' \
     --set='server.image.repository=hashicorp/vault-enterprise' \
-    --set='server.image.tag=1.8.4_ent' \
+    --set='server.image.tag=1.9.0_ent' \
     --set='server.ha.enabled=true' \
     --set='server.ha.raft.enabled=true' \
     --set='server.enterpriseLicense.secretName=vault-license' .

--- a/test/acceptance/server-ha-enterprise-perf.bats
+++ b/test/acceptance/server-ha-enterprise-perf.bats
@@ -8,7 +8,7 @@ load _helpers
   helm install "$(name_prefix)-east" \
     --set='injector.enabled=false' \
     --set='server.image.repository=hashicorp/vault-enterprise' \
-    --set='server.image.tag=1.8.4_ent' \
+    --set='server.image.tag=1.9.0_ent' \
     --set='server.ha.enabled=true' \
     --set='server.ha.raft.enabled=true' \
     --set='server.enterpriseLicense.secretName=vault-license' .
@@ -77,7 +77,7 @@ load _helpers
   helm install "$(name_prefix)-west" \
     --set='injector.enabled=false' \
     --set='server.image.repository=hashicorp/vault-enterprise' \
-    --set='server.image.tag=1.8.4_ent' \
+    --set='server.image.tag=1.9.0_ent' \
     --set='server.ha.enabled=true' \
     --set='server.ha.raft.enabled=true' \
     --set='server.enterpriseLicense.secretName=vault-license' .

--- a/values.openshift.yaml
+++ b/values.openshift.yaml
@@ -6,13 +6,13 @@ global:
 injector:
   image:
     repository: "registry.connect.redhat.com/hashicorp/vault-k8s"
-    tag: "0.14.0-ubi"
+    tag: "0.14.1-ubi"
 
   agentImage:
     repository: "registry.connect.redhat.com/hashicorp/vault"
-    tag: "1.8.4-ubi"
+    tag: "1.9.0-ubi"
 
 server:
   image:
     repository: "registry.connect.redhat.com/hashicorp/vault"
-    tag: "1.8.4-ubi"
+    tag: "1.9.0-ubi"

--- a/values.yaml
+++ b/values.yaml
@@ -49,7 +49,7 @@ injector:
   # image sets the repo and tag of the vault-k8s image to use for the injector.
   image:
     repository: "hashicorp/vault-k8s"
-    tag: "0.14.0"
+    tag: "0.14.1"
     pullPolicy: IfNotPresent
 
   # agentImage sets the repo and tag of the Vault image to use for the Vault Agent
@@ -57,7 +57,7 @@ injector:
   # required.
   agentImage:
     repository: "hashicorp/vault"
-    tag: "1.8.4"
+    tag: "1.9.0"
 
   # The default values for the injected Vault Agent containers.
   agentDefaults:
@@ -221,7 +221,7 @@ server:
 
   image:
     repository: "hashicorp/vault"
-    tag: "1.8.4"
+    tag: "1.9.0"
     # Overrides the default Image Pull Policy
     pullPolicy: IfNotPresent
 


### PR DESCRIPTION
CHANGES:
* Removed support for deploying a leader-elector container with the [vault-k8s injector](https://github.com/hashicorp/vault-k8s) injector since vault-k8s now uses an internal mechanism to determine leadership [GH-649](https://github.com/hashicorp/vault-helm/pull/649)
* Vault image default 1.9.0
* Vault K8s image default 0.14.1

Improvements:
* Added templateConfig.staticSecretRenderInterval chart option for the injector [GH-621](https://github.com/hashicorp/vault-helm/pull/621)