### PR TITLE
Add Vault Agent sidecar to CSI Provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Features:
 * server: New `extraPorts` option for adding ports to the Vault server statefulset [GH-841](https://github.com/hashicorp/vault-helm/pull/841)
 * server: Add configurable Port Number in readinessProbe and livenessProbe for the server-statefulset [GH-831](https://github.com/hashicorp/vault-helm/pull/831)
 * injector: Make livenessProbe and readinessProbe configurable and add configurable startupProbe [GH-852](https://github.com/hashicorp/vault-helm/pull/852)
+* csi: Add an Agent sidecar to Vault CSI Provider pods to provide lease caching and renewals [GH-749](https://github.com/hashicorp/vault-helm/pull/749)
 
 ## 0.23.0 (November 28th, 2022)
 

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -677,6 +677,16 @@ Sets the container resources if the user has set any.
 {{- end -}}
 
 {{/*
+Sets the container resources for CSI's Agent sidecar if the user has set any.
+*/}}
+{{- define "csi.agent.resources" -}}
+  {{- if .Values.csi.agent.resources -}}
+          resources:
+{{ toYaml .Values.csi.agent.resources | indent 12}}
+  {{ end }}
+{{- end -}}
+
+{{/*
 Sets extra CSI daemonset annotations
 */}}
 {{- define "csi.daemonSet.annotations" -}}

--- a/templates/csi-agent-configmap.yaml
+++ b/templates/csi-agent-configmap.yaml
@@ -3,7 +3,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ template "vault.fullname" . }}-csi-agent-config
+  name: {{ template "vault.fullname" . }}-csi-provider-agent-config
   namespace: {{ .Release.Namespace }}
   labels:
     helm.sh/chart: {{ include "vault.chart" . }}

--- a/templates/csi-agent-configmap.yaml
+++ b/templates/csi-agent-configmap.yaml
@@ -1,0 +1,30 @@
+{{- template "vault.csiEnabled" . -}}
+{{- if and (.csiEnabled) (eq (.Values.csi.agent.enabled | toString) "true") -}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "vault.fullname" . }}-csi-agent-config
+  namespace: {{ .Release.Namespace }}
+  labels:
+    helm.sh/chart: {{ include "vault.chart" . }}
+    app.kubernetes.io/name: {{ include "vault.name" . }}-csi-provider
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+data:
+  config.hcl: |
+    vault {
+        {{- if .Values.global.externalVaultAddr }}
+        "address" = "{{ .Values.global.externalVaultAddr }}"
+        {{- else }}
+        "address" = "{{ include "vault.scheme" . }}://{{ template "vault.fullname" . }}.{{ .Release.Namespace }}.svc:{{ .Values.server.service.port }}"
+        {{- end }}
+    }
+
+    cache {}
+
+    listener "tcp" {
+        address = "127.0.0.1:8200"
+        tls_disable = true
+        # TODO: Add TLS for localhost communication
+    }
+{{- end }}

--- a/templates/csi-agent-configmap.yaml
+++ b/templates/csi-agent-configmap.yaml
@@ -22,9 +22,8 @@ data:
 
     cache {}
 
-    listener "tcp" {
-        address = "127.0.0.1:8200"
+    listener "unix" {
+        address = "/var/run/vault/agent.sock"
         tls_disable = true
-        # TODO: Add TLS for localhost communication
     }
 {{- end }}

--- a/templates/csi-daemonset.yaml
+++ b/templates/csi-daemonset.yaml
@@ -48,11 +48,14 @@ spec:
             - --endpoint=/provider/vault.sock
             - --debug={{ .Values.csi.debug }}
             {{- if .Values.csi.extraArgs }}
-              {{- toYaml .Values.csi.extraArgs | nindent 12 }}
+            {{- toYaml .Values.csi.extraArgs | nindent 12 }}
             {{- end }}
           env:
             - name: VAULT_ADDR
-            {{- if .Values.global.externalVaultAddr }}
+            {{- if eq (.Values.csi.agent.enabled | toString) "true" }}
+              value: "http://127.0.0.1:8200"
+              # TODO: Add TLS for localhost
+            {{- else if .Values.global.externalVaultAddr }}
               value: "{{ .Values.global.externalVaultAddr }}"
             {{- else }}
               value: {{ include "vault.scheme" . }}://{{ template "vault.fullname" . }}.{{ .Release.Namespace }}.svc:{{ .Values.server.service.port }}
@@ -84,6 +87,41 @@ spec:
             periodSeconds: {{ .Values.csi.readinessProbe.periodSeconds }}
             successThreshold: {{ .Values.csi.readinessProbe.successThreshold }}
             timeoutSeconds: {{ .Values.csi.readinessProbe.timeoutSeconds }}
+        {{- if eq (.Values.csi.agent.enabled | toString) "true" }}
+        - name: vault-agent
+          image: hashicorp/vault:1.10.3
+          imagePullPolicy: IfNotPresent
+          {{ template "csi.agent.resources" . }}
+          command:
+            - vault
+          args:
+            - agent
+            - -config=/etc/vault/config.hcl
+            {{- if .Values.csi.agent.extraArgs }}
+            {{- toYaml .Values.csi.agent.extraArgs | nindent 12 }}
+            {{- end }}
+          ports:
+            - containerPort: 8200
+          env:
+            - name: VAULT_LOG_LEVEL
+              value: "{{ .Values.csi.agent.logLevel }}"
+            - name: VAULT_LOG_FORMAT
+              value: "{{ .Values.csi.agent.logFormat }}"
+          securityContext:
+            runAsNonRoot: true
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            runAsUser: 100
+            runAsGroup: 1000
+          volumeMounts:
+            - name: agent-config
+              mountPath: /etc/vault/config.hcl
+              subPath: config.hcl
+              readOnly: true
+            {{- if .Values.csi.volumeMounts }}
+            {{- toYaml .Values.csi.volumeMounts | nindent 12 }}
+            {{- end }}
+        {{- end }}
       volumes:
         - name: providervol
           hostPath:
@@ -91,8 +129,13 @@ spec:
         - name: mountpoint-dir
           hostPath:
             path: {{ .Values.csi.daemonSet.kubeletRootDir }}/pods
-       {{- if .Values.csi.volumes }}
-         {{- toYaml .Values.csi.volumes | nindent 8}}
-       {{- end }}
+        {{- if eq (.Values.csi.agent.enabled | toString) "true" }}
+        - name: agent-config
+          configMap:
+            name: {{ template "vault.fullname" . }}-csi-agent-config
+        {{- end }}
+        {{- if .Values.csi.volumes }}
+        {{- toYaml .Values.csi.volumes | nindent 8}}
+        {{- end }}
       {{- include "imagePullSecrets" . | nindent 6 }}
 {{- end }}

--- a/templates/csi-daemonset.yaml
+++ b/templates/csi-daemonset.yaml
@@ -136,7 +136,7 @@ spec:
         {{- if eq (.Values.csi.agent.enabled | toString) "true" }}
         - name: agent-config
           configMap:
-            name: {{ template "vault.fullname" . }}-csi-agent-config
+            name: {{ template "vault.fullname" . }}-csi-provider-agent-config
         - name: agent-unix-socket
           emptyDir:
             medium: Memory

--- a/templates/csi-daemonset.yaml
+++ b/templates/csi-daemonset.yaml
@@ -60,8 +60,7 @@ spec:
           env:
             - name: VAULT_ADDR
             {{- if eq (.Values.csi.agent.enabled | toString) "true" }}
-              value: "http://127.0.0.1:8200"
-              # TODO: Add TLS for localhost
+              value: "unix:///var/run/vault/agent.sock"
             {{- else if .Values.global.externalVaultAddr }}
               value: "{{ .Values.global.externalVaultAddr }}"
             {{- else }}
@@ -70,9 +69,8 @@ spec:
           volumeMounts:
             - name: providervol
               mountPath: "/provider"
-            - name: mountpoint-dir
-              mountPath: {{ .Values.csi.daemonSet.kubeletRootDir }}/pods
-              mountPropagation: HostToContainer
+            - name: agent-unix-socket
+              mountPath: /var/run/vault
             {{- if .Values.csi.volumeMounts }}
               {{- toYaml .Values.csi.volumeMounts | nindent 12}}
             {{- end }}
@@ -95,8 +93,8 @@ spec:
             successThreshold: {{ .Values.csi.readinessProbe.successThreshold }}
             timeoutSeconds: {{ .Values.csi.readinessProbe.timeoutSeconds }}
         {{- if eq (.Values.csi.agent.enabled | toString) "true" }}
-        - name: vault-agent
-          image: hashicorp/vault:1.10.3
+        - name: {{ include "vault.name" . }}-agent
+          image: hashicorp/vault:1.13.1
           imagePullPolicy: IfNotPresent
           {{ template "csi.agent.resources" . }}
           command:
@@ -125,6 +123,8 @@ spec:
               mountPath: /etc/vault/config.hcl
               subPath: config.hcl
               readOnly: true
+            - name: agent-unix-socket
+              mountPath: /var/run/vault
             {{- if .Values.csi.volumeMounts }}
             {{- toYaml .Values.csi.volumeMounts | nindent 12 }}
             {{- end }}
@@ -133,13 +133,13 @@ spec:
         - name: providervol
           hostPath:
             path: {{ .Values.csi.daemonSet.providersDir }}
-        - name: mountpoint-dir
-          hostPath:
-            path: {{ .Values.csi.daemonSet.kubeletRootDir }}/pods
         {{- if eq (.Values.csi.agent.enabled | toString) "true" }}
         - name: agent-config
           configMap:
             name: {{ template "vault.fullname" . }}-csi-agent-config
+        - name: agent-unix-socket
+          emptyDir:
+            medium: Memory
         {{- end }}
         {{- if .Values.csi.volumes }}
         {{- toYaml .Values.csi.volumes | nindent 8}}

--- a/templates/csi-daemonset.yaml
+++ b/templates/csi-daemonset.yaml
@@ -69,8 +69,10 @@ spec:
           volumeMounts:
             - name: providervol
               mountPath: "/provider"
+            {{- if eq (.Values.csi.agent.enabled | toString) "true" }}
             - name: agent-unix-socket
               mountPath: /var/run/vault
+            {{- end }}
             {{- if .Values.csi.volumeMounts }}
               {{- toYaml .Values.csi.volumeMounts | nindent 12}}
             {{- end }}
@@ -94,8 +96,8 @@ spec:
             timeoutSeconds: {{ .Values.csi.readinessProbe.timeoutSeconds }}
         {{- if eq (.Values.csi.agent.enabled | toString) "true" }}
         - name: {{ include "vault.name" . }}-agent
-          image: hashicorp/vault:1.13.1
-          imagePullPolicy: IfNotPresent
+          image: "{{ .Values.csi.agent.image.repository }}:{{ .Values.csi.agent.image.tag }}"
+          imagePullPolicy: {{ .Values.csi.agent.image.pullPolicy }}
           {{ template "csi.agent.resources" . }}
           command:
             - vault

--- a/test/acceptance/csi-test/vault-kv-secretproviderclass.yaml
+++ b/test/acceptance/csi-test/vault-kv-secretproviderclass.yaml
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: MPL-2.0
 
 # The "Hello World" Vault SecretProviderClass
-apiVersion: secrets-store.csi.x-k8s.io/v1alpha1
+apiVersion: secrets-store.csi.x-k8s.io/v1
 kind: SecretProviderClass
 metadata:
   name: vault-kv
@@ -10,7 +10,6 @@ spec:
   provider: vault
   parameters:
     roleName: "kv-role"
-    vaultAddress: http://vault:8200
     objects: |
       - objectName: "bar"
         secretPath: "secret/data/kv1"

--- a/test/acceptance/csi.bats
+++ b/test/acceptance/csi.bats
@@ -12,7 +12,9 @@ load _helpers
   # Configure it to pass in a JWT for the provider to use, and rotate secrets rapidly
   # so we can see Agent's cache working.
   CSI_DRIVER_VERSION=1.3.2
-  helm install secrets-store-csi-driver https://kubernetes-sigs.github.io/secrets-store-csi-driver/charts/secrets-store-csi-driver-${CSI_DRIVER_VERSION}.tgz?raw=true \
+  helm install secrets-store-csi-driver secrets-store-csi-driver \
+    --repo https://kubernetes-sigs.github.io/secrets-store-csi-driver/charts \
+    --version=$(CSI_DRIVER_VERSION) \
     --wait --timeout=5m \
     --namespace=acceptance \
     --set linux.image.pullPolicy="IfNotPresent" \

--- a/test/acceptance/csi.bats
+++ b/test/acceptance/csi.bats
@@ -9,19 +9,26 @@ load _helpers
   kubectl create namespace acceptance
 
   # Install Secrets Store CSI driver
-  CSI_DRIVER_VERSION=1.0.0
+  # Configure it to pass in a JWT for the provider to use, and rotate secrets rapidly
+  # so we can see Agent's cache working.
+  CSI_DRIVER_VERSION=1.3.2
   helm install secrets-store-csi-driver https://kubernetes-sigs.github.io/secrets-store-csi-driver/charts/secrets-store-csi-driver-${CSI_DRIVER_VERSION}.tgz?raw=true \
     --wait --timeout=5m \
     --namespace=acceptance \
     --set linux.image.pullPolicy="IfNotPresent" \
-    --set syncSecret.enabled=true
+    --set tokenRequests[0].audience="vault" \
+    --set enableSecretRotation=true \
+    --set rotationPollInterval=5s
   # Install Vault and Vault provider
   helm install vault \
     --wait --timeout=5m \
     --namespace=acceptance \
     --set="server.dev.enabled=true" \
     --set="csi.enabled=true" \
-    --set="injector.enabled=false" .
+    --set="csi.debug=true" \
+    --set="csi.agent.logLevel=debug" \
+    --set="injector.enabled=false" \
+    .
   kubectl --namespace=acceptance wait --for=condition=Ready --timeout=5m pod -l app.kubernetes.io/name=vault
   kubectl --namespace=acceptance wait --for=condition=Ready --timeout=5m pod -l app.kubernetes.io/name=vault-csi-provider
 
@@ -29,10 +36,7 @@ load _helpers
   cat ./test/acceptance/csi-test/vault-policy.hcl | kubectl --namespace=acceptance exec -i vault-0 -- vault policy write kv-policy -
   kubectl --namespace=acceptance exec vault-0 -- vault auth enable kubernetes
   kubectl --namespace=acceptance exec vault-0 -- sh -c 'vault write auth/kubernetes/config \
-    token_reviewer_jwt="$(cat /var/run/secrets/kubernetes.io/serviceaccount/token)" \
-    kubernetes_host="https://$KUBERNETES_PORT_443_TCP_ADDR:443" \
-    kubernetes_ca_cert=@/var/run/secrets/kubernetes.io/serviceaccount/ca.crt \
-    disable_iss_validation=true'
+    kubernetes_host="https://$KUBERNETES_PORT_443_TCP_ADDR:443"'
   kubectl --namespace=acceptance exec vault-0 -- vault write auth/kubernetes/role/kv-role \
     bound_service_account_names=nginx \
     bound_service_account_namespaces=acceptance \
@@ -46,6 +50,22 @@ load _helpers
 
   result=$(kubectl --namespace=acceptance exec nginx -- cat /mnt/secrets-store/bar)
   [[ "$result" == "hello1" ]]
+
+  for i in $(seq 10); do
+    sleep 2
+    if [ "$(kubectl --namespace=acceptance logs --tail=-1 -l "app.kubernetes.io/name=vault-csi-provider" -c vault-agent | grep "returning cached response: path=/v1/auth/kubernetes/login")" ]; then
+        echo "Agent returned a cached login response"
+        return
+    fi
+
+    echo "Waiting for a cached response from Agent..."
+  done
+
+  # Print the logs and fail the test
+  echo "Failed to find a log for a cached Agent response"
+  kubectl --namespace=acceptance logs --tail=-1 -l "app.kubernetes.io/name=vault-csi-provider" -c vault-agent
+  kubectl --namespace=acceptance logs --tail=-1 -l "app.kubernetes.io/name=vault-csi-provider" -c vault-csi-provider
+  exit 1
 }
 
 # Clean up

--- a/test/unit/csi-agent-configmap.bats
+++ b/test/unit/csi-agent-configmap.bats
@@ -11,16 +11,6 @@ load _helpers
   [ "${actual}" = "false" ]
 }
 
