### PR TITLE
fix: remove k8s 1.16 from acceptance testing

### DIFF
--- a/.github/workflows/acceptance.yaml
+++ b/.github/workflows/acceptance.yaml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        kind-k8s-version: [1.16.15, 1.20.15, 1.21.14, 1.22.15, 1.23.12, 1.24.6, 1.25.3]
+        kind-k8s-version: [1.20.15, 1.21.14, 1.22.15, 1.23.12, 1.24.6, 1.25.3]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Unreleased
 
+Changes:
+* Earliest Kubernetes version tested is now 1.20
+
 Features:
 * server: New `extraPorts` option for adding ports to the Vault server statefulset [GH-841](https://github.com/hashicorp/vault-helm/pull/841)
 

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -5,7 +5,7 @@ apiVersion: v2
 name: vault
 version: 0.23.0
 appVersion: 1.12.1
-kubeVersion: ">= 1.16.0-0"
+kubeVersion: ">= 1.20.0-0"
 description: Official HashiCorp Vault Chart
 home: https://www.vaultproject.io
 icon: https://github.com/hashicorp/vault/raw/f22d202cde2018f9455dec755118a9b84586e082/Vault_PrimaryLogo_Black.png

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ this README. Please refer to the Kubernetes and Helm documentation.
 The versions required are:
 
   * **Helm 3.6+**
-  * **Kubernetes 1.16+** - This is the earliest version of Kubernetes tested.
+  * **Kubernetes 1.20+** - This is the earliest version of Kubernetes tested.
     It is possible that this chart works with earlier versions but it is
     untested.
 

--- a/templates/server-ingress.yaml
+++ b/templates/server-ingress.yaml
@@ -17,7 +17,7 @@ SPDX-License-Identifier: MPL-2.0
 {{- $servicePort := .Values.server.service.port -}}
 {{- $pathType := .Values.server.ingress.pathType -}}
 {{- $kubeVersion := .Capabilities.KubeVersion.Version }}
-{{ if semverCompare ">= 1.19.0-0" $kubeVersion }}
+{{ if semverCompare ">= 1.20.0-0" $kubeVersion }}
 apiVersion: networking.k8s.io/v1
 {{ else if .Capabilities.APIVersions.Has "networking.k8s.io/v1beta1" }}
 apiVersion: networking.k8s.io/v1beta1
@@ -61,11 +61,11 @@ spec:
 {{- end }}
         {{- range (.paths | default (list "/")) }}
           - path: {{ . }}
-            {{ if semverCompare ">= 1.19.0-0" $kubeVersion }}
+            {{ if semverCompare ">= 1.20.0-0" $kubeVersion }}
             pathType: {{ $pathType }}
             {{ end }}
             backend:
-              {{ if semverCompare ">= 1.19.0-0" $kubeVersion }}
+              {{ if semverCompare ">= 1.20.0-0" $kubeVersion }}
               service:
                 name: {{ $serviceName }}
                 port:

--- a/templates/server-ingress.yaml
+++ b/templates/server-ingress.yaml
@@ -17,7 +17,7 @@ SPDX-License-Identifier: MPL-2.0
 {{- $servicePort := .Values.server.service.port -}}
 {{- $pathType := .Values.server.ingress.pathType -}}
 {{- $kubeVersion := .Capabilities.KubeVersion.Version }}
-{{ if semverCompare ">= 1.20.0-0" $kubeVersion }}
+{{ if semverCompare ">= 1.19.0-0" $kubeVersion }}
 apiVersion: networking.k8s.io/v1
 {{ else if .Capabilities.APIVersions.Has "networking.k8s.io/v1beta1" }}
 apiVersion: networking.k8s.io/v1beta1
@@ -61,19 +61,12 @@ spec:
 {{- end }}
         {{- range (.paths | default (list "/")) }}
           - path: {{ . }}
-            {{ if semverCompare ">= 1.20.0-0" $kubeVersion }}
             pathType: {{ $pathType }}
-            {{ end }}
             backend:
-              {{ if semverCompare ">= 1.20.0-0" $kubeVersion }}
               service:
                 name: {{ $serviceName }}
                 port:
                   number: {{ $servicePort }}
-              {{ else }}
-              serviceName: {{ $serviceName }}
-              servicePort: {{ $servicePort }}
-              {{ end }}
         {{- end }}
   {{- end }}
 {{- end }}

--- a/test/unit/injector-disruptionbudget.bats
+++ b/test/unit/injector-disruptionbudget.bats
@@ -36,7 +36,7 @@ load _helpers
   local actual=$(helm template \
       --show-only templates/injector-disruptionbudget.yaml \
       --set 'injector.podDisruptionBudget.minAvailable=2' \
-      --kube-version 1.19.5 \
+      --kube-version 1.20.15 \
       . | tee /dev/stderr |
       yq '.apiVersion == "policy/v1beta1"' | tee /dev/stderr)
   [ "${actual}" = "true" ]

--- a/test/unit/server-ha-disruptionbudget.bats
+++ b/test/unit/server-ha-disruptionbudget.bats
@@ -104,7 +104,7 @@ load _helpers
       --show-only templates/server-disruptionbudget.yaml \
       --set 'server.ha.enabled=true' \
       --set 'server.ha.replicas=1' \
-      --kube-version 1.19.5 \
+      --kube-version 1.20.15 \
       . | tee /dev/stderr |
       yq '.apiVersion == "policy/v1beta1"' | tee /dev/stderr)
   [ "${actual}" = "true" ]

