### PR TITLE
add namespaceOverride template to manifests

### DIFF
--- a/templates/NOTES.txt
+++ b/templates/NOTES.txt
@@ -7,8 +7,8 @@ Vault with Kubernetes available here:
 https://www.vaultproject.io/docs/
 
 
-Your release is named {{ .Release.Name }}. To learn more about the release, try:
+Your release is named {{ template "vault.namespace" . }}. To learn more about the release, try:
 
-  $ helm status {{ .Release.Name }}
-  $ helm get manifest {{ .Release.Name }}
+  $ helm status {{ template "vault.namespace" . }}
+  $ helm get manifest {{ template "vault.namespace" . }}
 

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -32,6 +32,17 @@ Expand the name of the chart.
 {{- end -}}
 
 {{/*
+Allow the release namespace to be overridden for multi-namespace deployments in combined charts
+*/}}
+{{- define "vault.namespace" -}}
+  {{- if .Values.namespaceOverride -}}
+    {{- .Values.namespaceOverride -}}
+  {{- else -}}
+    {{- .Release.Namespace -}}
+  {{- end -}}
+{{- end -}}
+
+{{/*
 Compute if the csi driver is enabled.
 */}}
 {{- define "vault.csiEnabled" -}}

--- a/templates/csi-clusterrolebinding.yaml
+++ b/templates/csi-clusterrolebinding.yaml
@@ -15,5 +15,5 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: {{ template "vault.fullname" . }}-csi-provider
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ template "vault.namespace" . }}
 {{- end }}

--- a/templates/csi-daemonset.yaml
+++ b/templates/csi-daemonset.yaml
@@ -4,7 +4,7 @@ apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: {{ template "vault.fullname" . }}-csi-provider
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ template "vault.namespace" . }}
   labels:
     app.kubernetes.io/name: {{ include "vault.name" . }}-csi-provider
     app.kubernetes.io/instance: {{ .Release.Name }}
@@ -57,7 +57,7 @@ spec:
             {{- if .Values.global.externalVaultAddr }}
               value: "{{ .Values.global.externalVaultAddr }}"
             {{- else }}
-              value: {{ include "vault.scheme" . }}://{{ template "vault.fullname" . }}.{{ .Release.Namespace }}.svc:{{ .Values.server.service.port }}
+              value: {{ include "vault.scheme" . }}://{{ template "vault.fullname" . }}.{{ template "vault.namespace" . }}.svc:{{ .Values.server.service.port }}
             {{- end }}
           volumeMounts:
             - name: providervol

--- a/templates/csi-serviceaccount.yaml
+++ b/templates/csi-serviceaccount.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ template "vault.fullname" . }}-csi-provider
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ template "vault.namespace" . }}
   labels:
     app.kubernetes.io/name: {{ include "vault.name" . }}-csi-provider
     app.kubernetes.io/instance: {{ .Release.Name }}

--- a/templates/injector-certs-secret.yaml
+++ b/templates/injector-certs-secret.yaml
@@ -5,7 +5,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: vault-injector-certs
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ template "vault.namespace" . }}
   labels:
     app.kubernetes.io/name: {{ include "vault.name" . }}-agent-injector
     app.kubernetes.io/instance: {{ .Release.Name }}

--- a/templates/injector-clusterrolebinding.yaml
+++ b/templates/injector-clusterrolebinding.yaml
@@ -15,5 +15,5 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: {{ template "vault.fullname" . }}-agent-injector
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ template "vault.namespace" . }}
 {{ end }}

--- a/templates/injector-deployment.yaml
+++ b/templates/injector-deployment.yaml
@@ -5,7 +5,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "vault.fullname" . }}-agent-injector
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ template "vault.namespace" . }}
   labels:
     app.kubernetes.io/name: {{ include "vault.name" . }}-agent-injector
     app.kubernetes.io/instance: {{ .Release.Name }}
@@ -59,7 +59,7 @@ spec:
             {{- else if .Values.injector.externalVaultAddr }}
               value: "{{ .Values.injector.externalVaultAddr }}"
             {{- else }}
-              value: {{ include "vault.scheme" . }}://{{ template "vault.fullname" . }}.{{ .Release.Namespace }}.svc:{{ .Values.server.service.port }}
+              value: {{ include "vault.scheme" . }}://{{ template "vault.fullname" . }}.{{ template "vault.namespace" . }}.svc:{{ .Values.server.service.port }}
             {{- end }}
             - name: AGENT_INJECT_VAULT_AUTH_PATH
               value: {{ .Values.injector.authPath }}
