### PR TITLE
Add volumes and env vars to helm hook test pod

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ Features:
 * Added configurable update strategy for injector [GH-661](https://github.com/hashicorp/vault-helm/pull/661)
 * csi: ability to set priorityClassName for CSI daemonset pods [GH-670](https://github.com/hashicorp/vault-helm/pull/670)
 
+Improvements:
+* Add volumes and env vars to helm hook test pod [GH-673](https://github.com/hashicorp/vault-helm/pull/673)
+
 ## 0.18.0 (November 17th, 2021)
 
 CHANGES:

--- a/templates/tests/server-test.yaml
+++ b/templates/tests/server-test.yaml
@@ -1,4 +1,6 @@
-{{- if .Values.server.enabled }}
+{{ template "vault.mode" . }}
+{{- if ne .mode "external" }}
+{{- if and (ne .mode "") (eq (.Values.global.enabled | toString) "true") }}
 apiVersion: v1
 kind: Pod
 metadata:
@@ -37,4 +39,5 @@ spec:
           exit 0
 
   restartPolicy: Never
+{{- end }}
 {{- end }}

--- a/templates/tests/server-test.yaml
+++ b/templates/tests/server-test.yaml
@@ -17,6 +17,7 @@ spec:
       env:
         - name: VAULT_ADDR
           value: {{ include "vault.scheme" . }}://{{ template "vault.fullname" . }}.{{ .Release.Namespace }}.svc:{{ .Values.server.service.port }}
+        {{- include "vault.extraEnvironmentVars" .Values.server | nindent 8 }}
       command:
         - /bin/sh
         - -c
@@ -37,7 +38,14 @@ spec:
           fi
 
           exit 0
-
+      volumeMounts:
+        {{- if .Values.server.volumeMounts }}
+          {{- toYaml .Values.server.volumeMounts | nindent 8}}
+        {{- end }}
+  volumes:
+    {{- if .Values.server.volumes }}
+      {{- toYaml .Values.server.volumes | nindent 4}}
+    {{- end }}
   restartPolicy: Never
 {{- end }}
 {{- end }}

--- a/test/unit/server-statefulset.bats
+++ b/test/unit/server-statefulset.bats
@@ -537,7 +537,7 @@ load _helpers
   cd `chart_dir`
   local object=$(helm template \
       --show-only templates/server-statefulset.yaml  \
-      --set 'server.stanadlone.enabled=true' \
+      --set 'server.standalone.enabled=true' \
       --set 'server.extraEnvironmentVars.FOO=bar' \
       --set 'server.extraEnvironmentVars.FOOBAR=foobar' \
       . | tee /dev/stderr |

--- a/test/unit/server-test.bats
+++ b/test/unit/server-test.bats
@@ -66,6 +66,28 @@ load _helpers
   [ "${actual}" = "true" ]
 }
 
+@test "server/standalone-server-test-Pod: disable with global.enabled" {
+  cd `chart_dir`
+  local actual=$( (helm template \
+      --show-only templates/tests/server-test.yaml  \
+      --set 'global.enabled=false' \
+      --set 'server.standalone.enabled=true' \
+      . || echo "---") | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+}
+
+@test "server/standalone-server-test-Pod: disable with injector.externalVaultAddr" {
+  cd `chart_dir`
+  local actual=$( (helm template \
+      --show-only templates/tests/server-test.yaml  \
+      --set 'injector.externalVaultAddr=http://vault-outside' \
+      --set 'server.standalone.enabled=true' \
+      . || echo "---") | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+}
+
 @test "server/standalone-server-test-Pod: image defaults to server.image.repository:tag" {
   cd `chart_dir`
   local actual=$(helm template \

--- a/test/unit/server-test.bats
+++ b/test/unit/server-test.bats
@@ -1,0 +1,139 @@
+#!/usr/bin/env bats
+
+load _helpers
+
+#--------------------------------------------------------------------
+# disable / enable server deployment
+
+@test "server/server-test-Pod: disabled server.enabled" {
+  cd `chart_dir`
+  local actual=$( (helm template \
+      --show-only templates/tests/server-test.yaml  \
+      --set 'server.enabled=false' \
+      . || echo "---") | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+}
+
+@test "server/server-test-Pod: disabled server.enabled random string" {
+  cd `chart_dir`
+  local actual=$( (helm template \
+      --show-only templates/tests/server-test.yaml  \
+      --set 'server.enabled=blabla' \
+      . || echo "---") | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+}
+
+@test "server/server-test-Pod: enabled server.enabled explicit true" {
+  cd `chart_dir`
+  local actual=$( (helm template \
+      --show-only templates/tests/server-test.yaml  \
+      --set 'server.enabled=true' \
+      . || echo "---") | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}
+
+#--------------------------------------------------------------------
+
+@test "server/standalone-server-test-Pod: default server.standalone.enabled" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/tests/server-test.yaml  \
+      . | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}
+
+@test "server/standalone-server-test-Pod: enable with server.standalone.enabled true" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/tests/server-test.yaml  \
+      --set 'server.standalone.enabled=true' \
+      . | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}
+
+@test "server/ha-server-test-Pod: enable with server.ha.enabled true" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/tests/server-test.yaml  \
+      --set 'server.ha.enabled=true' \
+      . | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}
+
+@test "server/standalone-server-test-Pod: image defaults to server.image.repository:tag" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/tests/server-test.yaml  \
+      --set 'server.image.repository=foo' \
+      --set 'server.image.tag=1.2.3' \
+      . | tee /dev/stderr |
+      yq -r '.spec.containers[0].image' | tee /dev/stderr)
+  [ "${actual}" = "foo:1.2.3" ]
+
+  local actual=$(helm template \
+      --show-only templates/tests/server-test.yaml  \
+      --set 'server.image.repository=foo' \
+      --set 'server.image.tag=1.2.3' \
+      --set 'server.standalone.enabled=true' \
+      . | tee /dev/stderr |
+      yq -r '.spec.containers[0].image' | tee /dev/stderr)
+  [ "${actual}" = "foo:1.2.3" ]
+}
+
+@test "server/standalone-server-test-Pod: image tag defaults to latest" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/tests/server-test.yaml  \
+      --set 'server.image.repository=foo' \
+      --set 'server.image.tag=' \
+      . | tee /dev/stderr |
+      yq -r '.spec.containers[0].image' | tee /dev/stderr)
+  [ "${actual}" = "foo:latest" ]
+
+  local actual=$(helm template \
+      --show-only templates/tests/server-test.yaml  \
+      --set 'server.image.repository=foo' \
+      --set 'server.image.tag=' \
+      --set 'server.standalone.enabled=true' \
+      . | tee /dev/stderr |
+      yq -r '.spec.containers[0].image' | tee /dev/stderr)
+  [ "${actual}" = "foo:latest" ]
+}
+
+@test "server/standalone-server-test-Pod: default imagePullPolicy" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/tests/server-test.yaml  \
+      . | tee /dev/stderr |
+      yq -r '.spec.containers[0].imagePullPolicy' | tee /dev/stderr)
+  [ "${actual}" = "IfNotPresent" ]
+}
+
+@test "server/standalone-server-test-Pod: Custom imagePullPolicy" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/tests/server-test.yaml  \
+      --set 'server.image.pullPolicy=Always' \
+      . | tee /dev/stderr |
+      yq -r '.spec.containers[0].imagePullPolicy' | tee /dev/stderr)
+  [ "${actual}" = "Always" ]
+}
+
+#--------------------------------------------------------------------
+# resources
+
+@test "server/standalone-server-test-Pod: default resources" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/tests/server-test.yaml  \
+      --set 'server.standalone.enabled=true' \
+      . | tee /dev/stderr |
+      yq -r '.spec.containers[0].resources' | tee /dev/stderr)
+  [ "${actual}" = "null" ]
+}


### PR DESCRIPTION
 - Fix test typo
 - Add basic server-test Pod tests 
     - This covers all existing functionality that matches what's
        present in server-statefulset.bats
 - Fix server-test helm hook Pod rendering 
     - Properly adhere to the global.enabled flag and the presence of
   the injector.externalVaultAddr setting, the same way that
   the servers StatefulSet behaves
 - Uses the same extraEnvironmentVars, volumes and volumeMounts set on
   the server statefulset to configure the Vault server test pod used by
   the helm test hook
 - This is necessary in situations where TLS is configured, but the
   certificates are not affiliated with the k8s CA / part of k8s PKI

 - Fixes GH-665