### PR TITLE
Configurable PodDisruptionBudget for Injector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Unreleased
 
+Features:
+* Added configurable podDisruptionBudget for injector [GH-653](https://github.com/hashicorp/vault-helm/pull/653)
+
 ## 0.18.0 (November 17th, 2021)
 
 CHANGES:

--- a/templates/injector-disruptionbudget.yaml
+++ b/templates/injector-disruptionbudget.yaml
@@ -1,0 +1,20 @@
+{{- if .Values.injector.podDisruptionBudget }}
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ template "vault.fullname" . }}-agent-injector
+  namespace: {{ .Release.Namespace }}
+  labels:
+    helm.sh/chart: {{ include "vault.chart" . }}
+    app.kubernetes.io/name: {{ include "vault.name" . }}-agent-injector
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    component: webhook
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ template "vault.name" . }}-agent-injector
+      app.kubernetes.io/instance: {{ .Release.Name }}
+      component: webhook
+  {{- toYaml .Values.injector.podDisruptionBudget | nindent 2 }}
+{{- end -}}

--- a/test/unit/injector-disruptionbudget.bats
+++ b/test/unit/injector-disruptionbudget.bats
@@ -1,0 +1,32 @@
+#!/usr/bin/env bats
+
+load _helpers
+
+@test "injector/DisruptionBudget: disabled by default" {
+  cd `chart_dir`
+  local actual=$( (helm template \
+      --show-only templates/injector-disruptionbudget.yaml \
+      . || echo "---") | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+}
+
+@test "injector/DisruptionBudget: configure with injector.podDisruptionBudget maxUnavailable" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/injector-disruptionbudget.yaml \
+      --set 'injector.podDisruptionBudget.maxUnavailable=3' \
+      . | tee /dev/stderr |
+      yq '.spec.maxUnavailable == 3' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}
+
+@test "injector/DisruptionBudget: configure with injector.podDisruptionBudget minAvailable" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/injector-disruptionbudget.yaml \
+      --set 'injector.podDisruptionBudget.minAvailable=2' \
+      . | tee /dev/stderr |
+      yq '.spec.minAvailable == 2' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}

--- a/values.schema.json
+++ b/values.schema.json
@@ -320,6 +320,9 @@
                 "objectSelector": {
                     "type": "object"
                 },
+                "podDisruptionBudget": {
+                    "type": "object"
+                },
                 "port": {
                     "type": "integer"
                 },

--- a/values.yaml
+++ b/values.yaml
@@ -199,6 +199,12 @@ injector:
     # Extra annotations to attach to the injector service
     annotations: {}
 
+  # A disruption budget limits the number of pods of a replicated application
+  # that are down simultaneously from voluntary disruptions
+  podDisruptionBudget: {}
+  # podDisruptionBudget:
+  #   maxUnavailable: 1
+
 server:
   # If not set to true, Vault server will not be installed. See vault.mode in _helpers.tpl for implementation details
   enabled: true


### PR DESCRIPTION
This adds a section to values which can configure a PodDisruptionBudget for Injector.

I saw no reason not to configure it free-form, since it's propagating to the Kubernetes API rather than being internally significant. Please let me know if we'd prefer to change how that works.

Example:

```
helm template --show-only templates/injector-disruptionbudget.yaml --set 'injector.podDisruptionBudget.maxUnavailable=1' .
```

```yaml
---
# Source: vault/templates/injector-disruptionbudget.yaml
apiVersion: policy/v1beta1
kind: PodDisruptionBudget
metadata:
  name: RELEASE-NAME-vault-agent-injector
  namespace: inst-system
  labels:
    helm.sh/chart: vault-0.18.0
    app.kubernetes.io/name: vault-agent-injector
    app.kubernetes.io/instance: RELEASE-NAME
    app.kubernetes.io/managed-by: Helm
    component: webhook
spec:
  selector:
    matchLabels:
      app.kubernetes.io/name: vault-agent-injector
      app.kubernetes.io/instance: RELEASE-NAME
      component: webhook
  maxUnavailable: 1
```