### PR TITLE
feat: support policy/v1 on injector-psp for 1.21+

### DIFF
--- a/templates/injector-psp.yaml
+++ b/templates/injector-psp.yaml
@@ -1,7 +1,7 @@
 {{- template "vault.injectorEnabled" . -}}
 {{- if .injectorEnabled -}}
 {{- if eq (.Values.global.psp.enable | toString) "true" }}
-apiVersion: policy/v1beta1
+apiVersion: {{ ge .Capabilities.KubeVersion.Minor "21" | ternary "policy/v1" "policy/v1beta1" }}
 kind: PodSecurityPolicy
 metadata:
   name: {{ template "vault.fullname" . }}-agent-injector


### PR DESCRIPTION
With Kubernetes v1.21 we should be using `policy/v1`. You are already doing this [here](https://github.com/hashicorp/vault-helm/blob/main/templates/injector-disruptionbudget.yaml#L2) for `injector-disruptionbudget`.