### PR TITLE
Prepare for 0.23.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 ## Unreleased
 
+## 0.23.0 (November 22nd, 2022)
+
+Changes:
+* `vault` updated to 1.12.1 [GH-814](https://github.com/hashicorp/vault-helm/pull/814)
+* `vault-k8s` updated to 1.1.0 [GH-814](https://github.com/hashicorp/vault-helm/pull/814)
+* `vault-csi-provider` updated to 1.2.1 [GH-814](https://github.com/hashicorp/vault-helm/pull/814)
+
 Features:
 * server: Add `extraLabels` for Vault server serviceAccount [GH-806](https://github.com/hashicorp/vault-helm/pull/806)
 * server: Add `server.service.active.enabled` and `server.service.standby.enabled` options to selectively disable additional services [GH-811](https://github.com/hashicorp/vault-helm/pull/811)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Unreleased
 
-## 0.23.0 (November 22nd, 2022)
+## 0.23.0 (November 28th, 2022)
 
 Changes:
 * `vault` updated to 1.12.1 [GH-814](https://github.com/hashicorp/vault-helm/pull/814)

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: vault
-version: 0.22.1
-appVersion: 1.12.0
+version: 0.23.0
+appVersion: 1.12.1
 kubeVersion: ">= 1.16.0-0"
 description: Official HashiCorp Vault Chart
 home: https://www.vaultproject.io

--- a/test/acceptance/server-ha-enterprise-dr.bats
+++ b/test/acceptance/server-ha-enterprise-dr.bats
@@ -7,7 +7,7 @@ load _helpers
 
   helm install "$(name_prefix)-east" \
     --set='server.image.repository=hashicorp/vault-enterprise' \
-    --set='server.image.tag=1.12.0-ent' \
+    --set='server.image.tag=1.12.1-ent' \
     --set='injector.enabled=false' \
     --set='server.ha.enabled=true' \
     --set='server.ha.raft.enabled=true' \
@@ -75,7 +75,7 @@ load _helpers
   helm install "$(name_prefix)-west" \
     --set='injector.enabled=false' \
     --set='server.image.repository=hashicorp/vault-enterprise' \
-    --set='server.image.tag=1.12.0-ent' \
+    --set='server.image.tag=1.12.1-ent' \
     --set='server.ha.enabled=true' \
     --set='server.ha.raft.enabled=true' \
     --set='server.enterpriseLicense.secretName=vault-license' .

--- a/test/acceptance/server-ha-enterprise-perf.bats
+++ b/test/acceptance/server-ha-enterprise-perf.bats
@@ -8,7 +8,7 @@ load _helpers
   helm install "$(name_prefix)-east" \
     --set='injector.enabled=false' \
     --set='server.image.repository=hashicorp/vault-enterprise' \
-    --set='server.image.tag=1.12.0-ent' \
+    --set='server.image.tag=1.12.1-ent' \
     --set='server.ha.enabled=true' \
     --set='server.ha.raft.enabled=true' \
     --set='server.enterpriseLicense.secretName=vault-license' .
@@ -75,7 +75,7 @@ load _helpers
   helm install "$(name_prefix)-west" \
     --set='injector.enabled=false' \
     --set='server.image.repository=hashicorp/vault-enterprise' \
-    --set='server.image.tag=1.12.0-ent' \
+    --set='server.image.tag=1.12.1-ent' \
     --set='server.ha.enabled=true' \
     --set='server.ha.raft.enabled=true' \
     --set='server.enterpriseLicense.secretName=vault-license' .

--- a/values.openshift.yaml
+++ b/values.openshift.yaml
@@ -6,13 +6,13 @@ global:
 injector:
   image:
     repository: "registry.connect.redhat.com/hashicorp/vault-k8s"
-    tag: "1.0.1-ubi"
+    tag: "1.1.0-ubi"
 
   agentImage:
     repository: "registry.connect.redhat.com/hashicorp/vault"
-    tag: "1.12.0-ubi"
+    tag: "1.12.1-ubi"
 
 server:
   image:
     repository: "registry.connect.redhat.com/hashicorp/vault"
-    tag: "1.12.0-ubi"
+    tag: "1.12.1-ubi"

--- a/values.yaml
+++ b/values.yaml
@@ -62,7 +62,7 @@ injector:
   # image sets the repo and tag of the vault-k8s image to use for the injector.
   image:
     repository: "hashicorp/vault-k8s"
-    tag: "1.0.1"
+    tag: "1.1.0"
     pullPolicy: IfNotPresent
 
   # agentImage sets the repo and tag of the Vault image to use for the Vault Agent
@@ -70,7 +70,7 @@ injector:
   # required.
   agentImage:
     repository: "hashicorp/vault"
-    tag: "1.12.0"
+    tag: "1.12.1"
 
   # The default values for the injected Vault Agent containers.
   agentDefaults:
@@ -332,7 +332,7 @@ server:
 
   image:
     repository: "hashicorp/vault"
-    tag: "1.12.0"
+    tag: "1.12.1"
     # Overrides the default Image Pull Policy
     pullPolicy: IfNotPresent
 
@@ -947,7 +947,7 @@ csi:
 
   image:
     repository: "hashicorp/vault-csi-provider"
-    tag: "1.2.0"
+    tag: "1.2.1"
     pullPolicy: IfNotPresent
 
   # volumes is a list of volumes made available to all containers. These are rendered


### PR DESCRIPTION
## 0.23.0 (November 22nd, 2022)

### Changes

* `vault` updated to 1.12.1 [GH-814](https://github.com/hashicorp/vault-helm/pull/814)
* `vault-k8s` updated to 1.1.0 [GH-814](https://github.com/hashicorp/vault-helm/pull/814)
* `vault-csi-provider` updated to 1.2.1 [GH-814](https://github.com/hashicorp/vault-helm/pull/814)

### Features

* server: Add `extraLabels` for Vault server serviceAccount [GH-806](https://github.com/hashicorp/vault-helm/pull/806)
* server: Add `server.service.active.enabled` and `server.service.standby.enabled` options to selectively disable additional services [GH-811](https://github.com/hashicorp/vault-helm/pull/811)
* server: Add `server.serviceAccount.serviceDiscovery.enabled` option to selectively disable a Vault service discovery role and role binding [GH-811](https://github.com/hashicorp/vault-helm/pull/811)
* server: Add `server.service.instanceSelector.enabled` option to allow selecting pods outside the helm chart deployment [GH-813](https://github.com/hashicorp/vault-helm/pull/813)

### Bugs

* server: Quote `.server.ha.clusterAddr` value [GH-810](https://github.com/hashicorp/vault-helm/pull/810)