### PR TITLE
Default prometheusRules.rules should be an empty list, not map

### DIFF
--- a/values.yaml
+++ b/values.yaml
@@ -1125,7 +1125,7 @@ serverTelemetry:
       selectors: {}
 
       # Some example rules.
-      rules: {}
+      rules: []
       #  - alert: vault-HighResponseTime
       #    annotations:
       #      message: The response time of Vault is over 500ms on average over the last 5 minutes.


### PR DESCRIPTION
Support for prometheus-operator was added in https://github.com/hashicorp/vault-helm/pull/772 and a default empty set of rules was defined as an empty map `{}`. However, as evidenced by the commented out rule examples below that very same values.yaml, this is expected to be a list, so `rules:` value should be set to an empty list `[]`.

Because of this Helm issues a warning if you actually define rules and pass them with a --values <filename>:

```
coalesce.go:220: warning: cannot overwrite table with non table for vault.serverTelemetry.prometheusRules.rules (map[])
```