### PR TITLE
Fix spelling error in server disruptionbudget test

### DIFF
--- a/test/unit/server-ha-disruptionbudget.bats
+++ b/test/unit/server-ha-disruptionbudget.bats
@@ -16,7 +16,7 @@ load _helpers
   cd `chart_dir`
   local actual=$( (helm template \
       --show-only templates/server-disruptionbudget.yaml  \
-      --set 'globa.enabled=false' \
+      --set 'global.enabled=false' \
       --set 'server.ha.enabled=false' \
       . || echo "---") | tee /dev/stderr |
       yq 'length > 0' | tee /dev/stderr)


### PR DESCRIPTION
Fix a spelling error in the unit test which set a variable which does not exist.

There is no functional change, and no change to the result of the test.