### PR TITLE
Mutating Webhook Kubernetes 1.22

### DIFF
--- a/.github/workflows/acceptance.yaml
+++ b/.github/workflows/acceptance.yaml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        kind-k8s-version: [1.14.10, 1.19.11, 1.20.7, 1.21.2, 1.22.4]
+        kind-k8s-version: [1.21.9, 1.22.6, 1.23.3]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -23,11 +23,6 @@ jobs:
         with:
           config: test/kind/config.yaml
           node_image: kindest/node:v${{ matrix.kind-k8s-version }}
-
-      # Skip CSI tests if K8s version < 1.16.x
-      - run: echo K8S_MINOR=$(kubectl version -o json | jq -r .serverVersion.minor) >> $GITHUB_ENV
-      - if: ${{ env.K8S_MINOR < 16 }}
-        run: echo "SKIP_CSI=true" >> $GITHUB_ENV
 
       - run: bats ./test/acceptance -t
         env:

--- a/.github/workflows/acceptance.yaml
+++ b/.github/workflows/acceptance.yaml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        kind-k8s-version: [1.21.9, 1.22.6, 1.23.3]
+        kind-k8s-version: [1.14.10, 1.19.11, 1.20.7, 1.21.2, 1.22.4]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -23,6 +23,11 @@ jobs:
         with:
           config: test/kind/config.yaml
           node_image: kindest/node:v${{ matrix.kind-k8s-version }}
+
+      # Skip CSI tests if K8s version < 1.16.x
+      - run: echo K8S_MINOR=$(kubectl version -o json | jq -r .serverVersion.minor) >> $GITHUB_ENV
+      - if: ${{ env.K8S_MINOR < 16 }}
+        run: echo "SKIP_CSI=true" >> $GITHUB_ENV
 
       - run: bats ./test/acceptance -t
         env:

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -372,13 +372,13 @@ Sets extra injector service annotations
 Sets extra injector webhook annotations
 */}}
 {{- define "injector.webhookAnnotations" -}}
-  {{- if .Values.injector.webhookAnnotations }}
+  {{- if .Values.injector.webhook.webhookAnnotations }}
   annotations:
-    {{- $tp := typeOf .Values.injector.webhookAnnotations }}
+    {{- $tp := typeOf .Values.injector.webhook.webhookAnnotations }}
     {{- if eq $tp "string" }}
-      {{- tpl .Values.injector.webhookAnnotations . | nindent 4 }}
+      {{- tpl .Values.injector.webhook.webhookAnnotations . | nindent 4 }}
     {{- else }}
-      {{- toYaml .Values.injector.webhookAnnotations | nindent 4 }}
+      {{- toYaml .Values.injector.webhook.webhookAnnotations | nindent 4 }}
     {{- end }}
   {{- end }}
 {{- end -}}

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -372,13 +372,13 @@ Sets extra injector service annotations
 Sets extra injector webhook annotations
 */}}
 {{- define "injector.webhookAnnotations" -}}
-  {{- if .Values.injector.webhook.webhookAnnotations }}
+  {{- if or (((.Values.injector.webhook)).annotations) (.Values.injector.webhookAnnotations)  }}
   annotations:
-    {{- $tp := typeOf .Values.injector.webhook.webhookAnnotations }}
+    {{- $tp := typeOf (or (((.Values.injector.webhook)).annotations) (.Values.injector.webhookAnnotations)) }}
     {{- if eq $tp "string" }}
-      {{- tpl .Values.injector.webhook.webhookAnnotations . | nindent 4 }}
+      {{- tpl (((.Values.injector.webhook)).annotations | default .Values.injector.webhookAnnotations) . | nindent 4 }}
     {{- else }}
-      {{- toYaml .Values.injector.webhook.webhookAnnotations | nindent 4 }}
+      {{- toYaml (((.Values.injector.webhook)).annotations | default .Values.injector.webhookAnnotations) | nindent 4 }}
     {{- end }}
   {{- end }}
 {{- end -}}

--- a/templates/injector-mutating-webhook.yaml
+++ b/templates/injector-mutating-webhook.yaml
@@ -14,10 +14,11 @@ metadata:
   {{- template "injector.webhookAnnotations" . }}
 webhooks:
   - name: vault.hashicorp.com
