### PR TITLE
Amending comment for the vault service account creation helper

### DIFF
--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -59,7 +59,7 @@ Compute if the server is enabled.
 {{- end -}}
 
 {{/*
-Compute if the server auth delegator serviceaccount is enabled.
+Compute if the server serviceaccount is enabled.
 */}}
 {{- define "vault.serverServiceAccountEnabled" -}}
 {{- $_ := set . "serverServiceAccountEnabled"


### PR DESCRIPTION
Spotted a small inconsistency with a comment in the `_helpers.tpl` file. 

