### PR TITLE
server: Allow disabling the instance selector for services

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Features:
 * server: Add `extraLabels` for Vault server serviceAccount [GH-806](https://github.com/hashicorp/vault-helm/pull/806)
 * server: Add `server.service.active.enabled` and `server.service.standby.enabled` options to selectively disable additional services [GH-811](https://github.com/hashicorp/vault-helm/pull/811)
 * server: Add `server.serviceAccount.serviceDiscovery.enabled` option to selectively disable a Vault service discovery role and role binding [GH-811](https://github.com/hashicorp/vault-helm/pull/811)
+* server: Add `server.service.instanceSelector.enabled` option to allow selecting pods outside the helm chart deployment [GH-813](https://github.com/hashicorp/vault-helm/pull/813)
 
 Bugs:
 * server: Quote `.server.ha.clusterAddr` value [GH-810](https://github.com/hashicorp/vault-helm/pull/810)

--- a/templates/server-ha-active-service.yaml
+++ b/templates/server-ha-active-service.yaml
@@ -39,7 +39,9 @@ spec:
       targetPort: 8201
   selector:
     app.kubernetes.io/name: {{ include "vault.name" . }}
+    {{- if eq (.Values.server.service.instanceSelector.enabled | toString) "true" }}
     app.kubernetes.io/instance: {{ .Release.Name }}
+    {{- end }}
     component: server
     vault-active: "true"
 {{- end }}

--- a/templates/server-ha-standby-service.yaml
+++ b/templates/server-ha-standby-service.yaml
@@ -38,7 +38,9 @@ spec:
       targetPort: 8201
   selector:
     app.kubernetes.io/name: {{ include "vault.name" . }}
+    {{- if eq (.Values.server.service.instanceSelector.enabled | toString) "true" }}
     app.kubernetes.io/instance: {{ .Release.Name }}
+    {{- end }}
     component: server
     vault-active: "false"
 {{- end }}

--- a/templates/server-service.yaml
+++ b/templates/server-service.yaml
@@ -38,7 +38,9 @@ spec:
       targetPort: 8201
   selector:
     app.kubernetes.io/name: {{ include "vault.name" . }}
+    {{- if eq (.Values.server.service.instanceSelector.enabled | toString) "true" }}
     app.kubernetes.io/instance: {{ .Release.Name }}
+    {{- end }}
     component: server
 {{- end }}
 {{- end }}

--- a/test/unit/server-ha-active-service.bats
+++ b/test/unit/server-ha-active-service.bats
@@ -226,3 +226,21 @@ load _helpers
       yq -r '.spec.publishNotReadyAddresses' | tee /dev/stderr)
   [ "${actual}" = "false" ]
 }
+
+@test "server/ha-active-Service: instance selector can be disabled" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/server-ha-active-service.yaml \
+      --set 'server.ha.enabled=true' \
+      . | tee /dev/stderr |
+      yq -r '.spec.selector["app.kubernetes.io/instance"]' | tee /dev/stderr)
+  [ "${actual}" = "release-name" ]
+
+  local actual=$(helm template \
+      --show-only templates/server-ha-active-service.yaml \
+      --set 'server.ha.enabled=true' \
+      --set 'server.service.instanceSelector.enabled=false' \
+      . | tee /dev/stderr |
+      yq -r '.spec.selector["app.kubernetes.io/instance"]' | tee /dev/stderr)
+  [ "${actual}" = "null" ]
+}

--- a/test/unit/server-ha-standby-service.bats
+++ b/test/unit/server-ha-standby-service.bats
@@ -237,3 +237,21 @@ load _helpers
       yq -r '.spec.publishNotReadyAddresses' | tee /dev/stderr)
   [ "${actual}" = "false" ]
 }