+    failurePolicy: {{ .Values.injector.webhook.failurePolicy }}
+    matchPolicy: {{ .Values.injector.webhook.matchPolicy }}
     sideEffects: None
-    admissionReviewVersions:
-    - "v1beta1"
-    - "v1"
+    timeoutSeconds: {{ .Values.injector.webhook.timeoutSeconds }}
+    admissionReviewVersions: {{ .Values.injector.webhook.admissionReviewVersions }}
     clientConfig:
       service:
         name: {{ template "vault.fullname" . }}-agent-injector-svc
@@ -29,15 +30,12 @@ webhooks:
         apiGroups: [""]
         apiVersions: ["v1"]
         resources: ["pods"]
-{{- if .Values.injector.namespaceSelector }}
+{{- if .Values.injector.webhook.namespaceSelector }}
     namespaceSelector:
-{{ toYaml .Values.injector.namespaceSelector | indent 6}}
+{{ toYaml .Values.injector.webhook.namespaceSelector | indent 6}}
 {{ end }}
-{{- if .Values.injector.objectSelector }}
+{{- if .Values.injector.webhook.objectSelector }}
     objectSelector:
-{{ toYaml .Values.injector.objectSelector | indent 6}}
-{{ end }}
-{{- with .Values.injector.failurePolicy }}
-    failurePolicy: {{.}}
+{{ toYaml .Values.injector.webhook.objectSelector | indent 6}}
 {{ end }}
 {{ end }}

--- a/templates/injector-mutating-webhook.yaml
+++ b/templates/injector-mutating-webhook.yaml
@@ -14,11 +14,11 @@ metadata:
   {{- template "injector.webhookAnnotations" . }}
 webhooks:
   - name: vault.hashicorp.com
-    failurePolicy: {{ .Values.injector.webhook.failurePolicy }}
-    matchPolicy: {{ .Values.injector.webhook.matchPolicy }}
+    failurePolicy: {{ ((.Values.injector.webhook)).failurePolicy | default .Values.injector.failurePolicy }}
+    matchPolicy: {{ ((.Values.injector.webhook)).matchPolicy | default "Exact" }}
     sideEffects: None
-    timeoutSeconds: {{ .Values.injector.webhook.timeoutSeconds }}
-    admissionReviewVersions: {{ .Values.injector.webhook.admissionReviewVersions }}
+    timeoutSeconds: {{ ((.Values.injector.webhook)).timeoutSeconds | default "30" }}
+    admissionReviewVersions: ["v1", "v1beta1"]
     clientConfig:
       service:
         name: {{ template "vault.fullname" . }}-agent-injector-svc
@@ -30,12 +30,12 @@ webhooks:
         apiGroups: [""]
         apiVersions: ["v1"]
         resources: ["pods"]
-{{- if .Values.injector.webhook.namespaceSelector }}
+{{- if or (.Values.injector.namespaceSelector) (((.Values.injector.webhook)).namespaceSelector) }}
     namespaceSelector:
-{{ toYaml .Values.injector.webhook.namespaceSelector | indent 6}}
+{{ toYaml (((.Values.injector.webhook)).namespaceSelector | default .Values.injector.namespaceSelector) | indent 6}}
 {{ end }}
-{{- if .Values.injector.webhook.objectSelector }}
+{{- if or (((.Values.injector.webhook)).objectSelector) (.Values.injector.objectSelector) }}
     objectSelector:
-{{ toYaml .Values.injector.webhook.objectSelector | indent 6}}
+{{ toYaml (((.Values.injector.webhook)).objectSelector | default .Values.injector.objectSelector) | indent 6}}
 {{ end }}
 {{ end }}

--- a/test/unit/injector-mutating-webhook.bats
+++ b/test/unit/injector-mutating-webhook.bats
@@ -53,64 +53,19 @@ load _helpers
   [ "${actual}" = "\"\"" ]
 }
 
