### PR TITLE
Add support for globally disabling RBAC setup

### DIFF
--- a/templates/csi-clusterrole.yaml
+++ b/templates/csi-clusterrole.yaml
@@ -1,4 +1,4 @@
-{{- if and (eq (.Values.csi.enabled | toString) "true" ) (eq (.Values.global.enabled | toString) "true") }}
+{{- if and (eq (.Values.csi.enabled | toString) "true" ) (eq (.Values.global.enabled | toString) "true") (eq (.Values.global.rbac | toString) "true") }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:

--- a/templates/csi-clusterrolebinding.yaml
+++ b/templates/csi-clusterrolebinding.yaml
@@ -1,4 +1,4 @@
-{{- if and (eq (.Values.csi.enabled | toString) "true" ) (eq (.Values.global.enabled | toString) "true") }}
+{{- if and (eq (.Values.csi.enabled | toString) "true" ) (eq (.Values.global.enabled | toString) "true") (eq (.Values.global.rbac | toString) "true") }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:

--- a/templates/injector-clusterrole.yaml
+++ b/templates/injector-clusterrole.yaml
@@ -1,4 +1,4 @@
-{{- if and (eq (.Values.injector.enabled | toString) "true" ) (eq (.Values.global.enabled | toString) "true") }}
+{{- if and (eq (.Values.injector.enabled | toString) "true" ) (eq (.Values.global.enabled | toString) "true") (eq (.Values.global.rbac | toString) "true") }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:

--- a/templates/injector-clusterrolebinding.yaml
+++ b/templates/injector-clusterrolebinding.yaml
@@ -1,4 +1,4 @@
-{{- if and (eq (.Values.injector.enabled | toString) "true" ) (eq (.Values.global.enabled | toString) "true") }}
+{{- if and (eq (.Values.injector.enabled | toString) "true" ) (eq (.Values.global.enabled | toString) "true") (eq (.Values.global.rbac | toString) "true") }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:

--- a/templates/injector-psp-role.yaml
+++ b/templates/injector-psp-role.yaml
@@ -1,4 +1,4 @@
-{{- if and (eq (.Values.injector.enabled | toString) "true" ) (eq (.Values.global.enabled | toString) "true") (eq (.Values.global.psp.enable | toString) "true") }}
+{{- if and (eq (.Values.injector.enabled | toString) "true" ) (eq (.Values.global.enabled | toString) "true") (eq (.Values.global.psp.enable | toString) "true") (eq (.Values.global.rbac | toString) "true") }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:

--- a/templates/injector-psp-rolebinding.yaml
+++ b/templates/injector-psp-rolebinding.yaml
@@ -1,4 +1,4 @@
-{{- if and (eq (.Values.injector.enabled | toString) "true" ) (eq (.Values.global.enabled | toString) "true") (eq (.Values.global.psp.enable | toString) "true") }}
+{{- if and (eq (.Values.injector.enabled | toString) "true" ) (eq (.Values.global.enabled | toString) "true") (eq (.Values.global.psp.enable | toString) "true") (eq (.Values.global.rbac | toString) "true") }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:

--- a/templates/injector-role.yaml
+++ b/templates/injector-role.yaml
@@ -1,4 +1,4 @@
-{{- if and (eq (.Values.injector.enabled | toString) "true" ) (eq (.Values.global.enabled | toString) "true") (eq (.Values.injector.leaderElector.enabled | toString) "true") (gt (.Values.injector.replicas | int) 1) }}
+{{- if and (eq (.Values.injector.enabled | toString) "true" ) (eq (.Values.global.enabled | toString) "true") (eq (.Values.injector.leaderElector.enabled | toString) "true") (gt (.Values.injector.replicas | int) 1) (eq (.Values.global.rbac | toString) "true") }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:

--- a/templates/injector-rolebinding.yaml
+++ b/templates/injector-rolebinding.yaml
@@ -1,4 +1,4 @@
-{{- if and (eq (.Values.injector.enabled | toString) "true" ) (eq (.Values.global.enabled | toString) "true") (eq (.Values.injector.leaderElector.enabled | toString) "true") (gt (.Values.injector.replicas | int) 1) }}
+{{- if and (eq (.Values.injector.enabled | toString) "true" ) (eq (.Values.global.enabled | toString) "true") (eq (.Values.injector.leaderElector.enabled | toString) "true") (gt (.Values.injector.replicas | int) 1) (eq (.Values.global.rbac | toString) "true") }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:

--- a/templates/server-clusterrolebinding.yaml
+++ b/templates/server-clusterrolebinding.yaml
@@ -1,5 +1,5 @@
 {{ template "vault.mode" . }}
-{{- if and (ne .mode "") (eq (.Values.global.enabled | toString) "true") (eq (.Values.server.authDelegator.enabled | toString) "true") }}
+{{- if and (ne .mode "") (eq (.Values.global.enabled | toString) "true") (eq (.Values.server.authDelegator.enabled | toString) "true") (eq (.Values.global.rbac | toString) "true") }}
 {{- if .Capabilities.APIVersions.Has "rbac.authorization.k8s.io/v1" -}}
 apiVersion: rbac.authorization.k8s.io/v1
 {{- else }}

--- a/templates/server-discovery-role.yaml
+++ b/templates/server-discovery-role.yaml
@@ -1,6 +1,6 @@
 {{ template "vault.mode" . }}
 {{- if ne .mode "external" }}
-{{- if and (eq .mode "ha" ) (eq (.Values.global.enabled | toString) "true") }}
+{{- if and (eq .mode "ha" ) (eq (.Values.global.enabled | toString) "true") (eq (.Values.global.rbac | toString) "true") }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:

--- a/templates/server-discovery-rolebinding.yaml
+++ b/templates/server-discovery-rolebinding.yaml
@@ -1,6 +1,6 @@
 {{ template "vault.mode" . }}
 {{- if ne .mode "external" }}
-{{- if and (eq .mode "ha" ) (eq (.Values.global.enabled | toString) "true") }}
+{{- if and (eq .mode "ha" ) (eq (.Values.global.enabled | toString) "true") (eq (.Values.global.rbac | toString) "true") }}
 {{- if .Capabilities.APIVersions.Has "rbac.authorization.k8s.io/v1" -}}
 apiVersion: rbac.authorization.k8s.io/v1
 {{- else }}

--- a/templates/server-psp-role.yaml
+++ b/templates/server-psp-role.yaml
@@ -1,5 +1,5 @@
 {{ template "vault.mode" . }}
-{{- if and (ne .mode "") (eq (.Values.global.enabled | toString) "true") (eq (.Values.global.psp.enable | toString) "true") }}
+{{- if and (ne .mode "") (eq (.Values.global.enabled | toString) "true") (eq (.Values.global.psp.enable | toString) "true") (eq (.Values.global.rbac | toString) "true") }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:

--- a/templates/server-psp-rolebinding.yaml
+++ b/templates/server-psp-rolebinding.yaml
@@ -1,5 +1,5 @@
 {{ template "vault.mode" . }}
-{{- if and (ne .mode "") (eq (.Values.global.enabled | toString) "true") (eq (.Values.global.psp.enable | toString) "true") }}
+{{- if and (ne .mode "") (eq (.Values.global.enabled | toString) "true") (eq (.Values.global.psp.enable | toString) "true") (eq (.Values.global.rbac | toString) "true") }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:

--- a/test/unit/global-rbac.bats
+++ b/test/unit/global-rbac.bats
@@ -1,0 +1,25 @@
+#!/usr/bin/env bats
+
+load _helpers
+
+@test "global rbac: disabled by global.rbac" {
+  cd `chart_dir`
+  local actual=$( (helm template \
+      --show-only templates/csi-clusterrole.yaml \
+      --show-only templates/csi-clusterrolebinding.yaml \
+      --show-only templates/injector-clusterrole.yaml \
+      --show-only templates/injector-clusterrolebinding.yaml \
+      --show-only templates/injector-psp-role.yaml \
+      --show-only templates/injector-psp-rolebinding.yaml \
+      --show-only templates/injector-role.yaml \
+      --show-only templates/injector-rolebinding.yaml \
+      --show-only templates/server-clusterrolebinding.yaml \
+      --show-only templates/server-discovery-role.yaml \
+      --show-only templates/server-discovery-rolebinding.yaml \
+      --show-only templates/server-psp-role.yaml \
+      --show-only templates/server-psp-rolebinding.yaml \
+      --set 'global.rbac=false' \
+      . || echo "---") | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+}

--- a/values.yaml
+++ b/values.yaml
@@ -4,6 +4,9 @@ global:
   # enabled is the master enabled switch. Setting this to true or false
   # will enable or disable all the components within this chart by default.
   enabled: true
+  # Toggle RBAC creation. This is useful in more restricted environments where
+  # RBAC configuration is managed some other way.
+  rbac: true
   # Image pull secret to use for registry authentication.
   # Alternatively, the value may be specified as an array of strings.
   imagePullSecrets: []


### PR DESCRIPTION
In some more restrictive environments the Vault admins might not have
access required to let Helm create the RBAC configuration and instead
rely on that being managed some other way.

This change lets users disable such RBAC configuration globally with
`global.rbac=false` with the assumption that appropriate RBAC
configuration is set some other way prior to chart deployment.