### PR TITLE
Allow creation of ingress in Openshift

### DIFF
--- a/templates/server-ingress.yaml
+++ b/templates/server-ingress.yaml
@@ -1,4 +1,4 @@
-{{- if not .Values.global.openshift }}
+{{- if or (not .Values.global.openshift) (not .Values.server.route.enabled) }}
 {{ template "vault.mode" . }}
 {{- if ne .mode "external" }}
 {{- if .Values.server.ingress.enabled -}}

--- a/values.yaml
+++ b/values.yaml
@@ -263,8 +263,7 @@ server:
 
   # Ingress allows ingress services to be created to allow external access
   # from Kubernetes to access Vault pods.
-  # If deployment is on OpenShift, the following block is ignored.
-  # In order to expose the service, use the route section below
+  # If deployment is on OpenShift and route is enabled, the following block is ignored.
   ingress:
     enabled: false
     labels: {}


### PR DESCRIPTION
Currently the chart will completely ignore the `server.ingress` block if the target deployment platform is OpenShift. As far as I can tell this was done to prevent accidental creation of two routes if both `server.route` as well as `server.ingress` is enabled.

However it can be helpful to also be able to deploy an `Ingress` on OpenShift, for example because `cert-manager` does not support `Route` objects. 

With this PR there is the option to configure an `Ingress`, but we still keep as safeguard that a user doesn't accidentally create two routes.