### PR TITLE
csi/server.statefulset: custom security context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,14 +4,13 @@ CHANGES:
 * Start testing against Kubernetes 1.24. [GH-744](https://github.com/hashicorp/vault-helm/pull/744)
 * Deprecated `injector.externalVaultAddr`. Added `global.externalVaultAddr`, which applies to both the Injector and the CSI Provider. [GH-745](https://github.com/hashicorp/vault-helm/pull/745)
 * CSI Provider pods now set the `VAULT_ADDR` environment variable to either the internal Vault service or the configured external address. [GH-745](https://github.com/hashicorp/vault-helm/pull/745)
-* injector: Allow setting securityContext for pod and container to be objects or YAML strings. [GH-767](https://github.com/hashicorp/vault-helm/pull/767)
+* injector/csi/server: Allow setting securityContext for pod and container. [GH-750](https://github.com/hashicorp/vault-helm/pull/750) and [GH-767](https://github.com/hashicorp/vault-helm/pull/767)
 
 Features:
 * server: Add `server.statefulSet.securityContext` to override pod and container `securityContext`. [GH-767](https://github.com/hashicorp/vault-helm/pull/767)
 * csi: Add `csi.daemonSet.securityContext` to override pod and container `securityContext`. [GH-767](https://github.com/hashicorp/vault-helm/pull/767)
 * Add `server.service.activeNodePort` and `server.service.standbyNodePort` to specify the `nodePort` for active and standby services. [GH-610](https://github.com/hashicorp/vault-helm/pull/610)
 * Support for setting annotations on the injector's serviceAccount [GH-753](https://github.com/hashicorp/vault-helm/pull/753)
-* injector: Support setting both pod and container securityContext [GH-750](https://github.com/hashicorp/vault-helm/pull/750)
 
 ## 0.20.1 (May 25th, 2022)
 CHANGES:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,11 @@ CHANGES:
 * Start testing against Kubernetes 1.24. [GH-744](https://github.com/hashicorp/vault-helm/pull/744)
 * Deprecated `injector.externalVaultAddr`. Added `global.externalVaultAddr`, which applies to both the Injector and the CSI Provider. [GH-745](https://github.com/hashicorp/vault-helm/pull/745)
 * CSI Provider pods now set the `VAULT_ADDR` environment variable to either the internal Vault service or the configured external address. [GH-745](https://github.com/hashicorp/vault-helm/pull/745)
-* injector/csi/server: Allow setting securityContext for pod and container. [GH-750](https://github.com/hashicorp/vault-helm/pull/750) and [GH-767](https://github.com/hashicorp/vault-helm/pull/767)
 
 Features:
 * server: Add `server.statefulSet.securityContext` to override pod and container `securityContext`. [GH-767](https://github.com/hashicorp/vault-helm/pull/767)
 * csi: Add `csi.daemonSet.securityContext` to override pod and container `securityContext`. [GH-767](https://github.com/hashicorp/vault-helm/pull/767)
+* injector: Add `injector.securityContext` to override pod and container `securityContext`. [GH-750](https://github.com/hashicorp/vault-helm/pull/750) and [GH-767](https://github.com/hashicorp/vault-helm/pull/767)
 * Add `server.service.activeNodePort` and `server.service.standbyNodePort` to specify the `nodePort` for active and standby services. [GH-610](https://github.com/hashicorp/vault-helm/pull/610)
 * Support for setting annotations on the injector's serviceAccount [GH-753](https://github.com/hashicorp/vault-helm/pull/753)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,11 @@ CHANGES:
 * Deprecated `injector.externalVaultAddr`. Added `global.externalVaultAddr`, which applies to both the Injector and the CSI Provider. [GH-745](https://github.com/hashicorp/vault-helm/pull/745)
 * CSI Provider pods now set the `VAULT_ADDR` environment variable to either the internal Vault service or the configured external address. [GH-745](https://github.com/hashicorp/vault-helm/pull/745)
 * Deprecated `injector.uid` and `injector.gid`. Replaced with `injector.securityContext.pod`. [GH-750](https://github.com/hashicorp/vault-helm/pull/750)
+* injector: Allow setting securityContext for pod and container to be objects or YAML strings. [GH-767](https://github.com/hashicorp/vault-helm/pull/767)
 
 Features:
+* server: Add `server.statefulSet.securityContext` to override pod and container `securityContext`. [GH-767](https://github.com/hashicorp/vault-helm/pull/767)
+* csi: Add `csi.daemonSet.securityContext` to override pod and container `securityContext`. [GH-767](https://github.com/hashicorp/vault-helm/pull/767)
 * Add `server.service.activeNodePort` and `server.service.standbyNodePort` to specify the `nodePort` for active and standby services. [GH-610](https://github.com/hashicorp/vault-helm/pull/610)
 * Support for setting annotations on the injector's serviceAccount [GH-753](https://github.com/hashicorp/vault-helm/pull/753)
 * injector: Support setting both pod and container securityContext [GH-750](https://github.com/hashicorp/vault-helm/pull/750)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,6 @@ CHANGES:
 * Start testing against Kubernetes 1.24. [GH-744](https://github.com/hashicorp/vault-helm/pull/744)
 * Deprecated `injector.externalVaultAddr`. Added `global.externalVaultAddr`, which applies to both the Injector and the CSI Provider. [GH-745](https://github.com/hashicorp/vault-helm/pull/745)
 * CSI Provider pods now set the `VAULT_ADDR` environment variable to either the internal Vault service or the configured external address. [GH-745](https://github.com/hashicorp/vault-helm/pull/745)
-* Deprecated `injector.uid` and `injector.gid`. Replaced with `injector.securityContext.pod`. [GH-750](https://github.com/hashicorp/vault-helm/pull/750)
 * injector: Allow setting securityContext for pod and container to be objects or YAML strings. [GH-767](https://github.com/hashicorp/vault-helm/pull/767)
 
 Features:

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -482,7 +482,7 @@ securityContext for the injector pod level.
         {{- else }}
           {{- toYaml .Values.injector.securityContext.pod | nindent 8 }}
         {{- end }}
-  {{- else }}
+  {{- else if not .Values.global.openshift }}
       securityContext:
         runAsNonRoot: true
         runAsGroup: {{ .Values.injector.gid | default 1000 }}
@@ -503,6 +503,12 @@ securityContext for the injector container level.
             {{- else }}
               {{- toYaml .Values.injector.securityContext.container | nindent 12 }}
             {{- end }}
+  {{- else if not .Values.global.openshift }}
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
   {{- end }}
 {{- end -}}
 

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -474,14 +474,20 @@ Sets extra injector service annotations
 securityContext for the injector pod level.
 */}}
 {{- define "injector.securityContext.pod" -}}
-  {{- if or (.Values.injector.uid) (.Values.injector.gid) }}
+  {{- if .Values.injector.securityContext.pod }}
+      securityContext:
+        {{- $tp := typeOf .Values.injector.securityContext.pod }}
+        {{- if eq $tp "string" }}
+          {{- tpl .Values.injector.securityContext.pod . | nindent 8 }}
+        {{- else }}
+          {{- toYaml .Values.injector.securityContext.pod | nindent 8 }}
+        {{- end }}
+  {{- else }}
       securityContext:
         runAsNonRoot: true
         runAsGroup: {{ .Values.injector.gid | default 1000 }}
         runAsUser: {{ .Values.injector.uid | default 100 }}
-  {{- else if .Values.injector.securityContext.pod }}
-      securityContext:
-        {{- toYaml .Values.injector.securityContext.pod | nindent 8 }}
+        fsGroup: {{ .Values.injector.gid | default 1000 }}
   {{- end }}
 {{- end -}}
 
@@ -491,9 +497,54 @@ securityContext for the injector container level.
 {{- define "injector.securityContext.container" -}}
   {{- if .Values.injector.securityContext.container}}
           securityContext:
-            {{- toYaml .Values.injector.securityContext.container | nindent 12 }}
+            {{- $tp := typeOf .Values.injector.securityContext.container }}
+            {{- if eq $tp "string" }}
+              {{- tpl .Values.injector.securityContext.container . | nindent 12 }}
+            {{- else }}
+              {{- toYaml .Values.injector.securityContext.container | nindent 12 }}
+            {{- end }}
   {{- end }}
-{{- end -}} 
+{{- end -}}
+
+{{/*
+securityContext for the statefulset pod template.
+*/}}
+{{- define "server.statefulSet.securityContext.pod" -}}
+  {{- if .Values.server.statefulSet.securityContext.pod }}
+      securityContext:
+        {{- $tp := typeOf .Values.server.statefulSet.securityContext.pod }}
+        {{- if eq $tp "string" }}
+          {{- tpl .Values.server.statefulSet.securityContext.pod . | nindent 8 }}
+        {{- else }}
+          {{- toYaml .Values.server.statefulSet.securityContext.pod | nindent 8 }}
+        {{- end }}
+  {{- else if not .Values.global.openshift }}
+      securityContext:
+        runAsNonRoot: true
+        runAsGroup: {{ .Values.server.gid | default 1000 }}
+        runAsUser: {{ .Values.server.uid | default 100 }}
+        fsGroup: {{ .Values.server.gid | default 1000 }}
+  {{- end }}
+{{- end -}}
+
+{{/*
+securityContext for the statefulset vault container
+*/}}
+{{- define "server.statefulSet.securityContext.container" -}}
+  {{- if .Values.server.statefulSet.securityContext.container }}
+          securityContext:
+            {{- $tp := typeOf .Values.server.statefulSet.securityContext.container }}
+            {{- if eq $tp "string" }}
+              {{- tpl .Values.server.statefulSet.securityContext.container . | nindent 12 }}
+            {{- else }}
+              {{- toYaml .Values.server.statefulSet.securityContext.container | nindent 12 }}
+            {{- end }}
+  {{- else if not .Values.global.openshift }}
+          securityContext:
+            allowPrivilegeEscalation: false
+  {{- end }}
+{{- end -}}
+
 
 {{/*
 Sets extra injector service account annotations
@@ -730,6 +781,37 @@ Sets extra CSI daemonset annotations
     {{- end }}
   {{- end }}
 {{- end -}}
+
+{{/*
+Sets CSI daemonset securityContext for pod template
+*/}}
+{{- define "csi.daemonSet.securityContext.pod" -}}
+  {{- if .Values.csi.daemonSet.securityContext.pod }}
+      securityContext:
+    {{- $tp := typeOf .Values.csi.daemonSet.securityContext.pod }}
+    {{- if eq $tp "string" }}
+      {{- tpl .Values.csi.daemonSet.securityContext.pod . | nindent 8 }}
+    {{- else }}
+      {{- toYaml .Values.csi.daemonSet.securityContext.pod | nindent 8 }}
+    {{- end }}
+  {{- end }}
+{{- end -}}
+
+{{/*
+Sets CSI daemonset securityContext for container
+*/}}
+{{- define "csi.daemonSet.securityContext.container" -}}
+  {{- if .Values.csi.daemonSet.securityContext.container }}
+          securityContext:
+    {{- $tp := typeOf .Values.csi.daemonSet.securityContext.container }}
+    {{- if eq $tp "string" }}
+      {{- tpl .Values.csi.daemonSet.securityContext.container . | nindent 12 }}
+    {{- else }}
+      {{- toYaml .Values.csi.daemonSet.securityContext.container | nindent 12 }}
+    {{- end }}
+  {{- end }}
+{{- end -}}
+
 
 {{/*
 Sets the injector toleration for pod placement

--- a/templates/csi-daemonset.yaml
+++ b/templates/csi-daemonset.yaml
@@ -34,6 +34,7 @@ spec:
         {{- end -}}
       {{ template "csi.pod.annotations" . }}
     spec:
+      {{ template "csi.daemonSet.securityContext.pod" . }}
       {{- if .Values.csi.priorityClassName }}
       priorityClassName: {{ .Values.csi.priorityClassName }}
       {{- end }}
@@ -42,6 +43,7 @@ spec:
       containers:
         - name: {{ include "vault.name" . }}-csi-provider
           {{ template "csi.resources" . }}
+          {{ template "csi.daemonSet.securityContext.container" . }}
           image: "{{ .Values.csi.image.repository }}:{{ .Values.csi.image.tag }}"
           imagePullPolicy: {{ .Values.csi.image.pullPolicy }}
           args:

--- a/templates/injector-deployment.yaml
+++ b/templates/injector-deployment.yaml
@@ -38,18 +38,16 @@ spec:
       priorityClassName: {{ .Values.injector.priorityClassName }}
       {{- end }}
       serviceAccountName: "{{ template "vault.fullname" . }}-agent-injector"
+      {{ template "injector.securityContext.pod" . -}}
       {{- if not .Values.global.openshift }}
       hostNetwork: {{ .Values.injector.hostNetwork }}
-      {{ template "injector.securityContext.pod" . -}}
       {{- end }}
       containers:
         - name: sidecar-injector
           {{ template "injector.resources" . }}
           image: "{{ .Values.injector.image.repository }}:{{ .Values.injector.image.tag }}"
           imagePullPolicy: "{{ .Values.injector.image.pullPolicy }}"
-          {{- if not .Values.global.openshift }}
-          {{ template "injector.securityContext.container" . -}}
-          {{- end }}
+          {{- template "injector.securityContext.container" . }}
           env:
             - name: AGENT_INJECT_LISTEN
               value: {{ printf ":%v" .Values.injector.port  }}

--- a/templates/server-statefulset.yaml
+++ b/templates/server-statefulset.yaml
@@ -48,13 +48,7 @@ spec:
       {{ if  .Values.server.shareProcessNamespace }}
       shareProcessNamespace: true
       {{ end }}
-      {{- if not .Values.global.openshift }}
-      securityContext:
-        runAsNonRoot: true
-        runAsGroup: {{ .Values.server.gid | default 1000 }}
-        runAsUser: {{ .Values.server.uid | default 100 }}
-        fsGroup: {{ .Values.server.gid | default 1000 }}
-      {{- end }}
+      {{- template "server.statefulSet.securityContext.pod" . }}
       volumes:
         {{ template "vault.volumes" . }}
         - name: home
@@ -72,10 +66,7 @@ spec:
           - "/bin/sh"
           - "-ec"
           args: {{ template "vault.args" . }}
-          {{- if not .Values.global.openshift }}
-          securityContext:
-            allowPrivilegeEscalation: false
-          {{- end }}
+          {{- template "server.statefulSet.securityContext.container" . }}
           env:
             - name: HOST_IP
               valueFrom:

--- a/test/unit/csi-daemonset.bats
+++ b/test/unit/csi-daemonset.bats
@@ -592,3 +592,59 @@ load _helpers
       yq -r 'map(select(.name=="VAULT_ADDR")) | .[] .value' | tee /dev/stderr)
   [ "${value}" = "http://vault-outside" ]
 }
+
+#--------------------------------------------------------------------
+# securityContext
+
+@test "csi/daemonset: default csi.daemonSet.securityContext.pod" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/csi-daemonset.yaml \
+      --set 'csi.enabled=true' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.securityContext' | tee /dev/stderr)
+  [ "${actual}" = "null" ]
+}
+
+@test "csi/daemonset: default csi.daemonSet.securityContext.container" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/csi-daemonset.yaml \
+      --set 'csi.enabled=true' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.containers[0].securityContext' | tee /dev/stderr)
+  [ "${actual}" = "null" ]
+}
+
+@test "csi/daemonset: specify csi.daemonSet.securityContext.pod yaml" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/csi-daemonset.yaml \
+      --set 'csi.enabled=true' \
+      --set 'csi.daemonSet.securityContext.pod.foo=bar' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.securityContext.foo' | tee /dev/stderr)
+  [ "${actual}" = "bar" ]
+}
+
+@test "csi/daemonset: specify csi.daemonSet.securityContext.container yaml" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/csi-daemonset.yaml \
+      --set 'csi.enabled=true' \
+      --set 'csi.daemonSet.securityContext.container.foo=bar' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.containers[0].securityContext.foo' | tee /dev/stderr)
+  [ "${actual}" = "bar" ]
+}
+
+@test "csi/daemonset: specify csi.daemonSet.securityContext.container yaml string" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/csi-daemonset.yaml \
+      --set 'csi.enabled=true' \
+      --set 'csi.daemonSet.securityContext.container=foo: bar' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.containers[0].securityContext.foo' | tee /dev/stderr)
+  [ "${actual}" = "bar" ]
+}

--- a/test/unit/injector-deployment.bats
+++ b/test/unit/injector-deployment.bats
@@ -364,7 +364,7 @@ load _helpers
 }
 
 #--------------------------------------------------------------------
-# securityContext or pod and container
+# securityContext for pod and container
 
 # for backward compatibility
 @test "injector/deployment: backward pod securityContext" {
@@ -443,6 +443,49 @@ load _helpers
       . | tee /dev/stderr |
       yq -r '.spec.template.spec.securityContext.fsGroup' | tee /dev/stderr)
   [ "${actual}" = "1001" ]
+}
+
+@test "injector/deployment: custom pod securityContext from string" {
+  cd `chart_dir`
+  local multi=$(cat <<EOF
+foo: bar
+bar: foo
+EOF
+)
+  local actual=$(helm template \
+      --show-only templates/injector-deployment.yaml  \
+      --set 'injector.enabled=true' \
+      --set "injector.securityContext.pod=$multi" \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.securityContext.bar' | tee /dev/stderr)
+  [ "${actual}" = "foo" ]
+}
+
+@test "injector/deployment: custom container securityContext" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/injector-deployment.yaml  \
+      --set 'injector.enabled=true' \
+      --set "injector.securityContext.container.bar=foo" \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.containers[0].securityContext.bar' | tee /dev/stderr)
+  [ "${actual}" = "foo" ]
+}
+
+@test "injector/deployment: custom container securityContext from string" {
+  cd `chart_dir`
+  local multi=$(cat <<EOF
+foo: bar
+bar: foo
+EOF
+)
+  local actual=$(helm template \
+      --show-only templates/injector-deployment.yaml  \
+      --set 'injector.enabled=true' \
+      --set "injector.securityContext.container=$multi" \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.containers[0].securityContext.bar' | tee /dev/stderr)
+  [ "${actual}" = "foo" ]
 }
 
 @test "injector/deployment: default container securityContext sidecar-injector" {

--- a/test/unit/server-statefulset.bats
+++ b/test/unit/server-statefulset.bats
@@ -1723,3 +1723,64 @@ load _helpers
       yq -r -c '.spec.template.spec.containers[0].env[] | select(.name == "VAULT_LICENSE_PATH")' | tee /dev/stderr)
       [ "${actual}" = '' ]
 }
+
+#--------------------------------------------------------------------
+# securityContext
+
+@test "server/standalone-StatefulSet: default statefulSet.securityContext.pod" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/server-statefulset.yaml \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.securityContext' | tee /dev/stderr)
+  [ ! "${actual}" = "null" ]
+}
+
+@test "server/standalone-StatefulSet: default statefulSet.securityContext.container" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/server-statefulset.yaml \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.containers[0].securityContext' | tee /dev/stderr)
+  [ ! "${actual}" = "null" ]
+}
+
+@test "server/standalone-StatefulSet: specify statefulSet.securityContext.pod yaml" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/server-statefulset.yaml \
+      --set 'server.statefulSet.securityContext.pod.foo=bar' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.securityContext.foo' | tee /dev/stderr)
+  [ "${actual}" = "bar" ]
+}
+
+@test "server/standalone-StatefulSet: specify statefulSet.securityContext.container yaml" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/server-statefulset.yaml \
+      --set 'server.statefulSet.securityContext.container.foo=bar' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.containers[0].securityContext.foo' | tee /dev/stderr)
+  [ "${actual}" = "bar" ]
+}
+
+@test "server/standalone-StatefulSet: specify statefulSet.securityContext.pod yaml string" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/server-statefulset.yaml \
+      --set 'server.statefulSet.securityContext.pod=foo: bar' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.securityContext.foo' | tee /dev/stderr)
+  [ "${actual}" = "bar" ]
+}
+
+@test "server/standalone-StatefulSet: specify statefulSet.securityContext.container yaml string" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/server-statefulset.yaml \
+      --set 'server.statefulSet.securityContext.container=foo: bar' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.containers[0].securityContext.foo' | tee /dev/stderr)
+  [ "${actual}" = "bar" ]
+}

--- a/values.schema.json
+++ b/values.schema.json
@@ -23,6 +23,23 @@
                         "providersDir": {
                             "type": "string"
                         },
+                        "securityContext": {
+                            "type": "object",
+                            "properties": {
+                                "container": {
+                                    "type": [
+                                        "object",
+                                        "string"
+                                    ]
+                                },
+                                "pod": {
+                                    "type": [
+                                        "object",
+                                        "string"
+                                    ]
+                                }
+                            }
+                        },
                         "updateStrategy": {
                             "type": "object",
                             "properties": {
@@ -366,10 +383,16 @@
                     "type": "object",
                     "properties": {
                         "container": {
-                            "type": "object"
+                            "type": [
+                                "object",
+                                "string"
+                            ]
                         },
                         "pod": {
-                            "type": "object"
+                            "type": [
+                                "object",
+                                "string"
+                            ]
                         }
                     }
                 },
@@ -905,6 +928,23 @@
                                 "object",
                                 "string"
                             ]
+                        },
+                        "securityContext": {
+                            "type": "object",
+                            "properties": {
+                                "container": {
+                                    "type": [
+                                        "object",
+                                        "string"
+                                    ]
+                                },
+                                "pod": {
+                                    "type": [
+                                        "object",
+                                        "string"
+                                    ]
+                                }
+                            }
                         }
                     }
                 },

--- a/values.yaml
+++ b/values.yaml
@@ -844,7 +844,6 @@ server:
     # pod: {}
     # container:
     #   allowPrivilegeEscalation: false
-
     securityContext:
       pod: {}
       container: {}
@@ -941,8 +940,10 @@ csi:
     # Extra labels to attach to the vault-csi-provider daemonSet
     # This should be a YAML map of the labels to apply to the csi provider daemonSet
     extraLabels: {}
-    # security context for the pod template in the csi provider daemonSet
-    securityContext: {}
+    # security context for the pod template and container in the csi provider daemonSet
+    securityContext:
+      pod: {}
+      container: {}
 
   pod:
     # Extra annotations for the provider pods. This can either be YAML or a

--- a/values.yaml
+++ b/values.yaml
@@ -202,13 +202,14 @@ injector:
     certName: tls.crt
     keyName: tls.key
 
-  # Default pod and container security context for vault-injector
+  # Security context for the pod template and the injector container
+  # The default pod securityContext is:
+  #   runAsNonRoot: true
+  #   runAsGroup: {{ .Values.injector.gid | default 1000 }}
+  #   runAsUser: {{ .Values.injector.uid | default 100 }}
+  #   fsGroup: {{ .Values.injector.gid | default 1000 }}
   securityContext:
-    pod:
-      runAsNonRoot: true
-      runAsGroup: 1000
-      runAsUser: 100
-      fsGroup: 1000
+    pod: {}
     container:
       allowPrivilegeEscalation: false
       capabilities:
@@ -830,6 +831,25 @@ server:
     # to the statefulSet.
     annotations: {}
 
+    # Set the pod and container security contexts.
+    # If not set, these will default to, and for *not* OpenShift:
+    # pod:
+    #   runAsNonRoot: true
+    #   runAsGroup: {{ .Values.server.gid | default 1000 }}
+    #   runAsUser: {{ .Values.server.uid | default 100 }}
+    #   fsGroup: {{ .Values.server.gid | default 1000 }}
+    # container: {}
+    #
+    # If not set, these will default to, and for OpenShift:
+    # pod: {}
+    # container:
+    #   allowPrivilegeEscalation: false
+
+    securityContext:
+      pod: {}
+      container: {}
+
+
 # Vault UI
 ui:
   # True if you want to create a Service entry for the Vault UI.
@@ -921,6 +941,8 @@ csi:
     # Extra labels to attach to the vault-csi-provider daemonSet
     # This should be a YAML map of the labels to apply to the csi provider daemonSet
     extraLabels: {}
+    # security context for the pod template in the csi provider daemonSet
+    securityContext: {}
 
   pod:
     # Extra annotations for the provider pods. This can either be YAML or a

--- a/values.yaml
+++ b/values.yaml
@@ -208,13 +208,14 @@ injector:
   #   runAsGroup: {{ .Values.injector.gid | default 1000 }}
   #   runAsUser: {{ .Values.injector.uid | default 100 }}
   #   fsGroup: {{ .Values.injector.gid | default 1000 }}
+  # and for container is
+  #    allowPrivilegeEscalation: false
+  #    capabilities:
+  #      drop:
+  #        - ALL
   securityContext:
     pod: {}
-    container:
-      allowPrivilegeEscalation: false
-      capabilities:
-        drop:
-          - ALL
+    container: {}
 
   resources: {}
   # resources:


### PR DESCRIPTION
This adds flexibility to have custom pod template and container
`securityContext` and preserves current default values and behavior.

Fixes https://github.com/hashicorp/vault-helm/issues/663.

This also is a way to address https://github.com/hashicorp/vault-helm/pull/599
so that people can specify, for example, the CSI to run in a privileged
container for OpenShift.

This is a follow-up to https://github.com/hashicorp/vault-helm/pull/750
and builds on the same principles.

Side note: I am not able to run `helm schema-gen` since it is
unmaintained and does not work with M1 Macs.