### PR TITLE
Update minimum required helm version in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,7 @@ this README. Please refer to the Kubernetes and Helm documentation.
 
 The versions required are:
 
-  * **Helm 3.6+** - This is the earliest version of Helm tested. It is possible
-    it works with earlier versions but this chart is untested for those versions.
+  * **Helm 3.6+**
   * **Kubernetes 1.16+** - This is the earliest version of Kubernetes tested.
     It is possible that this chart works with earlier versions but it is
     untested.

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ this README. Please refer to the Kubernetes and Helm documentation.
 
 The versions required are:
 
-  * **Helm 3.0+** - This is the earliest version of Helm tested. It is possible
+  * **Helm 3.6+** - This is the earliest version of Helm tested. It is possible
     it works with earlier versions but this chart is untested for those versions.
   * **Kubernetes 1.16+** - This is the earliest version of Kubernetes tested.
     It is possible that this chart works with earlier versions but it is


### PR DESCRIPTION
Helm 3.6 or later is now required for the chart.

Related to https://github.com/hashicorp/vault-helm/issues/729