### PR TITLE
Fix typo in telemetry example

### DIFF
--- a/values.yaml
+++ b/values.yaml
@@ -747,7 +747,7 @@ server:
 
       # Example configuration for enabling Prometheus metrics in your config.
       #telemetry {
-      #  prometheus_retention_time = "30s",
+      #  prometheus_retention_time = "30s"
       #  disable_hostname = true
       #}
 
@@ -841,7 +841,7 @@ server:
       # If you are using Prometheus Operator you can enable a ServiceMonitor resource below.
       # You may wish to enable unauthenticated metrics in the listener block above.
       #telemetry {
-      #  prometheus_retention_time = "30s",
+      #  prometheus_retention_time = "30s"
       #  disable_hostname = true
       #}
 
@@ -1083,7 +1083,7 @@ serverTelemetry:
   #
   # example:
   #  telemetry {
-  #    prometheus_retention_time = "30s",
+  #    prometheus_retention_time = "30s"
   #    disable_hostname = true
   #  }
   #


### PR DESCRIPTION
The example for the telemetry block has a comma at the end of the list, which is not valid HCL and causes vault to crashloop if used as is.