-@test "csi/Agent-ConfigMap: enabled with csi.enabled" {
-  cd `chart_dir`
-  local actual=$(helm template \
-      --show-only templates/csi-agent-configmap.yaml  \
-      --set 'csi.enabled=true' \
-      . | tee /dev/stderr |
-      yq 'length > 0' | tee /dev/stderr)
-  [ "${actual}" = "true" ]
-}
-
 @test "csi/Agent-ConfigMap: name" {
   cd `chart_dir`
   local actual=$(helm template \

--- a/test/unit/csi-agent-configmap.bats
+++ b/test/unit/csi-agent-configmap.bats
@@ -1,0 +1,55 @@
+#!/usr/bin/env bats
+
+load _helpers
+
+@test "csi/Agent-ConfigMap: disabled by default" {
+  cd `chart_dir`
+  local actual=$( (helm template \
+      --show-only templates/csi-agent-configmap.yaml  \
+      . || echo "---") | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+}
+
+@test "csi/Agent-ConfigMap: enabled with csi.enabled" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/csi-agent-configmap.yaml  \
+      --set 'csi.enabled=true' \
+      . | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}
+
+@test "csi/Agent-ConfigMap: name" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/csi-agent-configmap.yaml \
+      --set "csi.enabled=true" \
+      . | tee /dev/stderr |
+      yq -r '.metadata.name' | tee /dev/stderr)
+  [ "${actual}" = "release-name-vault-csi-provider-agent-config" ]
+}
+
+@test "csi/Agent-ConfigMap: Vault addr not affected by injector setting" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/csi-agent-configmap.yaml \
+      --set "csi.enabled=true" \
+      --release-name not-external-test \
+      --set 'injector.externalVaultAddr=http://vault-outside' \
+      . | tee /dev/stderr |
+      yq -r '.data["config.hcl"]' | tee /dev/stderr)
+  echo "${actual}" | grep "http://not-external-test-vault.default.svc:8200"
+}
+
+@test "csi/Agent-ConfigMap: Vault addr correctly set for externalVaultAddr" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/csi-agent-configmap.yaml \
+      --set "csi.enabled=true" \
+      --set 'global.externalVaultAddr=http://vault-outside' \
+      . | tee /dev/stderr |
+      yq -r '.data["config.hcl"]' | tee /dev/stderr)
+  echo "${actual}" | grep "http://vault-outside"
+}

