### PR TITLE
Allow the route termination to be customized

### DIFF
--- a/templates/server-route.yaml
+++ b/templates/server-route.yaml
@@ -27,7 +27,7 @@ spec:
   port:
     targetPort: 8200
   tls:
-    termination: passthrough
+    termination: {{ .Values.server.route.termination }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/values.yaml
+++ b/values.yaml
@@ -316,6 +316,7 @@ server:
     labels: {}
     annotations: {}
     host: chart-example.local
+    termination: passthrough
 
   # authDelegator enables a cluster role binding to be attached to the service
   # account.  This cluster role binding can be used to setup Kubernetes auth


### PR DESCRIPTION
This covers, in part, issue #490. Namely, the route currently hardcodes
the termination mode to "passhtrough". Let's parametrize this so a user
can customize it. The use-case here being that we can deploy the vault
in http mode and expose it via https externally and by choosing 'edge'
as the termination type we let the TLS be taken care of by the route
object.

The default remains 'passthrough' in order to not disrupt any existing
setup.