--- a/test/unit/server-ingress.bats
+++ b/test/unit/server-ingress.bats
@@ -197,7 +197,7 @@ load _helpers
   [ "${actual}" = "release-name-vault" ]
 }
 
-@test "server/ingress: k8s 1.20.15 uses regular service when not ha - yaml" {
+@test "server/ingress: k8s 1.20.15 uses correct service format when not ha - yaml" {
   cd `chart_dir`
 
   local actual=$(helm template \
@@ -208,7 +208,7 @@ load _helpers
       --set 'server.service.enabled=true' \
       --kube-version 1.20.15 \
       . | tee /dev/stderr |
-      yq -r '.spec.rules[0].http.paths[0].backend.serviceName' | tee /dev/stderr)
+      yq -r '.spec.rules[0].http.paths[0].backend.service.name' | tee /dev/stderr)
   [ "${actual}" = "release-name-vault" ]
 }
 
@@ -238,19 +238,6 @@ load _helpers
       . | tee /dev/stderr |
       yq -r '.spec.rules[0].http.paths[0].pathType' | tee /dev/stderr)
   [ "${actual}" = "ImplementationSpecific" ]
-}
-
-@test "server/ingress: pathType is not added to Kubernetes versions < 1.21" {
-  cd `chart_dir`
-
-  local actual=$(helm template \
-      --show-only templates/server-ingress.yaml \
-      --set 'server.ingress.enabled=true' \
-      --set server.ingress.pathType=ImplementationSpecific \
-      --kube-version 1.20.15 \
-      . | tee /dev/stderr |
-      yq -r '.spec.rules[0].http.paths[0].pathType' | tee /dev/stderr)
-  [ "${actual}" = "null" ]
 }
 
 @test "server/ingress: pathType is added to Kubernetes versions > 1.19" {

--- a/test/unit/server-ingress.bats
+++ b/test/unit/server-ingress.bats
@@ -197,7 +197,7 @@ load _helpers
   [ "${actual}" = "release-name-vault" ]
 }
 
-@test "server/ingress: k8s 1.18.3 uses regular service when not ha - yaml" {
+@test "server/ingress: k8s 1.20.15 uses regular service when not ha - yaml" {
   cd `chart_dir`
 
   local actual=$(helm template \
@@ -206,7 +206,7 @@ load _helpers
       --set 'server.dev.enabled=false' \
       --set 'server.ha.enabled=false' \
       --set 'server.service.enabled=true' \
-      --kube-version 1.18.3 \
+      --kube-version 1.20.15 \
       . | tee /dev/stderr |
       yq -r '.spec.rules[0].http.paths[0].backend.serviceName' | tee /dev/stderr)
   [ "${actual}" = "release-name-vault" ]
@@ -227,27 +227,27 @@ load _helpers
   [ "${actual}" = "release-name-vault" ]
 }
 
-@test "server/ingress: pathType is added to Kubernetes version == 1.19.0" {
+@test "server/ingress: pathType is added to Kubernetes version == 1.20.15" {
   cd `chart_dir`
 
   local actual=$(helm template \
       --show-only templates/server-ingress.yaml \
       --set 'server.ingress.enabled=true' \
       --set server.ingress.pathType=ImplementationSpecific \
-      --kube-version 1.19.0 \
+      --kube-version 1.20.15 \
       . | tee /dev/stderr |
       yq -r '.spec.rules[0].http.paths[0].pathType' | tee /dev/stderr)
   [ "${actual}" = "ImplementationSpecific" ]
 }
 
-@test "server/ingress: pathType is not added to Kubernetes versions < 1.19" {
+@test "server/ingress: pathType is not added to Kubernetes versions < 1.21" {
   cd `chart_dir`
 
   local actual=$(helm template \
       --show-only templates/server-ingress.yaml \
       --set 'server.ingress.enabled=true' \
       --set server.ingress.pathType=ImplementationSpecific \
-      --kube-version 1.18.3 \
+      --kube-version 1.20.15 \
       . | tee /dev/stderr |
       yq -r '.spec.rules[0].http.paths[0].pathType' | tee /dev/stderr)
   [ "${actual}" = "null" ]


### PR DESCRIPTION
As `kind` no longer supports creating a k8s 1.16 cluster, we remove 1.16 from the versions tested in `.github/workflows/acceptance.yaml`, and update vault-helm's minimum support k8s version to 1.20 in README and `Chart.yaml`