### PR TITLE
add namespace support for openshift route

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ Features:
 * Added configurable update strategy for injector [GH-661](https://github.com/hashicorp/vault-helm/pull/661)
 * csi: ability to set priorityClassName for CSI daemonset pods [GH-670](https://github.com/hashicorp/vault-helm/pull/670)
 
+Improvements:
+* Set the namespace on the OpenShift Route [GH-679](https://github.com/hashicorp/vault-helm/pull/679)
+
 ## 0.18.0 (November 17th, 2021)
 
 CHANGES:

--- a/templates/server-route.yaml
+++ b/templates/server-route.yaml
@@ -9,6 +9,7 @@ kind: Route
 apiVersion: route.openshift.io/v1
 metadata:
   name: {{ template "vault.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     helm.sh/chart: {{ include "vault.chart" . }}
     app.kubernetes.io/name: {{ include "vault.name" . }}


### PR DESCRIPTION
This change adds the `namespace` key in the OpenShift route metadata so that the Route is deployed to the same namespace as the Vault services/endpoints . Before this change, the route was always put in the default namespace.