### PR TITLE
Feat/adding container security context

### DIFF
--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -474,16 +474,14 @@ Sets extra injector service annotations
 securityContext for the injector pod level.
 */}}
 {{- define "injector.securityContext.pod" -}}
-  {{- if not .Values.global.openshift }}
-    {{- if or (.Values.injector.uid) (.Values.injector.gid) }}
+  {{- if or (.Values.injector.uid) (.Values.injector.gid) }}
       securityContext:
         runAsNonRoot: true
         runAsGroup: {{ .Values.injector.gid | default 1000 }}
         runAsUser: {{ .Values.injector.uid | default 100 }}
-    {{- else }}
+  {{- else }}
       securityContext:
         {{- toYaml .Values.injector.securityContext.pod | nindent 8 }}
-    {{- end }}
   {{- end }}
 {{- end -}}
 

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -479,7 +479,7 @@ securityContext for the injector pod level.
         runAsNonRoot: true
         runAsGroup: {{ .Values.injector.gid | default 1000 }}
         runAsUser: {{ .Values.injector.uid | default 100 }}
-  {{- else }}
+  {{- else if .Values.injector.securityContext.pod }}
       securityContext:
         {{- toYaml .Values.injector.securityContext.pod | nindent 8 }}
   {{- end }}

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -471,6 +471,35 @@ Sets extra injector service annotations
 {{- end -}}
 
 {{/*
+securityContext for the injector pod level.
+*/}}
+{{- define "injector.securityContext.pod" -}}
+{{- if or (.Values.injector.uid) (.Values.injector.gid) }}
+{{- if not .Values.global.openshift }}
+      securityContext:
+        runAsNonRoot: true
+        runAsGroup: {{ .Values.injector.gid | default 1000 }}
+        runAsUser: {{ .Values.injector.uid | default 100 }}
+{{- else }}
+      securityContext:
+        {{- toYaml .Values.injector.securityContext.pod | nindent 8 }}
+{{- end }}
+{{- end }}
+{{- end -}}
+
+{{/*
+securityContext for the injector container level.
+*/}}
+{{- define "injector.securityContext.container" -}}
+{{- if .Values.injector.securityContext.container}}
+{{- if not .Values.global.openshift }}
+          securityContext:
+            {{- toYaml .Values.injector.securityContext.container | nindent 10 }}
+{{- end }}
+{{- end }}
+{{- end -}}
+
+{{/*
 Sets extra injector webhook annotations
 */}}
 {{- define "injector.webhookAnnotations" -}}

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -489,11 +489,9 @@ securityContext for the injector pod level.
 securityContext for the injector container level.
 */}}
 {{- define "injector.securityContext.container" -}}
-  {{- if not .Values.global.openshift }}
-    {{- if .Values.injector.securityContext.container}}
+  {{- if .Values.injector.securityContext.container}}
           securityContext:
             {{- toYaml .Values.injector.securityContext.container | nindent 12 }}
-    {{- end }}
   {{- end }}
 {{- end -}} 
 

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -494,7 +494,7 @@ securityContext for the injector container level.
 {{- if .Values.injector.securityContext.container}}
 {{- if not .Values.global.openshift }}
           securityContext:
-            {{- toYaml .Values.injector.securityContext.container | nindent 10 }}
+            {{- toYaml .Values.injector.securityContext.container | nindent 12 }}
 {{- end }}
 {{- end }}
 {{- end -}}

--- a/templates/injector-deployment.yaml
+++ b/templates/injector-deployment.yaml
@@ -40,13 +40,7 @@ spec:
       serviceAccountName: "{{ template "vault.fullname" . }}-agent-injector"
       {{- if not .Values.global.openshift }}
       hostNetwork: {{ .Values.injector.hostNetwork }}
-      securityContext:
-        runAsNonRoot: true
-        runAsGroup: {{ .Values.injector.gid | default 1000 }}
-        runAsUser: {{ .Values.injector.uid | default 100 }}
-        fsGroup: {{ .Values.injector.uid | default 100 }}
-        supplementalGroups:
-          - {{ .Values.injector.uid | default 100 }}
+      securityContext: {{ .Values.podSecurityContext }}
       {{- end }}
       containers:
         - name: sidecar-injector
