### PR TITLE
Add extraPorts property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Unreleased
 
+Features:
+* server: New `extraPorts` option for adding ports to the Vault server statefulset [GH-841](https://github.com/hashicorp/vault-helm/pull/841)
+
 ## 0.23.0 (November 28th, 2022)
 
 Changes:

--- a/templates/server-statefulset.yaml
+++ b/templates/server-statefulset.yaml
@@ -143,6 +143,9 @@ spec:
               name: https-internal
             - containerPort: 8202
               name: {{ include "vault.scheme" . }}-rep
+          {{- if .Values.server.extraPorts -}}
+          {{ toYaml .Values.server.extraPorts | nindent 12}}
+          {{- end }}
           {{- if .Values.server.readinessProbe.enabled }}
           readinessProbe:
             {{- if .Values.server.readinessProbe.path }}

--- a/test/unit/server-statefulset.bats
+++ b/test/unit/server-statefulset.bats
@@ -1828,3 +1828,4 @@ load _helpers
   local actual=$(echo $object |
       yq -r '.name' | tee /dev/stderr)
   [ "${actual}" = "foo" ]
+}

--- a/test/unit/server-statefulset.bats
+++ b/test/unit/server-statefulset.bats
@@ -1819,7 +1819,7 @@ load _helpers
       --set 'server.extraPorts[0].containerPort=1111' \
       --set 'server.extraPorts[0].name=foo' \
       . | tee /dev/stderr |
-      yq -r '.spec.template.spec.ports[] | select(.name == "foo")' | tee /dev/stderr)
+      yq -r '.spec.template.spec.containers[0].ports[] | select(.name == "foo")' | tee /dev/stderr)
 
   local actual=$(echo $object |
       yq -r '.containerPort' | tee /dev/stderr)

--- a/test/unit/server-statefulset.bats
+++ b/test/unit/server-statefulset.bats
@@ -1806,3 +1806,25 @@ load _helpers
       yq -r '.spec.template.spec.hostNetwork' | tee /dev/stderr)
   [ "${actual}" = "true" ]
 }
+
+#--------------------------------------------------------------------
+# extraPorts
+
+@test "server/standalone-StatefulSet: adds extra ports" {
+  cd `chart_dir`
+
+  # Test that it defines it
+  local object=$(helm template \
+      --show-only templates/server-statefulset.yaml  \
+      --set 'server.extraPorts[0].containerPort=1111' \
+      --set 'server.extraPorts[0].name=foo' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.ports[] | select(.name == "foo")' | tee /dev/stderr)
+
+  local actual=$(echo $object |
+      yq -r '.containerPort' | tee /dev/stderr)
+  [ "${actual}" = "1111" ]
+
+  local actual=$(echo $object |
+      yq -r '.name' | tee /dev/stderr)
+  [ "${actual}" = "foo" ]

--- a/values.schema.json
+++ b/values.schema.json
@@ -593,6 +593,12 @@
                 "extraArgs": {
                     "type": "string"
                 },
+                "extraPorts": {
+                    "type": [
+                        "null",
+                        "array"
+                    ]
+                },
                 "extraContainers": {
                     "type": [
                         "null",

--- a/values.yaml
+++ b/values.yaml
@@ -453,6 +453,12 @@ server:
   # extraArgs is a string containing additional Vault server arguments.
   extraArgs: ""
 
+  # extraPorts is a list of extra ports. Specified as a YAML list.
+  # This is useful if you need to add additional ports to the statefulset in dynamic way.
+  extraPorts: null
+    # - containerPort: 8300
+    #   name: http-monitoring
+
   # Used to define custom readinessProbe settings
   readinessProbe:
     enabled: true


### PR DESCRIPTION
Issue:
We are using the upstream helm chart and we added a new listener for monitoring, running on custom port.
The current chart do not allows us to add this custom port to the statefulset from the values file.
Resolution:
These changes allows us to add custom ports to values file and continue using the upstream helm chart at the same time.