@@ -74,7 +74,7 @@ spec:
             - name: AGENT_INJECT_TLS_AUTO
               value: {{ template "vault.fullname" . }}-agent-injector-cfg
             - name: AGENT_INJECT_TLS_AUTO_HOSTS
-              value: {{ template "vault.fullname" . }}-agent-injector-svc,{{ template "vault.fullname" . }}-agent-injector-svc.{{ .Release.Namespace }},{{ template "vault.fullname" . }}-agent-injector-svc.{{ .Release.Namespace }}.svc
+              value: {{ template "vault.fullname" . }}-agent-injector-svc,{{ template "vault.fullname" . }}-agent-injector-svc.{{ template "vault.namespace" . }},{{ template "vault.fullname" . }}-agent-injector-svc.{{ template "vault.namespace" . }}.svc
             {{- end }}
             - name: AGENT_INJECT_LOG_FORMAT
               value: {{ .Values.injector.logFormat | default "standard" }}

--- a/templates/injector-disruptionbudget.yaml
+++ b/templates/injector-disruptionbudget.yaml
@@ -3,7 +3,7 @@ apiVersion: {{ ge .Capabilities.KubeVersion.Minor "21" | ternary "policy/v1" "po
 kind: PodDisruptionBudget
 metadata:
   name: {{ template "vault.fullname" . }}-agent-injector
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ template "vault.namespace" . }}
   labels:
     helm.sh/chart: {{ include "vault.chart" . }}
     app.kubernetes.io/name: {{ include "vault.name" . }}-agent-injector

--- a/templates/injector-mutating-webhook.yaml
+++ b/templates/injector-mutating-webhook.yaml
@@ -23,7 +23,7 @@ webhooks:
     clientConfig:
       service:
         name: {{ template "vault.fullname" . }}-agent-injector-svc
-        namespace: {{ .Release.Namespace }}
+        namespace: {{ template "vault.namespace" . }}
         path: "/mutate"
       caBundle: {{ .Values.injector.certs.caBundle | quote }}
     rules:

--- a/templates/injector-psp-role.yaml
+++ b/templates/injector-psp-role.yaml
@@ -5,7 +5,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: {{ template "vault.fullname" . }}-agent-injector-psp
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ template "vault.namespace" . }}
   labels:
     app.kubernetes.io/name: {{ include "vault.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}

--- a/templates/injector-psp-rolebinding.yaml
+++ b/templates/injector-psp-rolebinding.yaml
@@ -5,7 +5,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: {{ template "vault.fullname" . }}-agent-injector-psp
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ template "vault.namespace" . }}
   labels:
     app.kubernetes.io/name: {{ include "vault.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}

--- a/templates/injector-psp.yaml
+++ b/templates/injector-psp.yaml
@@ -5,6 +5,7 @@ apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
   name: {{ template "vault.fullname" . }}-agent-injector
+  namespace: {{ template "vault.namespace" . }}
   labels:
     app.kubernetes.io/name: {{ include "vault.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}

--- a/templates/injector-role.yaml
+++ b/templates/injector-role.yaml
@@ -5,7 +5,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: {{ template "vault.fullname" . }}-agent-injector-leader-elector-role
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ template "vault.namespace" . }}
   labels:
     app.kubernetes.io/name: {{ include "vault.name" . }}-agent-injector
     app.kubernetes.io/instance: {{ .Release.Name }}

--- a/templates/injector-rolebinding.yaml
+++ b/templates/injector-rolebinding.yaml
@@ -5,7 +5,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: {{ template "vault.fullname" . }}-agent-injector-leader-elector-binding
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ template "vault.namespace" . }}
   labels:
     app.kubernetes.io/name: {{ include "vault.name" . }}-agent-injector
     app.kubernetes.io/instance: {{ .Release.Name }}
@@ -17,6 +17,6 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: {{ template "vault.fullname" . }}-agent-injector
-    namespace: {{ .Release.Namespace }}
+    namespace: {{ template "vault.namespace" . }}
 {{- end }}
 {{- end }}

--- a/templates/injector-service.yaml
+++ b/templates/injector-service.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ template "vault.fullname" . }}-agent-injector-svc
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ template "vault.namespace" . }}
   labels:
     app.kubernetes.io/name: {{ include "vault.name" . }}-agent-injector
     app.kubernetes.io/instance: {{ .Release.Name }}