@@ -54,11 +48,7 @@ spec:
           image: "{{ .Values.injector.image.repository }}:{{ .Values.injector.image.tag }}"
           imagePullPolicy: "{{ .Values.injector.image.pullPolicy }}"
           {{- if not .Values.global.openshift }}
-          securityContext:
-            allowPrivilegeEscalation: false
-            capabilities:
-              drop:
-                - ALL
+          securityContext: {{ .Values.securityContext }}
           {{- end }}
           env:
             - name: AGENT_INJECT_LISTEN

--- a/templates/injector-deployment.yaml
+++ b/templates/injector-deployment.yaml
@@ -40,7 +40,13 @@ spec:
       serviceAccountName: "{{ template "vault.fullname" . }}-agent-injector"
       {{- if not .Values.global.openshift }}
       hostNetwork: {{ .Values.injector.hostNetwork }}
-      securityContext: {{ .Values.podSecurityContext }}
+      securityContext:
+        runAsNonRoot: true
+        runAsGroup: {{ .Values.injector.gid | default 1000 }}
+        runAsUser: {{ .Values.injector.uid | default 100 }}
+        fsGroup: {{ .Values.injector.uid | default 100 }}
+        supplementalGroups:
+          - {{ .Values.injector.uid | default 100 }}
       {{- end }}
       containers:
         - name: sidecar-injector
@@ -48,7 +54,11 @@ spec:
           image: "{{ .Values.injector.image.repository }}:{{ .Values.injector.image.tag }}"
           imagePullPolicy: "{{ .Values.injector.image.pullPolicy }}"
           {{- if not .Values.global.openshift }}
-          securityContext: {{ .Values.securityContext }}
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
           {{- end }}
           env:
             - name: AGENT_INJECT_LISTEN

--- a/templates/injector-deployment.yaml
+++ b/templates/injector-deployment.yaml
@@ -44,6 +44,9 @@ spec:
         runAsNonRoot: true
         runAsGroup: {{ .Values.injector.gid | default 1000 }}
         runAsUser: {{ .Values.injector.uid | default 100 }}
+        fsGroup: {{ .Values.injector.uid | default 100 }}
+        supplementalGroups:
+          - {{ .Values.injector.uid | default 100 }}
       {{- end }}
       containers:
         - name: sidecar-injector
@@ -53,6 +56,9 @@ spec:
           {{- if not .Values.global.openshift }}
           securityContext:
             allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
           {{- end }}
           env:
             - name: AGENT_INJECT_LISTEN

--- a/templates/injector-deployment.yaml
+++ b/templates/injector-deployment.yaml
@@ -1,6 +1,4 @@
 {{- template "vault.injectorEnabled" . -}}
-{{- template "injector.securityContext.pod" . -}}
-{{- template "injector.securityContext.container" . -}}
 {{- if .injectorEnabled -}}
 # Deployment for the injector
 apiVersion: apps/v1

--- a/templates/injector-deployment.yaml
+++ b/templates/injector-deployment.yaml
@@ -1,4 +1,6 @@
 {{- template "vault.injectorEnabled" . -}}
+{{- template "injector.securityContext.pod" . -}}
+{{- template "injector.securityContext.container" . -}}
 {{- if .injectorEnabled -}}
 # Deployment for the injector
 apiVersion: apps/v1
@@ -40,35 +42,12 @@ spec:
       serviceAccountName: "{{ template "vault.fullname" . }}-agent-injector"
       {{- if not .Values.global.openshift }}
       hostNetwork: {{ .Values.injector.hostNetwork }}
