### PR TITLE
Fix values schema to support config in YAML

### DIFF
--- a/values.schema.json
+++ b/values.schema.json
@@ -522,7 +522,10 @@
                             ]
                         },
                         "config": {
-                            "type": "string"
+                            "type": [
+                                "string",
+                                "object"
+                            ]
                         },
                         "disruptionBudget": {
                             "type": "object",
@@ -545,7 +548,10 @@
                             "type": "object",
                             "properties": {
                                 "config": {
-                                    "type": "string"
+                                    "type": [
+                                        "string",
+                                        "object"
+                                    ]
                                 },
                                 "enabled": {
                                     "type": "boolean"
@@ -775,7 +781,10 @@
                     "type": "object",
                     "properties": {
                         "config": {
-                            "type": "string"
+                            "type": [
+                                "string",
+                                "object"
+                            ]
                         },
                         "enabled": {
                             "type": [


### PR DESCRIPTION
In newest Helm, if you provide `.Values.server.standalone.config` as a YAML object the schema validation fails with:
```
Error: values don't meet the specifications of the schema(s) in the following chart(s):
vault:
- server.standalone.config: Invalid type. Expected: string, given: object
```