### PR TITLE
Allow loadBalancerClass to be specified for the main vault service

### DIFF
--- a/templates/server-service.yaml
+++ b/templates/server-service.yaml
@@ -22,6 +22,9 @@ spec:
   {{- if .Values.server.service.clusterIP }}
   clusterIP: {{ .Values.server.service.clusterIP }}
   {{- end }}
+  {{- if (and (eq .Values.server.service.type "LoadBalancer") .Values.server.service.loadBalancerClass) }}
+  loadBalancerClass: {{ .Values.server.service.loadBalancerClass }}
+  {{- end }}
   {{- include "service.externalTrafficPolicy" .Values.server.service }}
   # We want the servers to become available even if they're not ready
   # since this DNS is also used for join operations.

--- a/values.yaml
+++ b/values.yaml
@@ -601,6 +601,10 @@ server:
     # or NodePort.
     #type: ClusterIP
 
+    # Configure the loadBalancerClass for the main Vault service.
+    # ref: https://kubernetes.io/docs/concepts/services-networking/service/#load-balancer-class
+    # loadBalancerClass: 
+
     # Do not wait for pods to be ready
     publishNotReadyAddresses: true
 


### PR DESCRIPTION
This allows the `loadBalancerClass` field of the main Vault service to be configured.