--- a/test/unit/csi-daemonset.bats
+++ b/test/unit/csi-daemonset.bats
@@ -379,21 +379,6 @@ load _helpers
   [ "${actual}" = "/etc/kubernetes/secrets-store-csi-providers" ]
 }
 
-@test "csi/daemonset: csi kubeletRootDir default" {
-  cd `chart_dir`
-
-  # Test that it defines it
-  local object=$(helm template \
-      --show-only templates/csi-daemonset.yaml  \
-      --set 'csi.enabled=true' \
-      . | tee /dev/stderr |
-      yq -r '.spec.template.spec.volumes[] | select(.name == "mountpoint-dir")' | tee /dev/stderr)
-
-  local actual=$(echo $object |
-      yq -r '.hostPath.path' | tee /dev/stderr)
-  [ "${actual}" = "/var/lib/kubelet/pods" ]
-}
-
 @test "csi/daemonset: csi providersDir override " {
   cd `chart_dir`
 
@@ -408,22 +393,6 @@ load _helpers
   local actual=$(echo $object |
       yq -r '.hostPath.path' | tee /dev/stderr)
   [ "${actual}" = "/alt/csi-prov-dir" ]
-}
-
-@test "csi/daemonset: csi kubeletRootDir override" {
-  cd `chart_dir`
-
-  # Test that it defines it
-  local object=$(helm template \
-      --show-only templates/csi-daemonset.yaml  \
-      --set 'csi.enabled=true' \
-      --set 'csi.daemonSet.kubeletRootDir=/alt/kubelet-root' \
-      . | tee /dev/stderr |
-      yq -r '.spec.template.spec.volumes[] | select(.name == "mountpoint-dir")' | tee /dev/stderr)
-
-  local actual=$(echo $object |
-      yq -r '.hostPath.path' | tee /dev/stderr)
-  [ "${actual}" = "/alt/kubelet-root/pods" ]
 }
 
 #--------------------------------------------------------------------