--- a/templates/injector-serviceaccount.yaml
+++ b/templates/injector-serviceaccount.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ template "vault.fullname" . }}-agent-injector
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ template "vault.namespace" . }}
   labels:
     app.kubernetes.io/name: {{ include "vault.name" . }}-agent-injector
     app.kubernetes.io/instance: {{ .Release.Name }}

--- a/templates/server-clusterrolebinding.yaml
+++ b/templates/server-clusterrolebinding.yaml
@@ -20,5 +20,5 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: {{ template "vault.serviceAccount.name" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ template "vault.namespace" . }}
 {{ end }}

--- a/templates/server-config-configmap.yaml
+++ b/templates/server-config-configmap.yaml
@@ -7,7 +7,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ template "vault.fullname" . }}-config
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ template "vault.namespace" . }}
   labels:
     helm.sh/chart: {{ include "vault.chart" . }}
     app.kubernetes.io/name: {{ include "vault.name" . }}

--- a/templates/server-discovery-role.yaml
+++ b/templates/server-discovery-role.yaml
@@ -5,7 +5,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ template "vault.namespace" . }}
   name: {{ template "vault.fullname" . }}-discovery-role
   labels:
     helm.sh/chart: {{ include "vault.chart" . }}

--- a/templates/server-discovery-rolebinding.yaml
+++ b/templates/server-discovery-rolebinding.yaml
@@ -10,7 +10,7 @@ apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: RoleBinding
 metadata:
   name: {{ template "vault.fullname" . }}-discovery-rolebinding
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ template "vault.namespace" . }}
   labels:
     helm.sh/chart: {{ include "vault.chart" . }}
     app.kubernetes.io/name: {{ include "vault.name" . }}
@@ -23,7 +23,7 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: {{ template "vault.serviceAccount.name" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ template "vault.namespace" . }}
 {{ end }}
 {{ end }}
 {{ end }}

--- a/templates/server-disruptionbudget.yaml
+++ b/templates/server-disruptionbudget.yaml
@@ -8,7 +8,7 @@ apiVersion: {{ ge .Capabilities.KubeVersion.Minor "21" | ternary "policy/v1" "po
 kind: PodDisruptionBudget
 metadata:
   name: {{ template "vault.fullname" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ template "vault.namespace" . }}
   labels:
     helm.sh/chart: {{ include "vault.chart" . }}
     app.kubernetes.io/name: {{ include "vault.name" . }}

--- a/templates/server-ha-active-service.yaml
+++ b/templates/server-ha-active-service.yaml
@@ -8,7 +8,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ template "vault.fullname" . }}-active
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ template "vault.namespace" . }}
   labels:
     helm.sh/chart: {{ include "vault.chart" . }}
     app.kubernetes.io/name: {{ include "vault.name" . }}

--- a/templates/server-ha-standby-service.yaml
+++ b/templates/server-ha-standby-service.yaml
@@ -8,7 +8,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ template "vault.fullname" . }}-standby
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ template "vault.namespace" . }}
   labels:
     helm.sh/chart: {{ include "vault.chart" . }}
     app.kubernetes.io/name: {{ include "vault.name" . }}

--- a/templates/server-headless-service.yaml
+++ b/templates/server-headless-service.yaml
@@ -7,7 +7,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ template "vault.fullname" . }}-internal
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ template "vault.namespace" . }}
   labels:
     helm.sh/chart: {{ include "vault.chart" . }}
     app.kubernetes.io/name: {{ include "vault.name" . }}

--- a/templates/server-ingress.yaml
+++ b/templates/server-ingress.yaml
@@ -22,7 +22,7 @@ apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
   name: {{ template "vault.fullname" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ template "vault.namespace" . }}
   labels:
     helm.sh/chart: {{ include "vault.chart" . }}
     app.kubernetes.io/name: {{ include "vault.name" . }}

