### PR TITLE
Restore missing 'vault' service account

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Unreleased
 
+CHANGES:
+* `vault` service account is now created even if the server is set to disabled, as per before 0.20.0
+
 ## 0.20.0 (May 16th, 2022)
 
 CHANGES:

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -59,6 +59,32 @@ Compute if the server is enabled.
 {{- end -}}
 
 {{/*
+Compute if the server auth delegator serviceaccount is enabled.
+*/}}
+{{- define "vault.serverServiceAccountEnabled" -}}
+{{- $_ := set . "serverServiceAccountEnabled"
+  (and
+    (eq (.Values.server.serviceAccount.create | toString) "true" )
+    (or
+      (eq (.Values.server.enabled | toString) "true")
+      (eq (.Values.global.enabled | toString) "true"))) -}}
+{{- end -}}
+
+{{/*
+Compute if the server auth delegator serviceaccount is enabled.
+*/}}
+{{- define "vault.serverAuthDelegator" -}}
+{{- $_ := set . "serverAuthDelegator"
+  (and
+    (eq (.Values.server.authDelegator.enabled | toString) "true" )
+    (or (eq (.Values.server.serviceAccount.create | toString) "true")
+        (not (eq .Values.server.serviceAccount.name "")))
+    (or
+      (eq (.Values.server.enabled | toString) "true")
+      (eq (.Values.global.enabled | toString) "true"))) -}}
+{{- end -}}
+
+{{/*
 Compute if the server service is enabled.
 */}}
 {{- define "vault.serverServiceEnabled" -}}

--- a/templates/server-clusterrolebinding.yaml
+++ b/templates/server-clusterrolebinding.yaml
@@ -1,6 +1,5 @@
-{{ template "vault.mode" . }}
-{{- if .serverEnabled -}}
-{{- if and (ne .mode "") (eq (.Values.server.authDelegator.enabled | toString) "true") }}
+{{ template "vault.serverAuthDelegator" . }}
+{{- if .serverAuthDelegator -}}
 {{- if .Capabilities.APIVersions.Has "rbac.authorization.k8s.io/v1" -}}
 apiVersion: rbac.authorization.k8s.io/v1
 {{- else }}
@@ -22,5 +21,4 @@ subjects:
 - kind: ServiceAccount
   name: {{ template "vault.serviceAccount.name" . }}
   namespace: {{ .Release.Namespace }}
-{{ end }}
 {{ end }}

--- a/templates/server-serviceaccount.yaml
+++ b/templates/server-serviceaccount.yaml
@@ -1,6 +1,5 @@
-{{ template "vault.mode" . }}
-{{- if .serverEnabled -}}
-{{- if (eq (.Values.server.serviceAccount.create | toString) "true" ) }}
+{{ template "vault.serverServiceAccountEnabled" . }}
+{{- if .serverServiceAccountEnabled -}}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -12,5 +11,4 @@ metadata:
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
   {{ template "vault.serviceAccount.annotations" . }}
-{{ end }}
 {{ end }}

--- a/test/unit/server-clusterrolebinding.bats
+++ b/test/unit/server-clusterrolebinding.bats
@@ -65,6 +65,7 @@ load _helpers
   cd `chart_dir`
   local actual=$( (helm template \
       --show-only templates/server-clusterrolebinding.yaml  \
+      --set 'server.enabled=false' \
       --set 'injector.externalVaultAddr=http://vault-outside' \
       . || echo "---") | tee /dev/stderr |
       yq 'length > 0' | tee /dev/stderr)


### PR DESCRIPTION
Our tutorials rely on this service account being present even if we are
using an external Vault.

The `values.yaml` also states that external Vaults are expected to use
this service account.

For example,
https://learn.hashicorp.com/tutorials/vault/kubernetes-external-vault?in=vault/kubernetes#install-the-vault-helm-chart-configured-to-address-an-external-vault