-      securityContext:
-        runAsNonRoot: true
-        runAsGroup: {{ .Values.injector.gid | default 1000 }}
-        runAsUser: {{ .Values.injector.uid | default 100 }}
-        {{- if  .Values.injector.fsGroup -}}
-        fsGroup: {{ .Values.injector.fsGroup }}
-        {{- end }}
-        {{- if  .Values.injector.supplementalGroups -}}
-        supplementalGroups: {{ .Values.injector.supplementalGroups }}
-        {{- end }}
       {{- end }}
       containers:
         - name: sidecar-injector
           {{ template "injector.resources" . }}
           image: "{{ .Values.injector.image.repository }}:{{ .Values.injector.image.tag }}"
           imagePullPolicy: "{{ .Values.injector.image.pullPolicy }}"
-          {{- if not .Values.global.openshift }}
-          securityContext:
-            allowPrivilegeEscalation: false
-            {{- if  .Values.injector.capabilities -}}
-            capabilities: {{ .Values.injector.capabilities }}
-            {{- end }}
-            {{- if  .Values.injector.readOnlyRootFilesystem -}}
-            readOnlyRootFilesystem: {{ .Values.injector.readOnlyRootFilesystem }}
-            {{- end }}
-            {{- if  .Values.injector.privileged -}}
-            privileged: {{ .Values.injector.privileged }}
-            {{- end }}
-          {{- end }}
           env:
             - name: AGENT_INJECT_LISTEN
               value: {{ printf ":%v" .Values.injector.port  }}

--- a/templates/injector-deployment.yaml
+++ b/templates/injector-deployment.yaml
@@ -44,9 +44,6 @@ spec:
         runAsNonRoot: true
         runAsGroup: {{ .Values.injector.gid | default 1000 }}
         runAsUser: {{ .Values.injector.uid | default 100 }}
-        fsGroup: {{ .Values.injector.uid | default 100 }}
-        supplementalGroups:
-          - {{ .Values.injector.uid | default 100 }}
       {{- end }}
       containers:
         - name: sidecar-injector
@@ -56,9 +53,6 @@ spec:
           {{- if not .Values.global.openshift }}
           securityContext:
             allowPrivilegeEscalation: false
-            capabilities:
-              drop:
-                - ALL
           {{- end }}
           env:
             - name: AGENT_INJECT_LISTEN

--- a/templates/injector-deployment.yaml
+++ b/templates/injector-deployment.yaml
@@ -44,6 +44,12 @@ spec:
         runAsNonRoot: true
         runAsGroup: {{ .Values.injector.gid | default 1000 }}
         runAsUser: {{ .Values.injector.uid | default 100 }}
+        {{- if  .Values.injector.fsGroup -}}
+        fsGroup: {{ .Values.injector.fsGroup }}
+        {{- end }}
+        {{- if  .Values.injector.supplementalGroups -}}
+        supplementalGroups: {{ .Values.injector.supplementalGroups }}
+        {{- end }}
       {{- end }}
       containers:
         - name: sidecar-injector
@@ -53,6 +59,15 @@ spec:
           {{- if not .Values.global.openshift }}
           securityContext:
             allowPrivilegeEscalation: false
+            {{- if  .Values.injector.capabilities -}}
+            capabilities: {{ .Values.injector.capabilities }}
+            {{- end }}
+            {{- if  .Values.injector.readOnlyRootFilesystem -}}
+            readOnlyRootFilesystem: {{ .Values.injector.readOnlyRootFilesystem }}
+            {{- end }}
+            {{- if  .Values.injector.privileged -}}
+            privileged: {{ .Values.injector.privileged }}
+            {{- end }}
           {{- end }}
           env:
             - name: AGENT_INJECT_LISTEN

--- a/templates/injector-deployment.yaml
+++ b/templates/injector-deployment.yaml
@@ -40,6 +40,7 @@ spec:
       serviceAccountName: "{{ template "vault.fullname" . }}-agent-injector"
       {{- if not .Values.global.openshift }}
       hostNetwork: {{ .Values.injector.hostNetwork }}
+      {{ template "injector.securityContext.pod" . -}}
       {{- end }}
       containers:
         - name: sidecar-injector

