### PR TITLE
jira-sync: transition to "Closed" not "Close"

### DIFF
--- a/.github/workflows/jira.yaml
+++ b/.github/workflows/jira.yaml
@@ -62,7 +62,7 @@ jobs:
       uses: atlassian/gajira-transition@v2.0.1
       with:
         issue: ${{ steps.search.outputs.issue }}
-        transition: Close
+        transition: Closed
 
     - name: Reopen ticket
       if: github.event.action == 'reopened' && steps.search.outputs.issue


### PR DESCRIPTION
To fix errors like this: https://github.com/hashicorp/vault-helm/runs/7395965763?check_suite_focus=true