@@ -569,6 +538,7 @@ load _helpers
   local object=$(helm template \
       --show-only templates/csi-daemonset.yaml \
       --set 'csi.enabled=true' \
+      --set 'csi.agent.enabled=false' \
       --release-name not-external-test \
       --set 'injector.externalVaultAddr=http://vault-outside' \
       . | tee /dev/stderr |
@@ -584,6 +554,7 @@ load _helpers
   local object=$(helm template \
       --show-only templates/csi-daemonset.yaml \
       --set 'csi.enabled=true' \
+      --set 'csi.agent.enabled=false' \
       --set 'global.externalVaultAddr=http://vault-outside' \
       . | tee /dev/stderr |
       yq -r '.spec.template.spec.containers[0].env' | tee /dev/stderr)

--- a/values.schema.json
+++ b/values.schema.json
@@ -5,6 +5,26 @@
         "csi": {
             "type": "object",
             "properties": {
+                "agent": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean"
+                        },
+                        "extraArgs": {
+                            "type": "array"
+                        },
+                        "logFormat": {
+                            "type": "string"
+                        },
+                        "logLevel": {
+                            "type": "string"
+                        },
+                        "resources": {
+                            "type": "object"
+                        }
+                    }
+                },
                 "daemonSet": {
                     "type": "object",
                     "properties": {

--- a/values.schema.json
+++ b/values.schema.json
@@ -14,6 +14,20 @@
                         "extraArgs": {
                             "type": "array"
                         },
+                        "image": {
+                            "type": "object",
+                            "properties": {
+                                "pullPolicy": {
+                                    "type": "string"
+                                },
+                                "repository": {
+                                    "type": "string"
+                                },
+                                "tag": {
+                                    "type": "string"
+                                }
+                            }
+                        },
                         "logFormat": {
                             "type": "string"
                         },

--- a/values.yaml
+++ b/values.yaml
@@ -1065,6 +1065,11 @@ csi:
     enabled: true
     extraArgs: []
 
+    image:
+      repository: "hashicorp/vault"
+      tag: "1.13.1"
+      pullPolicy: IfNotPresent
+
     logFormat: standard
     logLevel: info
 

--- a/values.yaml
+++ b/values.yaml
@@ -909,7 +909,21 @@ csi:
     # This should be a YAML map of the labels to apply to the csi provider pod
     extraLabels: {}
 
+  agent:
+    enabled: true
+    extraArgs: []
 
+    logLevel: info
+    logFormat: normal
+
+    resources: {}
+    # resources:
+    #   requests:
+    #     memory: 256Mi
+    #     cpu: 250m
+    #   limits:
+    #     memory: 256Mi
+    #     cpu: 250m
 
   # Priority class for csi pods
   priorityClassName: ""

--- a/values.yaml
+++ b/values.yaml
@@ -993,7 +993,7 @@ csi:
 
   image:
     repository: "hashicorp/vault-csi-provider"
-    tag: "1.2.1"
+    tag: "1.3.0"
     pullPolicy: IfNotPresent
 
   # volumes is a list of volumes made available to all containers. These are rendered
@@ -1062,7 +1062,7 @@ csi:
     extraArgs: []
 
     logLevel: info
-    logFormat: normal
+    logFormat: standard
 
     resources: {}
     # resources:

--- a/values.yaml
+++ b/values.yaml
@@ -1061,8 +1061,8 @@ csi:
     enabled: true
     extraArgs: []
 
-    logLevel: info
     logFormat: standard
+    logLevel: info
 
     resources: {}
     # resources:


### PR DESCRIPTION
Adds Agent as a sidecar for the CSI Provider to:

* Cache k8s auth login leases
* Cache secret leases
* Automatically renew renewable leases in the background

It depends on https://github.com/hashicorp/vault-csi-provider/pull/163 to work properly, because otherwise the initial Kubernetes JWT used to log in will be different every time, so we'll never get cache hits.