-@test "injector/MutatingWebhookConfiguration: namespaceSelector empty by default" {
+@test "injector/MutatingWebhookConfiguration: failurePolicy 'Ignore' by default (deprecated)" {
   cd `chart_dir`
   local actual=$(helm template \
       --show-only templates/injector-mutating-webhook.yaml  \
       --set 'injector.enabled=true' \
-      --namespace foo \
-      . | tee /dev/stderr |
-      yq '.webhooks[0].namespaceSelector' | tee /dev/stderr)
-  [ "${actual}" = "null" ]
-}
-
-@test "injector/MutatingWebhookConfiguration: can set namespaceSelector" {
-  cd `chart_dir`
-  local actual=$(helm template \
-      --show-only templates/injector-mutating-webhook.yaml  \
-      --set 'injector.enabled=true' \
-      --set 'injector.namespaceSelector.matchLabels.injector=true' \
-      . | tee /dev/stderr |
-      yq '.webhooks[0].namespaceSelector.matchLabels.injector' | tee /dev/stderr)
-
-  [ "${actual}" = "true" ]
-}
-
-@test "injector/MutatingWebhookConfiguration: objectSelector empty by default" {
-  cd `chart_dir`
-  local actual=$(helm template \
-      --show-only templates/injector-mutating-webhook.yaml  \
-      --set 'injector.enabled=true' \
-      --namespace foo \
-      . | tee /dev/stderr |
-      yq '.webhooks[0].objectSelector' | tee /dev/stderr)
-  [ "${actual}" = "null" ]
-}
-
-@test "injector/MutatingWebhookConfiguration: can set objectSelector" {
-  cd `chart_dir`
-  local actual=$(helm template \
-      --show-only templates/injector-mutating-webhook.yaml  \
-      --set 'injector.enabled=true' \
-      --set 'injector.objectSelector.matchLabels.injector=true' \
-      . | tee /dev/stderr |
-      yq '.webhooks[0].objectSelector.matchLabels.injector' | tee /dev/stderr)
-
-  [ "${actual}" = "true" ]
-}
-
-@test "injector/MutatingWebhookConfiguration: failurePolicy 'Ignore' by default" {
-  cd `chart_dir`
-  local actual=$(helm template \
-      --show-only templates/injector-mutating-webhook.yaml  \
-      --set 'injector.enabled=true' \
+      --set 'injector.webhook=null' \
       --namespace foo \
       . | tee /dev/stderr |
       yq '.webhooks[0].failurePolicy' | tee /dev/stderr)
   [ "${actual}" = "\"Ignore\"" ]
 }
 
-@test "injector/MutatingWebhookConfiguration: can set failurePolicy" {
+@test "injector/MutatingWebhookConfiguration: can set failurePolicy (deprecated)" {
   cd `chart_dir`
   local actual=$(helm template \
       --show-only templates/injector-mutating-webhook.yaml  \
@@ -122,34 +77,250 @@ load _helpers
   [ "${actual}" = "\"Fail\"" ]
 }
 
+@test "injector/MutatingWebhookConfiguration: webhook.failurePolicy 'Ignore' by default" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/injector-mutating-webhook.yaml  \
+      --set 'injector.enabled=true' \
+      --set 'injector.failurePolicy=Invalid' \
+      . | tee /dev/stderr |
+      yq '.webhooks[0].failurePolicy' | tee /dev/stderr)
+
+  [ "${actual}" = "\"Ignore\"" ]
+}
+
+@test "injector/MutatingWebhookConfiguration: can set webhook.failurePolicy" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/injector-mutating-webhook.yaml  \
+      --set 'injector.enabled=true' \
+      --set 'injector.webhook.failurePolicy=Fail' \
+      --set 'injector.failurePolicy=Invalid' \
+      . | tee /dev/stderr |
+      yq '.webhooks[0].failurePolicy' | tee /dev/stderr)
+
+  [ "${actual}" = "\"Fail\"" ]
+}
+
+@test "injector/MutatingWebhookConfiguration: webhook.matchPolicy 'Exact' by default" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/injector-mutating-webhook.yaml  \
+      --set 'injector.enabled=true' \
+      . | tee /dev/stderr |
+      yq '.webhooks[0].matchPolicy' | tee /dev/stderr)
+
+  [ "${actual}" = "\"Exact\"" ]
+}
+
+@test "injector/MutatingWebhookConfiguration: can set webhook.matchPolicy" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/injector-mutating-webhook.yaml  \
+      --set 'injector.enabled=true' \
+      --set 'injector.webhook.matchPolicy=Equivalent' \
+      . | tee /dev/stderr |
+      yq '.webhooks[0].matchPolicy' | tee /dev/stderr)
+
+  [ "${actual}" = "\"Equivalent\"" ]
+}
+
+@test "injector/MutatingWebhookConfiguration: timeoutSeconds by default 30" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/injector-mutating-webhook.yaml  \
+      --set 'injector.enabled=true' \
+      --set 'injector.webhook=null' \
+      . | tee /dev/stderr |
+      yq '.webhooks[0].timeoutSeconds' | tee /dev/stderr)
+
+  [ "${actual}" = "30" ]
+}
+
+@test "injector/MutatingWebhookConfiguration: can set webhook.timeoutSeconds" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/injector-mutating-webhook.yaml  \
+      --set 'injector.enabled=true' \
+      --set 'injector.webhook.timeoutSeconds=50' \
+      . | tee /dev/stderr |
+      yq '.webhooks[0].timeoutSeconds' | tee /dev/stderr)
+
+  [ "${actual}" = "50" ]
+}
+
 #--------------------------------------------------------------------
 # annotations
 
