### PR TITLE
Update vault-k8s to 1.0.0

### DIFF
--- a/.github/workflows/acceptance.yaml
+++ b/.github/workflows/acceptance.yaml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        kind-k8s-version: [1.16.15, 1.20.15, 1.21.12, 1.22.9, 1.23.6, 1.24.1]
+        kind-k8s-version: [1.16.15, 1.20.15, 1.21.14, 1.22.13, 1.23.10, 1.24.4, 1.25.0]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 ## Unreleased
+
 Features:
 * Add PrometheusOperator support for collecting Vault server metrics. [GH-772](https://github.com/hashicorp/vault-helm/pull/772)
+
+Changes:
+* `vault-k8s` to 1.0.0 [GH-XXX](https://github.com/hashicorp/vault-helm/pull/xxx)
+* Test against Kubernetes 1.25 [GH-XXX](https://github.com/hashicorp/vault-helm/pull/xxx)
 
 ## 0.21.0 (August 10th, 2022)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,8 @@ Features:
 * Add PrometheusOperator support for collecting Vault server metrics. [GH-772](https://github.com/hashicorp/vault-helm/pull/772)
 
 Changes:
-* `vault-k8s` to 1.0.0 [GH-XXX](https://github.com/hashicorp/vault-helm/pull/xxx)
-* Test against Kubernetes 1.25 [GH-XXX](https://github.com/hashicorp/vault-helm/pull/xxx)
+* `vault-k8s` to 1.0.0 [GH-784](https://github.com/hashicorp/vault-helm/pull/784)
+* Test against Kubernetes 1.25 [GH-784](https://github.com/hashicorp/vault-helm/pull/784)
 
 ## 0.21.0 (August 10th, 2022)
 

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ LOCAL_ACCEPTANCE_TESTS?=false
 KIND_CLUSTER_NAME?=vault-helm
 
 # kind k8s version
-KIND_K8S_VERSION?=v1.24.1
+KIND_K8S_VERSION?=v1.25.0
 
 # Generate json schema for chart values. See test/README.md for more details.
 values-schema:

--- a/test/acceptance/server-ha.bats
+++ b/test/acceptance/server-ha.bats
@@ -87,8 +87,10 @@ setup() {
   kubectl create namespace acceptance
   kubectl config set-context --current --namespace=acceptance
 
-  helm install consul \
-    https://github.com/hashicorp/consul-helm/archive/v0.32.1.tar.gz \
+  helm repo add hashicorp https://helm.releases.hashicorp.com
+  helm repo update
+  helm install consul hashicorp/consul \
+    --version v0.48.0 \
     --set 'ui.enabled=false'
 
   wait_for_running_consul

--- a/test/acceptance/server-ha.bats
+++ b/test/acceptance/server-ha.bats
@@ -88,7 +88,7 @@ setup() {
   kubectl config set-context --current --namespace=acceptance
 
   helm install consul \
-    https://github.com/hashicorp/consul-helm/archive/v0.28.0.tar.gz \
+    https://github.com/hashicorp/consul-helm/archive/v0.32.1.tar.gz \
     --set 'ui.enabled=false'
 
   wait_for_running_consul

--- a/test/acceptance/server-ha.bats
+++ b/test/acceptance/server-ha.bats
@@ -89,8 +89,16 @@ setup() {
 
   helm repo add hashicorp https://helm.releases.hashicorp.com
   helm repo update
+
+  CONSUL_HELM_VERSION=v0.48.0
+
+  K8S_MAJOR=$(kubectl version --output=json | jq -r .serverVersion.major)
+  K8S_MINOR=$(kubectl version --output=json | jq -r .serverVersion.minor)
+  if [ \( $K8S_MAJOR -eq 1 \) -a \( $K8S_MINOR -le 20 \) ]; then
+    CONSUL_HELM_VERSION=v0.32.1
+  fi
   helm install consul hashicorp/consul \
-    --version v0.48.0 \
+    --version $CONSUL_HELM_VERSION \
     --set 'ui.enabled=false'
 
   wait_for_running_consul

--- a/values.openshift.yaml
+++ b/values.openshift.yaml
@@ -6,7 +6,7 @@ global:
 injector:
   image:
     repository: "registry.connect.redhat.com/hashicorp/vault-k8s"
-    tag: "0.17.0-ubi"
+    tag: "1.0.0-ubi"
 
   agentImage:
     repository: "registry.connect.redhat.com/hashicorp/vault"

--- a/values.yaml
+++ b/values.yaml
@@ -62,7 +62,7 @@ injector:
   # image sets the repo and tag of the vault-k8s image to use for the injector.
   image:
     repository: "hashicorp/vault-k8s"
-    tag: "0.17.0"
+    tag: "1.0.0"
     pullPolicy: IfNotPresent
 
   # agentImage sets the repo and tag of the Vault image to use for the Vault Agent


### PR DESCRIPTION
Also update Kubernetes versions tested against, including adding 1.25. (This required using a newer version of Consul in our acceptance tests for 1.25, but keeping the old version for 1.20 and 1.16.)