### PR TITLE
Add extraLabels for CSI DaemonSet

### DIFF
--- a/templates/csi-daemonset.yaml
+++ b/templates/csi-daemonset.yaml
@@ -8,6 +8,9 @@ metadata:
     app.kubernetes.io/name: {{ include "vault.name" . }}-csi-provider
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
+    {{- if  .Values.csi.extraLabels -}}
+      {{- toYaml .Values.csi.extraLabels | nindent 8 -}}
+    {{- end -}}
   {{ template "csi.daemonSet.annotations" . }}
 spec:
   updateStrategy:

--- a/templates/csi-daemonset.yaml
+++ b/templates/csi-daemonset.yaml
@@ -8,6 +8,9 @@ metadata:
     app.kubernetes.io/name: {{ include "vault.name" . }}-csi-provider
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
+    {{- if  .Values.csi.daemonSet.extraLabels -}}
+      {{- toYaml .Values.csi.daemonSet.extraLabels | nindent 4 -}}
+    {{- end -}}
   {{ template "csi.daemonSet.annotations" . }}
 spec:
   updateStrategy:
@@ -25,8 +28,8 @@ spec:
       labels:
         app.kubernetes.io/name: {{ template "vault.name" . }}-csi-provider
         app.kubernetes.io/instance: {{ .Release.Name }}
-        {{- if  .Values.csi.extraLabels -}}
-          {{- toYaml .Values.csi.extraLabels | nindent 8 -}}
+        {{- if  .Values.csi.pod.extraLabels -}}
+          {{- toYaml .Values.csi.pod.extraLabels | nindent 8 -}}
         {{- end -}}
       {{ template "csi.pod.annotations" . }}
     spec:

--- a/templates/csi-daemonset.yaml
+++ b/templates/csi-daemonset.yaml
@@ -8,9 +8,6 @@ metadata:
     app.kubernetes.io/name: {{ include "vault.name" . }}-csi-provider
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
-    {{- if  .Values.csi.extraLabels -}}
-      {{- toYaml .Values.csi.extraLabels | nindent 8 -}}
-    {{- end -}}
   {{ template "csi.daemonSet.annotations" . }}
 spec:
   updateStrategy:
@@ -28,6 +25,9 @@ spec:
       labels:
         app.kubernetes.io/name: {{ template "vault.name" . }}-csi-provider
         app.kubernetes.io/instance: {{ .Release.Name }}
+        {{- if  .Values.csi.extraLabels -}}
+          {{- toYaml .Values.csi.extraLabels | nindent 8 -}}
+        {{- end -}}
       {{ template "csi.pod.annotations" . }}
     spec:
       {{- if .Values.csi.priorityClassName }}

--- a/templates/csi-serviceaccount.yaml
+++ b/templates/csi-serviceaccount.yaml
@@ -8,5 +8,8 @@ metadata:
     app.kubernetes.io/name: {{ include "vault.name" . }}-csi-provider
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
+    {{- if  .Values.csi.serviceAccount.extraLabels -}}
+      {{- toYaml .Values.csi.serviceAccount.extraLabels | nindent 4 -}}
+    {{- end -}}
   {{ template "csi.serviceAccount.annotations" . }}
 {{- end }}

--- a/test/unit/csi-daemonset.bats
+++ b/test/unit/csi-daemonset.bats
@@ -319,6 +319,32 @@ load _helpers
 }
 
 #--------------------------------------------------------------------
+# Extra Labels
+
+@test "csi/daemonset: specify csi.daemonSet.extraLabels" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/csi-daemonset.yaml \
+      --set 'csi.enabled=true' \
+      --set 'csi.daemonSet.extraLabels.foo=bar' \
+      . | tee /dev/stderr |
+      yq -r '.metadata.labels.foo' | tee /dev/stderr)
+  [ "${actual}" = "bar" ]
+}
+
+@test "csi/daemonset: specify csi.pod.extraLabels" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/csi-daemonset.yaml \
+      --set 'csi.enabled=true' \
+      --set 'csi.pod.extraLabels.foo=bar' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.metadata.labels.foo' | tee /dev/stderr)
+  [ "${actual}" = "bar" ]
+}
+
+
+#--------------------------------------------------------------------
 # volumes
 
 @test "csi/daemonset: csi.volumes adds volume" {

--- a/test/unit/csi-serviceaccount.bats
+++ b/test/unit/csi-serviceaccount.bats
@@ -57,3 +57,18 @@ load _helpers
       yq -r '.metadata.annotations["foo"]' | tee /dev/stderr)
   [ "${actual}" = "bar" ]
 }