--- a/templates/injector-deployment.yaml
+++ b/templates/injector-deployment.yaml
@@ -48,6 +48,9 @@ spec:
           {{ template "injector.resources" . }}
           image: "{{ .Values.injector.image.repository }}:{{ .Values.injector.image.tag }}"
           imagePullPolicy: "{{ .Values.injector.image.pullPolicy }}"
+          {{- if not .Values.global.openshift }}
+          {{ template "injector.securityContext.container" . -}}
+          {{- end }}
           env:
             - name: AGENT_INJECT_LISTEN
               value: {{ printf ":%v" .Values.injector.port  }}

--- a/test/unit/injector-deployment.bats
+++ b/test/unit/injector-deployment.bats
@@ -380,10 +380,10 @@ load _helpers
   local actual=$(helm template \
       --show-only templates/injector-deployment.yaml  \
       --set 'injector.enabled=true' \
-      --set 'injector.securityContext.runAsNonRoot=true' \
-      --set 'injector.securityContext.runAsGroup=1000' \
-      --set 'injector.securityContext.runAsUser=100' \
-      --set 'injector.securityContext.fsGroup=1000' \
+      --set 'injector.securityContext.pod.runAsNonRoot=true' \
+      --set 'injector.securityContext.pod.runAsGroup=1000' \
+      --set 'injector.securityContext.pod.runAsUser=100' \
+      --set 'injector.securityContext.pod.fsGroup=1000' \
       . | tee /dev/stderr |
       yq -r '.spec.template.spec.securityContext.runAsGroup' | tee /dev/stderr)
   [ "${actual}" = "1000" ]
@@ -391,8 +391,8 @@ load _helpers
   local actual=$(helm template \
       --show-only templates/injector-deployment.yaml  \
       --set 'injector.enabled=true' \
-      --set 'injector.securityContext.runAsNonRoot=true' \
-      --set 'injector.securityContext.runAsGroup=1000' \
+      --set 'injector.securityContext.pod.runAsNonRoot=true' \
+      --set 'injector.securityContext.pod.runAsGroup=1000' \
       . | tee /dev/stderr |
       yq -r '.spec.template.spec.securityContext.runAsNonRoot' | tee /dev/stderr)
   [ "${actual}" = "true" ]
@@ -400,8 +400,8 @@ load _helpers
   local actual=$(helm template \
       --show-only templates/injector-deployment.yaml \
       --set 'injector.enabled=true' \
-      --set 'injector.securityContext.runAsUser=100' \
-      --set 'injector.securityContext.fsGroup=1000' \\
+      --set 'injector.securityContext.pod.runAsUser=100' \
+      --set 'injector.securityContext.pod.fsGroup=1000' \\
       . | tee /dev/stderr |
       yq -r '.spec.template.spec.securityContext.runAsUser' | tee /dev/stderr)
   [ "${actual}" = "100" ]
@@ -409,8 +409,8 @@ load _helpers
   local actual=$(helm template \
       --show-only templates/injector-deployment.yaml \
       --set 'injector.enabled=true' \
-      --set 'injector.securityContext.runAsNonRoot=true' \
-      --set 'injector.securityContext.fsGroup=1000' \
+      --set 'injector.securityContext.pod.runAsNonRoot=true' \
+      --set 'injector.securityContext.pod.fsGroup=1000' \
       . | tee /dev/stderr |
       yq -r '.spec.template.spec.securityContext.fsGroup' | tee /dev/stderr)
   [ "${actual}" = "1000" ]
@@ -430,8 +430,8 @@ load _helpers
   local actual=$(helm template \
       --show-only templates/injector-deployment.yaml  \
       --set 'injector.enabled=true' \
-      --set 'injector.securityContext.containers[0].allowPrivilegeEscalation=false' \
-      --set 'injector.securityContext.containers[0].capabilities.drop=ALL' \
+      --set 'injector.securityContext.container.allowPrivilegeEscalation=false' \
+      --set 'injector.securityContext.container.capabilities.drop=ALL' \
       . | tee /dev/stderr |
       yq -r '.spec.template.spec.containers[0].securityContext.allowPrivilegeEscalation' | tee /dev/stderr)
   [ "${actual}" = "false" ]