--- a/templates/server-psp-role.yaml
+++ b/templates/server-psp-role.yaml
@@ -5,7 +5,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: {{ template "vault.fullname" . }}-psp
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ template "vault.namespace" . }}
   labels:
     app.kubernetes.io/name: {{ include "vault.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}

--- a/templates/server-psp-rolebinding.yaml
+++ b/templates/server-psp-rolebinding.yaml
@@ -5,7 +5,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: {{ template "vault.fullname" . }}-psp
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ template "vault.namespace" . }}
   labels:
     app.kubernetes.io/name: {{ include "vault.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}

--- a/templates/server-psp.yaml
+++ b/templates/server-psp.yaml
@@ -5,6 +5,7 @@ apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
   name: {{ template "vault.fullname" . }}
+  namespace: {{ template "vault.namespace" . }}
   labels:
     app.kubernetes.io/name: {{ include "vault.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}

--- a/templates/server-route.yaml
+++ b/templates/server-route.yaml
@@ -9,7 +9,7 @@ kind: Route
 apiVersion: route.openshift.io/v1
 metadata:
   name: {{ template "vault.fullname" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ template "vault.namespace" . }}
   labels:
     helm.sh/chart: {{ include "vault.chart" . }}
     app.kubernetes.io/name: {{ include "vault.name" . }}

--- a/templates/server-service.yaml
+++ b/templates/server-service.yaml
@@ -7,7 +7,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ template "vault.fullname" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ template "vault.namespace" . }}
   labels:
     helm.sh/chart: {{ include "vault.chart" . }}
     app.kubernetes.io/name: {{ include "vault.name" . }}

--- a/templates/server-serviceaccount.yaml
+++ b/templates/server-serviceaccount.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ template "vault.serviceAccount.name" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ template "vault.namespace" . }}
   labels:
     helm.sh/chart: {{ include "vault.chart" . }}
     app.kubernetes.io/name: {{ include "vault.name" . }}

--- a/templates/server-statefulset.yaml
+++ b/templates/server-statefulset.yaml
@@ -7,7 +7,7 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: {{ template "vault.fullname" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ template "vault.namespace" . }}
   labels:
     app.kubernetes.io/name: {{ include "vault.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}

--- a/templates/tests/server-test.yaml
+++ b/templates/tests/server-test.yaml
@@ -5,7 +5,7 @@ apiVersion: v1
 kind: Pod
 metadata:
   name: "{{ .Release.Name }}-server-test"
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ template "vault.namespace" . }}
   annotations:
     "helm.sh/hook": test
 spec:
@@ -16,7 +16,7 @@ spec:
       imagePullPolicy: {{ .Values.server.image.pullPolicy }}
       env:
         - name: VAULT_ADDR
-          value: {{ include "vault.scheme" . }}://{{ template "vault.fullname" . }}.{{ .Release.Namespace }}.svc:{{ .Values.server.service.port }}
+          value: {{ include "vault.scheme" . }}://{{ template "vault.fullname" . }}.{{ template "vault.namespace" . }}.svc:{{ .Values.server.service.port }}
         {{- include "vault.extraEnvironmentVars" .Values.server | nindent 8 }}
       command:
         - /bin/sh

--- a/templates/ui-service.yaml
+++ b/templates/ui-service.yaml
@@ -7,7 +7,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ template "vault.fullname" . }}-ui
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ template "vault.namespace" . }}
   labels:
     helm.sh/chart: {{ include "vault.chart" . }}
     app.kubernetes.io/name: {{ include "vault.name" . }}-ui


### PR DESCRIPTION
This PR adds a way to override namespace for Vault helm chart if it is being used as dependency in another helm (umbrella) chart.

```
$ helm template --set namespaceOverride="hashicorp" . | kubeval
PASS - vault/templates/injector-serviceaccount.yaml contains a valid ServiceAccount (hashicorp.release-name-vault-agent-injector)
PASS - vault/templates/server-serviceaccount.yaml contains a valid ServiceAccount (hashicorp.release-name-vault)
PASS - vault/templates/server-config-configmap.yaml contains a valid ConfigMap (hashicorp.release-name-vault-config)
PASS - vault/templates/injector-clusterrole.yaml contains a valid ClusterRole (release-name-vault-agent-injector-clusterrole)
PASS - vault/templates/injector-clusterrolebinding.yaml contains a valid ClusterRoleBinding (release-name-vault-agent-injector-binding)
PASS - vault/templates/server-clusterrolebinding.yaml contains a valid ClusterRoleBinding (release-name-vault-server-binding)
PASS - vault/templates/injector-service.yaml contains a valid Service (hashicorp.release-name-vault-agent-injector-svc)
PASS - vault/templates/server-headless-service.yaml contains a valid Service (hashicorp.release-name-vault-internal)
PASS - vault/templates/server-service.yaml contains a valid Service (hashicorp.release-name-vault)
PASS - vault/templates/injector-deployment.yaml contains a valid Deployment (hashicorp.release-name-vault-agent-injector)
PASS - vault/templates/server-statefulset.yaml contains a valid StatefulSet (hashicorp.release-name-vault)
PASS - vault/templates/injector-mutating-webhook.yaml contains a valid MutatingWebhookConfiguration (release-name-vault-agent-injector-cfg)
PASS - vault/templates/tests/server-test.yaml contains a valid Pod (hashicorp.release-name-server-test)
$
```