### PR TITLE
Add servicemonitor relabelings

### DIFF
--- a/templates/prometheus-servicemonitor.yaml
+++ b/templates/prometheus-servicemonitor.yaml
@@ -38,6 +38,12 @@ spec:
       - prometheus
     tlsConfig:
       insecureSkipVerify: true
+    {{- if .Values.serverTelemetry.serviceMonitor.metricRelabelings }}
+    metricRelabelings: {{- toYaml .Values.serverTelemetry.serviceMonitor.metricRelabelings | nindent 4 }}
+    {{- end }}
+    {{- if .Values.serverTelemetry.serviceMonitor.relabelings }}
+    relabelings: {{- toYaml .Values.serverTelemetry.serviceMonitor.relabelings | nindent 4 }}
+    {{- end }}
   namespaceSelector:
     matchNames:
       - {{ .Release.Namespace }}

--- a/test/unit/prometheus-servicemonitor.bats
+++ b/test/unit/prometheus-servicemonitor.bats
@@ -123,3 +123,57 @@ load _helpers
   [ "$(echo "$output" | yq -r '.spec.endpoints | length')" = "1" ]
   [ "$(echo "$output" | yq -r '.spec.endpoints[0].port')" = "https" ]
 }
+
+@test "prometheus/ServiceMonitor-server: assertMetricRelabelings default" {
+  cd `chart_dir`
+  local output=$( (helm template \
+      --show-only templates/prometheus-servicemonitor.yaml \
+      --set 'serverTelemetry.serviceMonitor.enabled=true' \
+      . ) | tee /dev/stderr)
+
+  [ "$(echo "$output" | yq -r '.spec.endpoints | length')" = "1" ]
+  [ "$(echo "$output" | yq -r '.spec.endpoints[0] | has("metricRelabelings")')" = "false" ]
+}
+
+@test "prometheus/ServiceMonitor-server: assertMetricRelabelings override" {
+  cd `chart_dir`
+  local output=$( (helm template \
+      --show-only templates/prometheus-servicemonitor.yaml \
+      --set 'serverTelemetry.serviceMonitor.enabled=true' \
+      --set 'serverTelemetry.serviceMonitor.metricRelabelings[0]=foo' \
+      --set 'serverTelemetry.serviceMonitor.metricRelabelings[1]=foo' \
+      . ) | tee /dev/stderr)
+
+  [ "$(echo "$output" | yq -r '.spec.endpoints | length')" = "1" ]
+  [ "$(echo "$output" | yq -r '.spec.endpoints[0] | has("metricRelabelings")')" = "true" ]
+  [ "$(echo "$output" | yq -r '.spec.endpoints[0].metricRelabelings | length')" = "2" ]
+  [ "$(echo "$output" | yq -r '.spec.endpoints[0].metricRelabelings[0]')" = "foo" ]
+  [ "$(echo "$output" | yq -r '.spec.endpoints[0].metricRelabelings[1]')" = "foo" ]
+}
+
+@test "prometheus/ServiceMonitor-server: assertRelabelings default" {
+  cd `chart_dir`
+  local output=$( (helm template \
+      --show-only templates/prometheus-servicemonitor.yaml \
+      --set 'serverTelemetry.serviceMonitor.enabled=true' \
+      . ) | tee /dev/stderr)
+
+  [ "$(echo "$output" | yq -r '.spec.endpoints | length')" = "1" ]
+  [ "$(echo "$output" | yq -r '.spec.endpoints[0] | has("relabelings")')" = "false" ]
+}
+
+@test "prometheus/ServiceMonitor-server: assertRelabelings override" {
+  cd `chart_dir`
+  local output=$( (helm template \
+      --show-only templates/prometheus-servicemonitor.yaml \
+      --set 'serverTelemetry.serviceMonitor.enabled=true' \
+      --set 'serverTelemetry.serviceMonitor.relabelings[0]=foo' \
+      --set 'serverTelemetry.serviceMonitor.relabelings[1]=foo' \
+      . ) | tee /dev/stderr)
+
+  [ "$(echo "$output" | yq -r '.spec.endpoints | length')" = "1" ]
+  [ "$(echo "$output" | yq -r '.spec.endpoints[0] | has("relabelings")')" = "true" ]
+  [ "$(echo "$output" | yq -r '.spec.endpoints[0].relabelings | length')" = "2" ]
+  [ "$(echo "$output" | yq -r '.spec.endpoints[0].relabelings[0]')" = "foo" ]
+  [ "$(echo "$output" | yq -r '.spec.endpoints[0].relabelings[1]')" = "foo" ]
+}

--- a/values.yaml
+++ b/values.yaml
@@ -1110,6 +1110,24 @@ serverTelemetry:
     # Timeout for Prometheus scrapes
     scrapeTimeout: 10s
 
+    # MetricRelabelConfigs to apply to samples before ingestion.
+    metricRelabelings: []
+    # Some example metricRelabelings.
+    #- action: "replace"
+    #  regex: "(.*)"
+    #  sourceLabels:
+    #    - "cluster"
+    #  targetLabel: "vault_cluster"
+
+    # RelabelConfigs to apply to samples before scraping.
+    relabelings: []
+    # Some example relabelings.
+    #- action: "replace"
+    #  regex: "(.*)"
+    #  sourceLabels:
+    #    - "cluster"
+    #  targetLabel: "vault_cluster"
+
   prometheusRules:
       # The Prometheus operator *must* be installed before enabling this feature,
       # if not the chart will fail to install due to missing CustomResourceDefinitions


### PR DESCRIPTION
Adds support for specifying metricRelabelings and relabelings fields of `ServiceMonitor.spec.endpoints`. 
https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#monitoring.coreos.com/v1.Endpoint

This is useful when labels of the metrics collide with external labels of the Prometheus Server (e.g. `cluster`) and allows one to replace the colliding label name with a new label name.
