### PR TITLE
Set VAULT_ADDR env var for CSI Provider pods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,13 @@
 ## Unreleased
 
 CHANGES:
-* Start testing against Kubernetes 1.24
-* Deprecated `injector.externalVaultAddr`. Added `global.externalVaultAddr`, which applies to both the Injector and the CSI Provider.
-* CSI Provider pods now set the `VAULT_ADDR` environment variable to either the internal Vault service or the configured external address.
+* Start testing against Kubernetes 1.24. [GH-744](https://github.com/hashicorp/vault-helm/pull/744)
+* Deprecated `injector.externalVaultAddr`. Added `global.externalVaultAddr`, which applies to both the Injector and the CSI Provider. [GH-745](https://github.com/hashicorp/vault-helm/pull/745)
+* CSI Provider pods now set the `VAULT_ADDR` environment variable to either the internal Vault service or the configured external address. [GH-745](https://github.com/hashicorp/vault-helm/pull/745)
 
 ## 0.20.1 (May 25th, 2022)
 CHANGES:
-* `vault-k8s` updated to 0.16.1
+* `vault-k8s` updated to 0.16.1 [GH-739](https://github.com/hashicorp/vault-helm/pull/739)
 
 Improvements:
 * Mutating webhook will no longer target the agent injector pod [GH-736](https://github.com/hashicorp/vault-helm/pull/736)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 CHANGES:
 * Start testing against Kubernetes 1.24
+* Deprecated `injector.externalVaultAddr`. Added `global.externalVaultAddr`, which applies to both the Injector and the CSI Provider.
+* CSI Provider pods now set the `VAULT_ADDR` environment variable to either the internal Vault service or the configured external address.
 
 ## 0.20.1 (May 25th, 2022)
 CHANGES:

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -122,7 +122,7 @@ template logic.
 */}}
 {{- define "vault.mode" -}}
   {{- template "vault.serverEnabled" . -}}
-  {{- if .Values.injector.externalVaultAddr -}}
+  {{- if or (.Values.injector.externalVaultAddr) (.Values.global.externalVaultAddr) -}}
     {{- $_ := set . "mode" "external" -}}
   {{- else if not .serverEnabled -}}
     {{- $_ := set . "mode" "external" -}}

--- a/templates/csi-daemonset.yaml
+++ b/templates/csi-daemonset.yaml
@@ -50,6 +50,13 @@ spec:
             {{- if .Values.csi.extraArgs }}
               {{- toYaml .Values.csi.extraArgs | nindent 12 }}
             {{- end }}
+          env:
+            - name: VAULT_ADDR
+            {{- if .Values.global.externalVaultAddr }}
+              value: "{{ .Values.global.externalVaultAddr }}"
+            {{- else }}
+              value: {{ include "vault.scheme" . }}://{{ template "vault.fullname" . }}.{{ .Release.Namespace }}.svc:{{ .Values.server.service.port }}
+            {{- end }}
           volumeMounts:
             - name: providervol
               mountPath: "/provider"

--- a/templates/injector-deployment.yaml
+++ b/templates/injector-deployment.yaml
@@ -60,7 +60,9 @@ spec:
             - name: AGENT_INJECT_LOG_LEVEL
               value: {{ .Values.injector.logLevel | default "info" }}
             - name: AGENT_INJECT_VAULT_ADDR
-            {{- if .Values.injector.externalVaultAddr }}
+            {{- if .Values.global.externalVaultAddr }}
+              value: "{{ .Values.global.externalVaultAddr }}"
+            {{- else if .Values.injector.externalVaultAddr }}
               value: "{{ .Values.injector.externalVaultAddr }}"
             {{- else }}
               value: {{ include "vault.scheme" . }}://{{ template "vault.fullname" . }}.{{ .Release.Namespace }}.svc:{{ .Values.server.service.port }}

--- a/values.schema.json
+++ b/values.schema.json
@@ -185,6 +185,9 @@
                 },
                 "tlsDisable": {
                     "type": "boolean"
+                },
+                "externalVaultAddr": {
+                    "type": "string"
                 }
             }
         },

--- a/values.yaml
+++ b/values.yaml
@@ -953,4 +953,6 @@ csi:
   debug: false
 
   # Pass arbitrary additional arguments to vault-csi-provider.
+  # See https://www.vaultproject.io/docs/platform/k8s/csi/configurations#command-line-arguments
+  # for the available command line flags.
   extraArgs: []

--- a/values.yaml
+++ b/values.yaml
@@ -4,15 +4,23 @@ global:
   # enabled is the master enabled switch. Setting this to true or false
   # will enable or disable all the components within this chart by default.
   enabled: true
+
   # Image pull secret to use for registry authentication.
   # Alternatively, the value may be specified as an array of strings.
   imagePullSecrets: []
   # imagePullSecrets:
   #   - name: image-pull-secret
+
   # TLS for end-to-end encrypted transport
   tlsDisable: true
+
+  # External vault server address for the injector and CSI provider to use.
+  # Setting this will disable deployment of a vault server.
+  externalVaultAddr: ""
+
   # If deploying to OpenShift
   openshift: false
+
   # Create PodSecurityPolicy for pods
   psp:
     enable: false
@@ -43,8 +51,7 @@ injector:
   metrics:
     enabled: false
 
-  # External vault server address for the injector to use. Setting this will
-  # disable deployment of a vault server along with the injector.
+  # Deprecated: Please use global.externalVaultAddr instead.
   externalVaultAddr: ""
 
   # image sets the repo and tag of the vault-k8s image to use for the injector.


### PR DESCRIPTION
Makes the setting of Vault address for CSI more consistent with the injector.

This won't have any effect until we update the CSI Provider `-vault-addr` flag to have an empty default, as flags take precedence over environment variables: https://github.com/hashicorp/vault-csi-provider/pull/160. Note this also means users can continue to set the `-vault-addr` flag via `csi.extraArgs` without being affected by this change.