### PR TITLE
Disable unit and acceptance tests in CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -85,16 +85,7 @@ jobs:
 
 workflows:
   version: 2
-  build_and_test:
-    jobs:
-      - bats-unit-test
-      - chart-verifier
-      - acceptance:
-          requires:
-            - bats-unit-test
-          filters:
-            branches:
-              only: main
+  # Note: unit and acceptance tests are now being run in GitHub Actions
   update-helm-charts-index:
     jobs:
       - update-helm-charts-index:


### PR DESCRIPTION
Removes the `build_and_test` workflow from CircleCI, since the unit and acceptance tests are running under GitHub Actions now.

This means the acceptance tests will not be running on GKE until we port that setup over to a GitHub workflow. (The acceptance tests are still running in kind.)