### PR TITLE
Adding new option to agent deployment AGENT_INJECT_VAULT_ADDR section

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: vault
-version: 0.22.0
+version: 0.23.0
 appVersion: 1.11.3
 kubeVersion: ">= 1.16.0-0"
 description: Official HashiCorp Vault Chart

--- a/templates/injector-deployment.yaml
+++ b/templates/injector-deployment.yaml
@@ -58,6 +58,8 @@ spec:
               value: "{{ .Values.global.externalVaultAddr }}"
             {{- else if .Values.injector.externalVaultAddr }}
               value: "{{ .Values.injector.externalVaultAddr }}"
+            {{- else if .Values.server.ha.apiAddr }}
+              value: "{{ .Values.server.ha.apiAddr }}"
             {{- else }}
               value: {{ include "vault.scheme" . }}://{{ template "vault.fullname" . }}.{{ .Release.Namespace }}.svc:{{ .Values.server.service.port }}
             {{- end }}


### PR DESCRIPTION
Signed-off-by: garcia.ryan <garcia.ryan@solute.us>

Add more options for `AGENT_INJECT_VAULT_ADDR` Env Variable population, helpful when utilizing own TLS & LoadBalancers alongside "internal" vault deployment.

Closes #789 