+
+# serviceAccount extraLabels
+
+@test "csi/serviceAccount: specify csi.serviceAccount.extraLabels" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/csi-serviceaccount.yaml \
+      --set 'csi.enabled=true' \
+      --set 'csi.serviceAccount.extraLabels.foo=bar' \
+      . | tee /dev/stderr |
+      yq -r '.metadata.labels.foo' | tee /dev/stderr)
+  [ "${actual}" = "bar" ]
+}
+
+

--- a/values.schema.json
+++ b/values.schema.json
@@ -14,6 +14,9 @@
                                 "string"
                             ]
                         },
+                        "extraLabels": {
+                            "type": "object"
+                        },
                         "kubeletRootDir": {
                             "type": "string"
                         },
@@ -44,9 +47,6 @@
                 },
                 "extraArgs": {
                     "type": "array"
-                },
-                "extraLabels": {
-                    "type": "object"
                 },
                 "image": {
                     "type": "object",
@@ -91,6 +91,9 @@
                                 "string"
                             ]
                         },
+                        "extraLabels": {
+                            "type": "object"
+                        },
                         "tolerations": {
                             "type": [
                                 "null",
@@ -131,6 +134,9 @@
                                 "object",
                                 "string"
                             ]
+                        },
+                        "extraLabels": {
+                            "type": "object"
                         }
                     }
                 },

--- a/values.schema.json
+++ b/values.schema.json
@@ -45,6 +45,9 @@
                 "extraArgs": {
                     "type": "array"
                 },
+                "extraLabels": {
+                    "type": "object"
+                },
                 "image": {
                     "type": "object",
                     "properties": {

--- a/values.yaml
+++ b/values.yaml
@@ -805,6 +805,9 @@ csi:
     providersDir: "/etc/kubernetes/secrets-store-csi-providers"
     # Kubelet host path
     kubeletRootDir: "/var/lib/kubelet"
+    # Extra labels to attach to the vault-csi-provider daemonSet
+    # This should be a YAML map of the labels to apply to the csi provider daemonSet
+    extraLabels: {}
 
   pod:
     # Extra annotations for the provider pods. This can either be YAML or a
@@ -817,6 +820,12 @@ csi:
     # in a PodSpec.
     tolerations: []
 
+    # Extra labels to attach to the vault-csi-provider pod
+    # This should be a YAML map of the labels to apply to the csi provider pod
+    extraLabels: {}
+
+   
+
   # Priority class for csi pods
   priorityClassName: ""
 
@@ -825,6 +834,10 @@ csi:
     # YAML or a YAML-formatted multi-line templated string map of the
     # annotations to apply to the serviceAccount.
     annotations: {}
+
+    # Extra labels to attach to the vault-csi-provider serviceAccount
+    # This should be a YAML map of the labels to apply to the csi provider serviceAccount
+    extraLabels: {}
 
   # Used to configure readinessProbe for the pods.
   readinessProbe:
@@ -853,10 +866,6 @@ csi:
 
   # Enables debug logging.
   debug: false
-
-  # Extra labels to attach to the vault-csi-provider
-  # This should be a YAML map of the labels to apply to the csi provider
-  extraLabels: {}
 
   # Pass arbitrary additional arguments to vault-csi-provider.
   extraArgs: []

--- a/values.yaml
+++ b/values.yaml
@@ -854,5 +854,9 @@ csi:
   # Enables debug logging.
   debug: false
 
+  # Extra labels to attach to the vault-csi-provider
+  # This should be a YAML map of the labels to apply to the csi provider
+  extraLabels: {}
+
   # Pass arbitrary additional arguments to vault-csi-provider.
   extraArgs: []


### PR DESCRIPTION
In our environment, we have some required labels in order to be able to deploy some resources including daemonsets. You support this for the server and agent already this just adds it for the csi provider as well.