### PR TITLE
feat: add fsGroupChangePolicy

### DIFF
--- a/templates/server-statefulset.yaml
+++ b/templates/server-statefulset.yaml
@@ -54,6 +54,9 @@ spec:
         runAsGroup: {{ .Values.server.gid | default 1000 }}
         runAsUser: {{ .Values.server.uid | default 100 }}
         fsGroup: {{ .Values.server.gid | default 1000 }}
+        {{ if  .Values.server.fsGroupChangePolicy }}
+        fsGroupChangePolicy:  {{ .Values.server.fsGroupChangePolicy }}
+        {{ end }}
       {{- end }}
       volumes:
         {{ template "vault.volumes" . }}

--- a/test/unit/server-statefulset.bats
+++ b/test/unit/server-statefulset.bats
@@ -1145,6 +1145,25 @@ load _helpers
   [ "${actual}" = "2000" ]
 }
 
+@test "server/standalone-StatefulSet: fsGroupChangePolicy omitted by default" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/server-statefulset.yaml \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.securityContext.fsGroupChangePolicy' | tee /dev/stderr)
+  [ "${actual}" = "null" ]
+}
+
+@test "server/standalone-StatefulSet: fsGroupChangePolicy configurable" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/server-statefulset.yaml \
+      --set 'server.fsGroupChangePolicy="OnRootMismatch"' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.securityContext.fsGroupChangePolicy' | tee /dev/stderr)
+  [ "${actual}" = "OnRootMismatch" ]
+}
+
 #--------------------------------------------------------------------
 # health checks
 

--- a/values.yaml
+++ b/values.yaml
@@ -430,6 +430,10 @@ server:
   # This is useful if Vault must be signaled, e.g. to send a SIGHUP for log rotation
   shareProcessNamespace: false
 
+  # fsGroupChangePolicy defines the behavior for changing ownership and permission of the volume before being exposed inside the pod
+  # https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#configure-volume-permission-and-ownership-change-policy-for-pods
+  fsGroupChangePolicy: null
+
   # extraArgs is a string containing additional Vault server arguments.
   extraArgs: ""
 


### PR DESCRIPTION
Kubernetes is chown-ing the entire data volume by default, which can be rather slow.

Make this configurable which is possible since v1.23 (GA) and v1.20 (beta) https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#configure-volume-permission-and-ownership-change-policy-for-pods