@@ -439,7 +439,7 @@ load _helpers
   local actual=$(helm template \
       --show-only templates/injector-deployment.yaml  \
       --set 'injector.enabled=true' \
-      --set 'injector.securityContext.containers[0].capabilities.drop=ALL' \
+      --set 'injector.securityContext.container.capabilities.drop=ALL' \
       . | tee /dev/stderr |
       yq -r '.spec.template.spec.containers[0].securityContext.capabilities.drop' | tee /dev/stderr)
   [ "${actual}" = "ALL" ]

--- a/test/unit/injector-deployment.bats
+++ b/test/unit/injector-deployment.bats
@@ -372,7 +372,19 @@ load _helpers
       --show-only templates/injector-deployment.yaml  \
       . | tee /dev/stderr |
       yq -r '.spec.template.spec.securityContext' | tee /dev/stderr)
-  [ "${actual}" = "null" ]
+  [ "${actual}" != "null" ]
+
+  local value=$(echo $actual | yq -r .fsGroup | tee /dev/stderr)
+  [ "${value}" = "1000" ]
+
+  local value=$(echo $actual | yq -r .runAsGroup | tee /dev/stderr)
+  [ "${value}" = "1000" ]
+
+  local value=$(echo $actual | yq -r .runAsNonRoot | tee /dev/stderr)
+  [ "${value}" = "true" ]
+
+  local value=$(echo $actual | yq -r .runAsUser | tee /dev/stderr)
+  [ "${value}" = "100" ]
 }
 
 @test "injector/deployment: custom pod securityContext" {

--- a/test/unit/injector-deployment.bats
+++ b/test/unit/injector-deployment.bats
@@ -455,6 +455,7 @@ load _helpers
       . | tee /dev/stderr |
       yq -r '.spec.template.spec.containers[0].securityContext.capabilities.drop' | tee /dev/stderr)
   [ "${actual}" = "ALL" ]
+}
 
 #--------------------------------------------------------------------
 # extraEnvironmentVars

--- a/test/unit/injector-deployment.bats
+++ b/test/unit/injector-deployment.bats
@@ -456,6 +456,8 @@ load _helpers
   local value=$(echo $actual | yq -r .allowPrivilegeEscalation | tee /dev/stderr)
   [ "${value}" = "false" ]
 
