### PR TITLE
Add namespace to injector-leader-elector role, rolebinding and secret

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ CHANGES:
 
 Improvements:
 * CSI: Set `extraLabels` for daemonset, pods, and service account [GH-690](https://github.com/hashicorp/vault-helm/pull/690)
+* Add namespace to injector-leader-elector role, rolebinding and secret [GH-683](https://github.com/hashicorp/vault-helm/pull/683)
 
 ## 0.19.0 (January 20th, 2022)
 

--- a/templates/injector-certs-secret.yaml
+++ b/templates/injector-certs-secret.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: vault-injector-certs
+  namespace: {{ .Release.Namespace }}
   labels:
     app.kubernetes.io/name: {{ include "vault.name" . }}-agent-injector
     app.kubernetes.io/instance: {{ .Release.Name }}

--- a/templates/injector-role.yaml
+++ b/templates/injector-role.yaml
@@ -3,6 +3,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: {{ template "vault.fullname" . }}-agent-injector-leader-elector-role
+  namespace: {{ .Release.Namespace }}
   labels:
     app.kubernetes.io/name: {{ include "vault.name" . }}-agent-injector
     app.kubernetes.io/instance: {{ .Release.Name }}

--- a/templates/injector-rolebinding.yaml
+++ b/templates/injector-rolebinding.yaml
@@ -3,6 +3,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: {{ template "vault.fullname" . }}-agent-injector-leader-elector-binding
+  namespace: {{ .Release.Namespace }}
   labels:
     app.kubernetes.io/name: {{ include "vault.name" . }}-agent-injector
     app.kubernetes.io/instance: {{ .Release.Name }}

--- a/test/unit/injector-leader-elector.bats
+++ b/test/unit/injector-leader-elector.bats
@@ -87,6 +87,17 @@ load _helpers
   [ "${actual}" = "true" ]
 }
 
+@test "injector/certs-secret: namespace is set" {
+  cd `chart_dir`
+  local actual=$( (helm template \
+      --show-only templates/injector-certs-secret.yaml \
+      --set "injector.replicas=2" \
+      --namespace foo \
+      . || echo "---") | tee /dev/stderr |
+      yq '.metadata.namespace' | tee /dev/stderr)
+  [ "${actual}" = "\"foo\"" ]
+}
+
 @test "injector/role: created/skipped as appropriate" {
   cd `chart_dir`
   local actual=$( (helm template \
@@ -127,6 +138,17 @@ load _helpers
   [ "${actual}" = "true" ]
 }
 
+@test "injector/role: namespace is set" {
+  cd `chart_dir`
+  local actual=$( (helm template \
+      --show-only templates/injector-role.yaml \
+      --set "injector.replicas=2" \
+      --namespace foo \
+      . || echo "---") | tee /dev/stderr |
+      yq '.metadata.namespace' | tee /dev/stderr)
+  [ "${actual}" = "\"foo\"" ]
+}
+
 @test "injector/rolebinding: created/skipped as appropriate" {
   cd `chart_dir`
   local actual=$( (helm template \
@@ -165,4 +187,15 @@ load _helpers
       . || echo "---") | tee /dev/stderr |
       yq 'length > 0' | tee /dev/stderr)
   [ "${actual}" = "true" ]
+}
+
+@test "injector/rolebinding: namespace is set" {
+  cd `chart_dir`
+  local actual=$( (helm template \
+      --show-only templates/injector-rolebinding.yaml \
+      --set "injector.replicas=2" \
+      --namespace foo \
+      . || echo "---") | tee /dev/stderr |
+      yq '.metadata.namespace' | tee /dev/stderr)
+  [ "${actual}" = "\"foo\"" ]
 }


### PR DESCRIPTION
This adds namespaces to namespaced resources needed by the injector-leader-elector.

This fixes https://github.com/hashicorp/vault-helm/issues/682