-@test "injector/MutatingWebhookConfiguration: default annotations" {
+@test "injector/MutatingWebhookConfiguration: default webhookAnnotations (deprecated)" {
   cd `chart_dir`
   local actual=$(helm template \
       --show-only templates/injector-mutating-webhook.yaml \
+      --set 'injector.enabled=true' \
+      --set 'injector.webhook=null' \
       . | tee /dev/stderr |
       yq -r '.metadata.annotations' | tee /dev/stderr)
   [ "${actual}" = "null" ]
 }
 
-@test "injector/MutatingWebhookConfiguration: specify annotations yaml" {
+@test "injector/MutatingWebhookConfiguration: specify webhookAnnotations yaml (deprecated)" {
   cd `chart_dir`
   local actual=$(helm template \
       --show-only templates/injector-mutating-webhook.yaml \
+      --set 'injector.enabled=true' \
+      --set 'injector.webhook=null' \
       --set 'injector.webhookAnnotations.foo=bar' \
       . | tee /dev/stderr |
       yq -r '.metadata.annotations.foo' | tee /dev/stderr)
   [ "${actual}" = "bar" ]
 }
 
-@test "injector/MutatingWebhookConfiguration: specify annotations yaml string" {
+@test "injector/MutatingWebhookConfiguration: specify webhookAnnotations yaml string (deprecated)" {
   cd `chart_dir`
   local actual=$(helm template \
       --show-only templates/injector-mutating-webhook.yaml \
+      --set 'injector.enabled=true' \
+      --set 'injector.webhook=null' \
       --set 'injector.webhookAnnotations=foo: bar' \
       . | tee /dev/stderr |
       yq -r '.metadata.annotations.foo' | tee /dev/stderr)
   [ "${actual}" = "bar" ]
+}
+
+@test "injector/MutatingWebhookConfiguration: default webhook.annotations" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/injector-mutating-webhook.yaml \
+      --set 'injector.enabled=true' \
+      . | tee /dev/stderr |
+      yq -r '.metadata.annotations' | tee /dev/stderr)
+  [ "${actual}" = "null" ]
+}
+
+@test "injector/MutatingWebhookConfiguration: specify webhook.annotations yaml" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/injector-mutating-webhook.yaml \
+      --set 'injector.enabled=true' \
+      --set 'injector.webhook=null' \
+      --set 'injector.webhook.annotations.foo=bar' \
+      --set 'injector.webhookAnnotations.invalid=invalid' \
+      . | tee /dev/stderr |
+      yq -r '.metadata.annotations.foo' | tee /dev/stderr)
+  [ "${actual}" = "bar" ]
+}
+
+@test "injector/MutatingWebhookConfiguration: specify webhook.annotations yaml string" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/injector-mutating-webhook.yaml \
+      --set 'injector.enabled=true' \
+      --set 'injector.webhook.annotations=foo: bar' \
+      --set 'injector.webhookAnnotations=invalid: invalid' \
+      . | tee /dev/stderr |
+      yq -r '.metadata.annotations.foo' | tee /dev/stderr)
+  [ "${actual}" = "bar" ]
+}
+
+#--------------------------------------------------------------------
+# namespaceSelector
+
+@test "injector/MutatingWebhookConfiguration: namespaceSelector empty by default (deprecated)" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/injector-mutating-webhook.yaml  \
+      --set 'injector.enabled=true' \
+      --set 'injector.webhook=null' \
+      --namespace foo \
+      . | tee /dev/stderr |
+      yq '.webhooks[0].namespaceSelector' | tee /dev/stderr)
+  [ "${actual}" = "null" ]
+}
+
+@test "injector/MutatingWebhookConfiguration: can set namespaceSelector (deprecated)" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/injector-mutating-webhook.yaml  \
+      --set 'injector.enabled=true' \
+      --set 'injector.namespaceSelector.matchLabels.injector=true' \
+      . | tee /dev/stderr |
+      yq '.webhooks[0].namespaceSelector.matchLabels.injector' | tee /dev/stderr)
+
+  [ "${actual}" = "true" ]
+}
+
+@test "injector/MutatingWebhookConfiguration: webhook.namespaceSelector empty by default" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/injector-mutating-webhook.yaml  \
+      --set 'injector.enabled=true' \
+      --namespace foo \
+      . | tee /dev/stderr |
+      yq '.webhooks[0].namespaceSelector' | tee /dev/stderr)
+  [ "${actual}" = "null" ]
+}
+
+@test "injector/MutatingWebhookConfiguration: can set set webhook.namespaceSelector" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/injector-mutating-webhook.yaml  \
+      --set 'injector.enabled=true' \
+      --set 'injector.webhook.namespaceSelector.matchLabels.injector=true' \
+      --set 'injector.namespaceSelector.matchLabels.injector=false' \
+      . | tee /dev/stderr |
+      yq '.webhooks[0].namespaceSelector.matchLabels.injector' | tee /dev/stderr)
+
+  [ "${actual}" = "true" ]
+}
+
+#--------------------------------------------------------------------
+# objectSelector
+
+@test "injector/MutatingWebhookConfiguration: objectSelector empty by default (deprecated)" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/injector-mutating-webhook.yaml  \
+      --set 'injector.enabled=true' \
+      --set 'injector.webhook=null' \
+      --namespace foo \
+      . | tee /dev/stderr |
+      yq '.webhooks[0].objectSelector' | tee /dev/stderr)
+  [ "${actual}" = "null" ]
+}
+
+@test "injector/MutatingWebhookConfiguration: can set objectSelector (deprecated)" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/injector-mutating-webhook.yaml  \
+      --set 'injector.enabled=true' \
+      --set 'injector.webhook=null' \
+      --set 'injector.objectSelector.matchLabels.injector=true' \
+      . | tee /dev/stderr |
+      yq '.webhooks[0].objectSelector.matchLabels.injector' | tee /dev/stderr)
+
+  [ "${actual}" = "true" ]
+}
+
+@test "injector/MutatingWebhookConfiguration: webhook.objectSelector empty by default" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/injector-mutating-webhook.yaml  \
+      --set 'injector.enabled=true' \
+      --namespace foo \
+      . | tee /dev/stderr |
+      yq '.webhooks[0].objectSelector' | tee /dev/stderr)
+  [ "${actual}" = "null" ]
+}
+
+@test "injector/MutatingWebhookConfiguration: can set webhook.objectSelector" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/injector-mutating-webhook.yaml  \
+      --set 'injector.enabled=true' \
+      --set 'injector.webhook.objectSelector.matchLabels.injector=true' \
+      --set 'injector.objectSelector.matchLabels.injector=false' \
+      . | tee /dev/stderr |
+      yq '.webhooks[0].objectSelector.matchLabels.injector' | tee /dev/stderr)
+
+  [ "${actual}" = "true" ]
 }

