### PR TITLE
Restore Secrets Store CSI driver to 1.0.0

### DIFF
--- a/test/acceptance/csi.bats
+++ b/test/acceptance/csi.bats
@@ -17,7 +17,7 @@ check_skip_csi() {
   kubectl create namespace acceptance
 
   # Install Secrets Store CSI driver
-  CSI_DRIVER_VERSION=1.1.2
+  CSI_DRIVER_VERSION=1.0.0
   helm install secrets-store-csi-driver https://kubernetes-sigs.github.io/secrets-store-csi-driver/charts/secrets-store-csi-driver-${CSI_DRIVER_VERSION}.tgz?raw=true \
     --wait --timeout=5m \
     --namespace=acceptance \


### PR DESCRIPTION
1.0.1+ seems to only support Kubernetes 1.19+, so we break support for k8s 1.16 if we upgrade