### PR TITLE
Prepare for 0.22.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Features:
 Changes:
 * `vault-k8s` to 1.0.0 [GH-784](https://github.com/hashicorp/vault-helm/pull/784)
 * Test against Kubernetes 1.25 [GH-784](https://github.com/hashicorp/vault-helm/pull/784)
+* `vault` updated to 1.11.3 [GH-785](https://github.com/hashicorp/vault-helm/pull/785)
 
 ## 0.21.0 (August 10th, 2022)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+## 0.21.1 (September 8th, 2022)
+
 Features:
 * Add PrometheusOperator support for collecting Vault server metrics. [GH-772](https://github.com/hashicorp/vault-helm/pull/772)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Unreleased
 
-## 0.21.1 (September 8th, 2022)
+## 0.22.0 (September 8th, 2022)
 
 Features:
 * Add PrometheusOperator support for collecting Vault server metrics. [GH-772](https://github.com/hashicorp/vault-helm/pull/772)

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: vault
 version: 0.22.0
-appVersion: 1.11.2
+appVersion: 1.11.3
 kubeVersion: ">= 1.16.0-0"
 description: Official HashiCorp Vault Chart
 home: https://www.vaultproject.io

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: vault
-version: 0.21.0
+version: 0.21.1
 appVersion: 1.11.2
 kubeVersion: ">= 1.16.0-0"
 description: Official HashiCorp Vault Chart

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: vault
-version: 0.21.1
+version: 0.22.0
 appVersion: 1.11.2
 kubeVersion: ">= 1.16.0-0"
 description: Official HashiCorp Vault Chart

--- a/test/acceptance/server-ha-enterprise-dr.bats
+++ b/test/acceptance/server-ha-enterprise-dr.bats
@@ -7,7 +7,7 @@ load _helpers
 
   helm install "$(name_prefix)-east" \
     --set='server.image.repository=hashicorp/vault-enterprise' \
-    --set='server.image.tag=1.11.2-ent' \
+    --set='server.image.tag=1.11.3-ent' \
     --set='injector.enabled=false' \
     --set='server.ha.enabled=true' \
     --set='server.ha.raft.enabled=true' \
@@ -75,7 +75,7 @@ load _helpers
   helm install "$(name_prefix)-west" \
     --set='injector.enabled=false' \
     --set='server.image.repository=hashicorp/vault-enterprise' \
-    --set='server.image.tag=1.11.2-ent' \
+    --set='server.image.tag=1.11.3-ent' \
     --set='server.ha.enabled=true' \
     --set='server.ha.raft.enabled=true' \
     --set='server.enterpriseLicense.secretName=vault-license' .

--- a/test/acceptance/server-ha-enterprise-perf.bats
+++ b/test/acceptance/server-ha-enterprise-perf.bats
@@ -8,7 +8,7 @@ load _helpers
   helm install "$(name_prefix)-east" \
     --set='injector.enabled=false' \
     --set='server.image.repository=hashicorp/vault-enterprise' \
-    --set='server.image.tag=1.11.2-ent' \
+    --set='server.image.tag=1.11.3-ent' \
     --set='server.ha.enabled=true' \
     --set='server.ha.raft.enabled=true' \
     --set='server.enterpriseLicense.secretName=vault-license' .
@@ -75,7 +75,7 @@ load _helpers
   helm install "$(name_prefix)-west" \
     --set='injector.enabled=false' \
     --set='server.image.repository=hashicorp/vault-enterprise' \
-    --set='server.image.tag=1.11.2-ent' \
+    --set='server.image.tag=1.11.3-ent' \
     --set='server.ha.enabled=true' \
     --set='server.ha.raft.enabled=true' \
     --set='server.enterpriseLicense.secretName=vault-license' .

--- a/values.openshift.yaml
+++ b/values.openshift.yaml
@@ -10,9 +10,9 @@ injector:
 
   agentImage:
     repository: "registry.connect.redhat.com/hashicorp/vault"
-    tag: "1.11.2-ubi"
+    tag: "1.11.3-ubi"
 
 server:
   image:
     repository: "registry.connect.redhat.com/hashicorp/vault"
-    tag: "1.11.2-ubi"
+    tag: "1.11.3-ubi"

--- a/values.yaml
+++ b/values.yaml
@@ -70,7 +70,7 @@ injector:
   # required.
   agentImage:
     repository: "hashicorp/vault"
-    tag: "1.11.2"
+    tag: "1.11.3"
 
   # The default values for the injected Vault Agent containers.
   agentDefaults:
@@ -332,7 +332,7 @@ server:
 
   image:
     repository: "hashicorp/vault"
-    tag: "1.11.2"
+    tag: "1.11.3"
     # Overrides the default Image Pull Policy
     pullPolicy: IfNotPresent
 


### PR DESCRIPTION
## 0.22.0 (September 8th, 2022)

Features:
* Add PrometheusOperator support for collecting Vault server metrics. [GH-772](https://github.com/hashicorp/vault-helm/pull/772)

Changes:
* `vault-k8s` to 1.0.0 [GH-784](https://github.com/hashicorp/vault-helm/pull/784)
* Test against Kubernetes 1.25 [GH-784](https://github.com/hashicorp/vault-helm/pull/784)