+  local value=$(echo $actual | yq -r .capabilities.drop[0] | tee /dev/stderr)
+  [ "${value}" = "ALL" ]
 }
 
 @test "injector/deployment: custom container securityContext sidecar-injector" {

--- a/values.yaml
+++ b/values.yaml
@@ -202,6 +202,22 @@ injector:
     certName: tls.crt
     keyName: tls.key
 
+  # Default pod and container security context for vault-injector
+  securityContext:
+    pod:
+      runAsNonRoot: true
+      runAsGroup: 1000
+      runAsUser: 100
+      fsGroup: 100
+      supplementalGroups:
+        - 100
+    container:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+          - ALL
+
+
   resources: {}
   # resources:
   #   requests:

--- a/values.yaml
+++ b/values.yaml
@@ -202,22 +202,6 @@ injector:
     certName: tls.crt
     keyName: tls.key
 
-  # Default pod security context for vault-injector
-  podSecurityContext:
-    runAsNonRoot: true
-    runAsGroup: 1000
-    runAsUser: 100
-    fsGroup: 100
-    supplementalGroups:
-      - 100
-
-  # Default container security context for vault-injector
-  securityContext:
-    allowPrivilegeEscalation: false
-    capabilities:
-      drop:
-        - ALL
-
   resources: {}
   # resources:
   #   requests:

--- a/values.yaml
+++ b/values.yaml
@@ -208,9 +208,7 @@ injector:
       runAsNonRoot: true
       runAsGroup: 1000
       runAsUser: 100
-      fsGroup: 100
-      supplementalGroups:
-        - 100
+      fsGroup: 1000
     container:
       allowPrivilegeEscalation: false
       capabilities:

--- a/values.yaml
+++ b/values.yaml
@@ -202,15 +202,6 @@ injector:
     certName: tls.crt
     keyName: tls.key
 
-  resources: {}
-  # resources:
-  #   requests:
-  #     memory: 256Mi
-  #     cpu: 250m
-  #   limits:
-  #     memory: 256Mi
-  #     cpu: 250m
-
   # Default pod security context for vault-injector
   podSecurityContext:
     runAsNonRoot: true
@@ -226,6 +217,15 @@ injector:
     capabilities:
       drop:
         - ALL
+
+  resources: {}
+  # resources:
+  #   requests:
+  #     memory: 256Mi
+  #     cpu: 250m
+  #   limits:
+  #     memory: 256Mi
+  #     cpu: 250m
 
   # extraEnvironmentVars is a list of extra environment variables to set in the
   # injector deployment.

--- a/values.yaml
+++ b/values.yaml
@@ -215,7 +215,6 @@ injector:
         drop:
           - ALL
 
-
   resources: {}
   # resources:
   #   requests:

--- a/values.yaml
+++ b/values.yaml
@@ -202,6 +202,22 @@ injector:
     certName: tls.crt
     keyName: tls.key
 
+  # Default pod security context for vault-injector
+  podSecurityContext:
+    runAsNonRoot: true
+    runAsGroup: 1000
+    runAsUser: 100
+    fsGroup: 100
+    supplementalGroups:
+      - 100
+
+  # Default container security context for vault-injector
+  securityContext:
+    allowPrivilegeEscalation: false
+    capabilities:
+      drop:
+        - ALL
+
   resources: {}
   # resources:
   #   requests:

--- a/values.yaml
+++ b/values.yaml
@@ -202,6 +202,15 @@ injector:
     certName: tls.crt
     keyName: tls.key
 
+  resources: {}
+  # resources:
+  #   requests:
+  #     memory: 256Mi
+  #     cpu: 250m
+  #   limits:
+  #     memory: 256Mi
+  #     cpu: 250m
+
   # Default pod security context for vault-injector
   podSecurityContext:
     runAsNonRoot: true
@@ -217,15 +226,6 @@ injector:
     capabilities:
       drop:
         - ALL
-
-  resources: {}
-  # resources:
-  #   requests:
-  #     memory: 256Mi
-  #     cpu: 250m
-  #   limits:
-  #     memory: 256Mi
-  #     cpu: 250m
 
   # extraEnvironmentVars is a list of extra environment variables to set in the
   # injector deployment.


### PR DESCRIPTION
It should partially related to this issue: https://github.com/hashicorp/vault-helm/issues/663 

What: Deployments can have security settings in their manifest on two levels: pod and container. However, there are some capabilities only configurable in one of the respective levels(https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#securitycontext-v1-core). This PR sets a default configuration for container securityContext, which drops all POSIX capabilities, and for podSecurityContext, which adds fsGroup and supplementalGroups. These are and should be standard settings in the context of Kubernetes. It also adds the possibility of running vault-injector in a Kubernetes environment without PSP (to be removed in v1.25 https://kubernetes.io/docs/concepts/security/pod-security-policy/), but with OpenPolicyAgent (possibly the PSP substitute) with the same capabilities as a **restricted** PSP instead.

Why: This missing configuration restricts vault-injector from being used with the simple upstream helm chart without modifications/unnecessary maintenance. This especially applies to the restricted policy use in OPA. 

This PR exports the respective settings to the values.yaml and is defaulting them there since the securityContext variables are hardcoded so far in the deployment, as well.
The other possibility would be to not use default values for the podSecurityContext and (container) securityContext variables in the values.yaml and let them e.g. empty to let the user decide themselves. This I would not recommend.
Benefit would be a more secure deployment in the future.
