### PR TITLE
Prepare for release 0.20.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Unreleased
 
+## 0.20.1 (May 25th, 2022)
+Improvements:
+* `vault-k8s` updated to 0.16.1
+
 CHANGES:
 * `vault` service account is now created even if the server is set to disabled, as per before 0.20.0 [GH-737](https://github.com/hashicorp/vault-helm/pull/737)
 * Mutating webhook will no longer target the agent injector pod [GH-736](https://github.com/hashicorp/vault-helm/pull/736)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,14 @@
 ## Unreleased
 
 ## 0.20.1 (May 25th, 2022)
-Improvements:
+CHANGES:
 * `vault-k8s` updated to 0.16.1
 
-CHANGES:
-* `vault` service account is now created even if the server is set to disabled, as per before 0.20.0 [GH-737](https://github.com/hashicorp/vault-helm/pull/737)
+Improvements:
 * Mutating webhook will no longer target the agent injector pod [GH-736](https://github.com/hashicorp/vault-helm/pull/736)
+
+Bugs:
+* `vault` service account is now created even if the server is set to disabled, as per before 0.20.0 [GH-737](https://github.com/hashicorp/vault-helm/pull/737)
 
 ## 0.20.0 (May 16th, 2022)
 

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: vault
-version: 0.20.0
+version: 0.20.1
 appVersion: 1.10.3
 kubeVersion: ">= 1.16.0-0"
 description: Official HashiCorp Vault Chart

--- a/values.openshift.yaml
+++ b/values.openshift.yaml
@@ -6,7 +6,7 @@ global:
 injector:
   image:
     repository: "registry.connect.redhat.com/hashicorp/vault-k8s"
-    tag: "0.16.0-ubi"
+    tag: "0.16.1-ubi"
 
   agentImage:
     repository: "registry.connect.redhat.com/hashicorp/vault"

--- a/values.yaml
+++ b/values.yaml
@@ -50,7 +50,7 @@ injector:
   # image sets the repo and tag of the vault-k8s image to use for the injector.
   image:
     repository: "hashicorp/vault-k8s"
-    tag: "0.16.0"
+    tag: "0.16.1"
     pullPolicy: IfNotPresent
 
   # agentImage sets the repo and tag of the Vault image to use for the Vault Agent


### PR DESCRIPTION
Improvements:
* `vault-k8s` updated to 0.16.1

CHANGES:
* `vault` service account is now created even if the server is set to disabled, as per before 0.20.0 [GH-737](https://github.com/hashicorp/vault-helm/pull/737)
* Mutating webhook will no longer target the agent injector pod [GH-736](https://github.com/hashicorp/vault-helm/pull/736)