+
+@test "server/ha-standby-Service: instance selector can be disabled" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/server-ha-standby-service.yaml \
+      --set 'server.ha.enabled=true' \
+      . | tee /dev/stderr |
+      yq -r '.spec.selector["app.kubernetes.io/instance"]' | tee /dev/stderr)
+  [ "${actual}" = "release-name" ]
+
+  local actual=$(helm template \
+      --show-only templates/server-ha-standby-service.yaml \
+      --set 'server.ha.enabled=true' \
+      --set 'server.service.instanceSelector.enabled=false' \
+      . | tee /dev/stderr |
+      yq -r '.spec.selector["app.kubernetes.io/instance"]' | tee /dev/stderr)
+  [ "${actual}" = "null" ]
+}

--- a/test/unit/server-headless-service.bats
+++ b/test/unit/server-headless-service.bats
@@ -17,3 +17,21 @@ load _helpers
       yq -r '.spec.publishNotReadyAddresses' | tee /dev/stderr)
   [ "${actual}" = "false" ]
 }
+
+@test "server/headless-Service: instance selector cannot be disabled" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/server-headless-service.yaml \
+      --set 'server.ha.enabled=true' \
+      . | tee /dev/stderr |
+      yq -r '.spec.selector["app.kubernetes.io/instance"]' | tee /dev/stderr)
+  [ "${actual}" = "release-name" ]
+
+  local actual=$(helm template \
+      --show-only templates/server-headless-service.yaml \
+      --set 'server.ha.enabled=true' \
+      --set 'server.service.instanceSelector.enabled=false' \
+      . | tee /dev/stderr |
+      yq -r '.spec.selector["app.kubernetes.io/instance"]' | tee /dev/stderr)
+  [ "${actual}" = "release-name" ]
+}

--- a/test/unit/server-service.bats
+++ b/test/unit/server-service.bats
@@ -431,3 +431,20 @@ load _helpers
   [ "${actual}" = "null" ]
 }
 
+@test "server/Service: instance selector can be disabled" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/server-service.yaml \
+      --set 'server.ha.enabled=true' \
+      . | tee /dev/stderr |
+      yq -r '.spec.selector["app.kubernetes.io/instance"]' | tee /dev/stderr)
+  [ "${actual}" = "release-name" ]
+
+  local actual=$(helm template \
+      --show-only templates/server-service.yaml \
+      --set 'server.ha.enabled=true' \
+      --set 'server.service.instanceSelector.enabled=false' \
+      . | tee /dev/stderr |
+      yq -r '.spec.selector["app.kubernetes.io/instance"]' | tee /dev/stderr)
+  [ "${actual}" = "null" ]
+}

--- a/values.schema.json
+++ b/values.schema.json
@@ -871,6 +871,14 @@
                         "externalTrafficPolicy": {
                             "type": "string"
                         },
+                        "instanceSelector": {
+                            "type": "object",
+                            "properties": {
+                                "enabled": {
+                                    "type": "boolean"
+                                }
+                            }
+                        },
                         "port": {
                             "type": "integer"
                         },

--- a/values.yaml
+++ b/values.yaml
@@ -604,6 +604,11 @@ server:
     # have labelled themselves as a cluster follower with `vault-active: "false"`
     standby:
       enabled: true
+    # If enabled, the service selectors will include `app.kubernetes.io/instance: {{ .Release.Name }}`
+    # When disabled, services may select Vault pods not deployed from the chart.
+    # Does not affect the headless vault-internal service with `ClusterIP: None`
+    instanceSelector:
+      enabled: true
     # clusterIP controls whether a Cluster IP address is attached to the
     # Vault service within Kubernetes.  By default, the Vault service will
     # be given a Cluster IP address, set to None to disable.  When disabled


### PR DESCRIPTION
Allows users to optionally loosen the selectors for services a little to select other deployments of Vault as well. If the new option is disabled, the service will essentially match all Vault pods within the same namespace.

I would have preferred to use a [set selector](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#set-based-requirement) but unfortunately the `Service` schema doesn't support that.