### PR TITLE
allow extraContainers to be set as a template string

### DIFF
--- a/templates/server-statefulset.yaml
+++ b/templates/server-statefulset.yaml
@@ -200,7 +200,11 @@ spec:
                 {{- end }}
             {{- end }}
         {{- if .Values.server.extraContainers }}
-          {{ toYaml .Values.server.extraContainers | nindent 8}}
+          {{- if eq (typeOf .Values.server.extraContainers) "string" }}
+            {{- tpl .Values.server.extraContainers . | nindent 8 }}
+          {{- else }}
+            {{ toYaml .Values.server.extraContainers | nindent 8 }}
+          {{- end }}
         {{- end }}
       {{- include "imagePullSecrets" . | nindent 6 }}
   {{ template "vault.volumeclaims" . }}

--- a/values.schema.json
+++ b/values.schema.json
@@ -479,6 +479,7 @@
                 "extraContainers": {
                     "type": [
                         "null",
+                        "string",
                         "array"
                     ]
                 },

--- a/values.yaml
+++ b/values.yaml
@@ -328,6 +328,7 @@ server:
     #       mountPath: /usr/local/libexec/vault
 
   # extraContainers is a list of sidecar containers. Specified as a YAML list.
+  # if the value is of type string then it is evaluated as a template.
   extraContainers: null
 
   # shareProcessNamespace enables process namespace sharing between Vault and the extraContainers


### PR DESCRIPTION
A container can be a complex structure that itself needs templating to allow both additional customization and reuse of existing values in the chart. Interpret the value of `server.extraContainers` as a template if its value is a string.