--- a/test/unit/injector-mutating-webhook.bats
+++ b/test/unit/injector-mutating-webhook.bats
@@ -70,6 +70,7 @@ load _helpers
   local actual=$(helm template \
       --show-only templates/injector-mutating-webhook.yaml  \
       --set 'injector.enabled=true' \
+      --set 'injector.webhook=null' \
       --set 'injector.failurePolicy=Fail' \
       . | tee /dev/stderr |
       yq '.webhooks[0].failurePolicy' | tee /dev/stderr)
@@ -202,7 +203,6 @@ load _helpers
   local actual=$(helm template \
       --show-only templates/injector-mutating-webhook.yaml \
       --set 'injector.enabled=true' \
-      --set 'injector.webhook=null' \
       --set 'injector.webhook.annotations.foo=bar' \
       --set 'injector.webhookAnnotations.invalid=invalid' \
       . | tee /dev/stderr |

--- a/values.schema.json
+++ b/values.schema.json
@@ -365,6 +365,32 @@
                         "string"
                     ]
                 },
+                "webhook": {
+                    "type": "object",
+                    "properties": {
+                        "annotations": {
+                            "type": [
+                                "object",
+                                "string"
+                            ]
+                        },
+                        "failurePolicy": {
+                            "type": "string"
+                        },
+                        "matchPolicy": {
+                            "type": "string"
+                        },
+                        "namespaceSelector": {
+                            "type": "object"
+                        },
+                        "objectSelector": {
+                            "type": "object"
+                        },
+                        "timeoutSeconds": {
+                            "type": "integer"
+                        }
+                    }
+                },
                 "webhookAnnotations": {
                     "type": [
                         "object",

--- a/values.yaml
+++ b/values.yaml
@@ -90,34 +90,62 @@ injector:
   # Configures all Vault Agent sidecars to revoke their token when shutting down
   revokeOnShutdown: false
 
-  # namespaceSelector is the selector for restricting the webhook to only
-  # specific namespaces.
-  # See https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/#matching-requests-namespaceselector
-  # for more details.
-  # Example:
-  # namespaceSelector:
-  #    matchLabels:
-  #      sidecar-injector: enabled
-  namespaceSelector: {}
-  # objectSelector is the selector for restricting the webhook to only
-  # specific labels.
-  # See https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/#matching-requests-objectselector
-  # for more details.
-  # Example:
-  # objectSelector:
-  #    matchLabels:
-  #      vault-sidecar-injector: enabled
-  objectSelector: {}
+  webhook: 
+    # Configures failurePolicy of the webhook. The "unspecified" default behaviour depends on the
+    # API Version of the WebHook.
+    # To block pod creation while webhook is unavailable, set the policy to `Fail` below.
+    # See https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/#failure-policy
+    #
+    failurePolicy: Ignore
 
-  # Configures failurePolicy of the webhook. The "unspecified" default behaviour deoends on the
-  # API Version of the WebHook.
-  # To block pod creation while webhook is unavailable, set the policy to `Fail` below.
-  # See https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/#failure-policy
-  #
-  failurePolicy: Ignore
+    # matchPolicy specifies the approach to accepting changes based on the rules of 
+    # the MutatingWebhookConfiguration.
+    # See https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/#matching-requests-matchpolicy
+    # for more details.
+    #
+    matchPolicy: Exact
 
-  # Extra annotations to attach to the webhook
-  webhookAnnotations: {}
+    # namespaceSelector is the selector for restricting the webhook to only
+    # specific namespaces.
+    # See https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/#matching-requests-namespaceselector
+    # for more details.
+    # Example:
+    # namespaceSelector:
+    #    matchLabels:
+    #      sidecar-injector: enabled
+    namespaceSelector: {}
+
+    # objectSelector is the selector for restricting the webhook to only
+    # specific labels.
+    # See https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/#matching-requests-objectselector
+    # for more details.
+    # Example:
+    # objectSelector:
+    #    matchLabels:
+    #      vault-sidecar-injector: enabled
+    objectSelector: {}
+
+    # timeoutSeconds is the amount of seconds before the webhook request will be ignored
+    # or fails.
+    # If it is ignored or fails depends on the failurePolicy
+    # See https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/#timeouts
+    # for more details.
+    #
+    timeoutSeconds: 30
+
+    # sideEffects reflects if the webhook changes (side effects) and is sometimes used by webhooks to reconcile.
+    # See https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/#side-effects
+    # for more details.
+    #
+    sideEffects: None
+    
+    # admissionReviewVersions specifies an ordered list of preferred `AdmissionReview` versions the webhook expects.
+    # See https://github.com/kubernetes/api/blob/v0.23.4/admissionregistration/v1beta1/types.go#L314
+    # for more details.
+    admissionReviewVersions: ["v1", "v1beta1"]
+
+    # Extra annotations to attach to the webhook
+    annotations: {}
 
   certs:
     # secretName is the name of the secret that has the TLS certificate and

--- a/values.yaml
+++ b/values.yaml
@@ -105,6 +105,19 @@ injector:
     #
     matchPolicy: Exact
 
+    # timeoutSeconds is the amount of seconds before the webhook request will be ignored
+    # or fails.
+    # If it is ignored or fails depends on the failurePolicy
+    # See https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/#timeouts
+    # for more details.
+    #
+    timeoutSeconds: 30
+    
+    # admissionReviewVersions specifies an ordered list of preferred `AdmissionReview` versions the webhook expects.
+    # See https://github.com/kubernetes/api/blob/v0.23.4/admissionregistration/v1beta1/types.go#L314
+    # for more details.
+    admissionReviewVersions: ["v1", "v1beta1"]
+    
     # namespaceSelector is the selector for restricting the webhook to only
     # specific namespaces.
     # See https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/#matching-requests-namespaceselector
@@ -124,25 +137,6 @@ injector:
     #    matchLabels:
     #      vault-sidecar-injector: enabled
     objectSelector: {}
-
-    # timeoutSeconds is the amount of seconds before the webhook request will be ignored
-    # or fails.
-    # If it is ignored or fails depends on the failurePolicy
-    # See https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/#timeouts
-    # for more details.
-    #
-    timeoutSeconds: 30
-
-    # sideEffects reflects if the webhook changes (side effects) and is sometimes used by webhooks to reconcile.
-    # See https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/#side-effects
-    # for more details.
-    #
-    sideEffects: None
-    
-    # admissionReviewVersions specifies an ordered list of preferred `AdmissionReview` versions the webhook expects.
-    # See https://github.com/kubernetes/api/blob/v0.23.4/admissionregistration/v1beta1/types.go#L314
-    # for more details.
-    admissionReviewVersions: ["v1", "v1beta1"]
 
     # Extra annotations to attach to the webhook
     annotations: {}

--- a/values.yaml
+++ b/values.yaml
@@ -113,11 +113,6 @@ injector:
     #
     timeoutSeconds: 30
     
-    # admissionReviewVersions specifies an ordered list of preferred `AdmissionReview` versions the webhook expects.
-    # See https://github.com/kubernetes/api/blob/v0.23.4/admissionregistration/v1beta1/types.go#L314
-    # for more details.
-    admissionReviewVersions: ["v1", "v1beta1"]
-    
     # namespaceSelector is the selector for restricting the webhook to only
     # specific namespaces.
     # See https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/#matching-requests-namespaceselector
@@ -140,6 +135,39 @@ injector:
 
     # Extra annotations to attach to the webhook
     annotations: {}
+
+  # Configures failurePolicy of the webhook. The "unspecified" default behaviour depends on the
+  # API Version of the WebHook.
+  # To block pod creation while webhook is unavailable, set the policy to `Fail` below.
+  # See https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/#failure-policy
+  #
+  failurePolicy: Ignore
+
+  # Deprecated: please use 'webhook.namespaceSelector' instead
+  # namespaceSelector is the selector for restricting the webhook to only
+  # specific namespaces.
+  # See https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/#matching-requests-namespaceselector
+  # for more details.
+  # Example:
+  # namespaceSelector:
+  #    matchLabels:
+  #      sidecar-injector: enabled
+  namespaceSelector: {}
+
+  # Deprecated: please use 'webhook.objectSelector' instead
+  # objectSelector is the selector for restricting the webhook to only
+  # specific labels.
+  # See https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/#matching-requests-objectselector
+  # for more details.
+  # Example:
+  # objectSelector:
+  #    matchLabels:
+  #      vault-sidecar-injector: enabled
+  objectSelector: {}
+
+  # Deprecated: please use 'webhook.annotations' instead
+  # Extra annotations to attach to the webhook
+  webhookAnnotations: {}
 
   certs:
     # secretName is the name of the secret that has the TLS certificate and

--- a/values.yaml
+++ b/values.yaml
@@ -136,6 +136,7 @@ injector:
     # Extra annotations to attach to the webhook
     annotations: {}
 
+  # Deprecated: please use 'webhook.failurePolicy' instead
   # Configures failurePolicy of the webhook. The "unspecified" default behaviour depends on the
   # API Version of the WebHook.
   # To block pod creation while webhook is unavailable, set the policy to `Fail` below.


### PR DESCRIPTION
Mutating Webhook Kubernetes 1.22 consistency pull request to ensure no previous behaviour is changed.

Changes to be done:
1. values.yaml hold default values from MutatingWebhookConfiguration/v1beta1
2. injector-mutating-webhook.yaml sets the default values based on the values.yaml