### PR TITLE
feat: make injector livenessProbe and readinessProbe configurable and add configurable startupProbe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Changes:
 
 Features:
 * server: New `extraPorts` option for adding ports to the Vault server statefulset [GH-841](https://github.com/hashicorp/vault-helm/pull/841)
+* injector: Make livenessProbe and readinessProbe configurable and add configurable startupProbe [GH-852](https://github.com/hashicorp/vault-helm/pull/852)
 
 ## 0.23.0 (November 28th, 2022)
 

--- a/templates/injector-deployment.yaml
+++ b/templates/injector-deployment.yaml
@@ -130,21 +130,31 @@ spec:
               path: /health/ready
               port: {{ .Values.injector.port }}
               scheme: HTTPS
-            failureThreshold: 2
-            initialDelaySeconds: 5
-            periodSeconds: 2
-            successThreshold: 1
-            timeoutSeconds: 5
+            failureThreshold: {{ .Values.injector.livenessProbe.failureThreshold }}
+            initialDelaySeconds: {{ .Values.injector.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.injector.livenessProbe.periodSeconds }}
+            successThreshold: {{ .Values.injector.livenessProbe.successThreshold }}
+            timeoutSeconds: {{ .Values.injector.livenessProbe.timeoutSeconds }}
           readinessProbe:
             httpGet:
               path: /health/ready
               port: {{ .Values.injector.port }}
               scheme: HTTPS
-            failureThreshold: 2
-            initialDelaySeconds: 5
-            periodSeconds: 2
-            successThreshold: 1
-            timeoutSeconds: 5
+            failureThreshold: {{ .Values.injector.readinessProbe.failureThreshold }}
+            initialDelaySeconds: {{ .Values.injector.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.injector.readinessProbe.periodSeconds }}
+            successThreshold: {{ .Values.injector.readinessProbe.successThreshold }}
+            timeoutSeconds: {{ .Values.injector.readinessProbe.timeoutSeconds }}
+          startupProbe:
+            httpGet:
+              path: /health/ready
+              port: {{ .Values.injector.port }}
+              scheme: HTTPS
+            failureThreshold: {{ .Values.injector.startupProbe.failureThreshold }}
+            initialDelaySeconds: {{ .Values.injector.startupProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.injector.startupProbe.periodSeconds }}
+            successThreshold: {{ .Values.injector.startupProbe.successThreshold }}
+            timeoutSeconds: {{ .Values.injector.startupProbe.timeoutSeconds }}
 {{- if .Values.injector.certs.secretName }}
           volumeMounts:
             - name: webhook-certs

--- a/test/unit/injector-deployment.bats
+++ b/test/unit/injector-deployment.bats
@@ -275,6 +275,291 @@ load _helpers
   [ "${value}" = "auth/k8s" ]
 }
 
+@test "injector/deployment: default liveness failureThreshold" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/injector-deployment.yaml  \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.containers[0].livenessProbe.failureThreshold' | tee /dev/stderr)
+  [ "${actual}" = "2" ]
+}
+
+@test "injector/deployment: custom liveness failureThreshold" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/injector-deployment.yaml \
+      --set 'injector.livenessProbe.failureThreshold=100' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.containers[0].livenessProbe.failureThreshold' | tee /dev/stderr)
+  [ "${actual}" = "100" ]
+}
+
+@test "injector/deployment: default liveness initialDelaySeconds" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/injector-deployment.yaml  \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.containers[0].livenessProbe.initialDelaySeconds' | tee /dev/stderr)
+  [ "${actual}" = "5" ]
+}
+
+@test "injector/deployment: custom liveness initialDelaySeconds" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/injector-deployment.yaml \
+      --set 'injector.livenessProbe.initialDelaySeconds=100' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.containers[0].livenessProbe.initialDelaySeconds' | tee /dev/stderr)
+  [ "${actual}" = "100" ]
+}
+
+@test "injector/deployment: default liveness periodSeconds" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/injector-deployment.yaml  \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.containers[0].livenessProbe.periodSeconds' | tee /dev/stderr)
+  [ "${actual}" = "2" ]
+}
+
+@test "injector/deployment: custom liveness periodSeconds" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/injector-deployment.yaml \
+      --set 'injector.livenessProbe.periodSeconds=100' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.containers[0].livenessProbe.periodSeconds' | tee /dev/stderr)
+  [ "${actual}" = "100" ]
+}
+
+@test "injector/deployment: default liveness successThreshold" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/injector-deployment.yaml  \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.containers[0].livenessProbe.successThreshold' | tee /dev/stderr)
+  [ "${actual}" = "1" ]
+}
+
+@test "injector/deployment: custom liveness successThreshold" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/injector-deployment.yaml \
+      --set 'injector.livenessProbe.successThreshold=100' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.containers[0].livenessProbe.successThreshold' | tee /dev/stderr)
+  [ "${actual}" = "100" ]
+}
+
+@test "injector/deployment: default liveness timeoutSeconds" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/injector-deployment.yaml  \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.containers[0].livenessProbe.timeoutSeconds' | tee /dev/stderr)
+  [ "${actual}" = "5" ]
+}
+
+@test "injector/deployment: custom liveness timeoutSeconds" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/injector-deployment.yaml \
+      --set 'injector.livenessProbe.timeoutSeconds=100' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.containers[0].livenessProbe.timeoutSeconds' | tee /dev/stderr)
+  [ "${actual}" = "100" ]
+}
+
+@test "injector/deployment: default readiness failureThreshold" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/injector-deployment.yaml  \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.containers[0].readinessProbe.failureThreshold' | tee /dev/stderr)
+  [ "${actual}" = "2" ]
+}
+
+@test "injector/deployment: custom readiness failureThreshold" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/injector-deployment.yaml \
+      --set 'injector.readinessProbe.failureThreshold=100' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.containers[0].readinessProbe.failureThreshold' | tee /dev/stderr)
+  [ "${actual}" = "100" ]
+}
+
+@test "injector/deployment: default readiness initialDelaySeconds" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/injector-deployment.yaml  \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.containers[0].readinessProbe.initialDelaySeconds' | tee /dev/stderr)
+  [ "${actual}" = "5" ]
+}
+
+@test "injector/deployment: custom readiness initialDelaySeconds" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/injector-deployment.yaml \
+      --set 'injector.readinessProbe.initialDelaySeconds=100' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.containers[0].readinessProbe.initialDelaySeconds' | tee /dev/stderr)
+  [ "${actual}" = "100" ]
+}
+
+@test "injector/deployment: default readiness periodSeconds" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/injector-deployment.yaml  \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.containers[0].readinessProbe.periodSeconds' | tee /dev/stderr)
+  [ "${actual}" = "2" ]
+}
+
+@test "injector/deployment: custom readiness periodSeconds" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/injector-deployment.yaml \
+      --set 'injector.readinessProbe.periodSeconds=100' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.containers[0].readinessProbe.periodSeconds' | tee /dev/stderr)
+  [ "${actual}" = "100" ]
+}
+
+@test "injector/deployment: default readiness successThreshold" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/injector-deployment.yaml  \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.containers[0].readinessProbe.successThreshold' | tee /dev/stderr)
+  [ "${actual}" = "1" ]
+}
+
+@test "injector/deployment: custom readiness successThreshold" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/injector-deployment.yaml \
+      --set 'injector.readinessProbe.successThreshold=100' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.containers[0].readinessProbe.successThreshold' | tee /dev/stderr)
+  [ "${actual}" = "100" ]
+}
+
+@test "injector/deployment: default readiness timeoutSeconds" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/injector-deployment.yaml  \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.containers[0].readinessProbe.timeoutSeconds' | tee /dev/stderr)
+  [ "${actual}" = "5" ]
+}
+
+@test "injector/deployment: custom readiness timeoutSeconds" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/injector-deployment.yaml \
+      --set 'injector.readinessProbe.timeoutSeconds=100' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.containers[0].readinessProbe.timeoutSeconds' | tee /dev/stderr)
+  [ "${actual}" = "100" ]
+}
+
+@test "injector/deployment: default startup failureThreshold" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/injector-deployment.yaml  \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.containers[0].startupProbe.failureThreshold' | tee /dev/stderr)
+  [ "${actual}" = "12" ]
+}
+
+@test "injector/deployment: custom startup failureThreshold" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/injector-deployment.yaml \
+      --set 'injector.startupProbe.failureThreshold=100' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.containers[0].startupProbe.failureThreshold' | tee /dev/stderr)
+  [ "${actual}" = "100" ]
+}
+
+@test "injector/deployment: default startup initialDelaySeconds" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/injector-deployment.yaml  \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.containers[0].startupProbe.initialDelaySeconds' | tee /dev/stderr)
+  [ "${actual}" = "5" ]
+}
+
+@test "injector/deployment: custom startup initialDelaySeconds" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/injector-deployment.yaml \
+      --set 'injector.startupProbe.initialDelaySeconds=100' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.containers[0].startupProbe.initialDelaySeconds' | tee /dev/stderr)
+  [ "${actual}" = "100" ]
+}
+
+@test "injector/deployment: default startup periodSeconds" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/injector-deployment.yaml  \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.containers[0].startupProbe.periodSeconds' | tee /dev/stderr)
+  [ "${actual}" = "5" ]
+}
+
+@test "injector/deployment: custom startup periodSeconds" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/injector-deployment.yaml \
+      --set 'injector.startupProbe.periodSeconds=100' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.containers[0].startupProbe.periodSeconds' | tee /dev/stderr)
+  [ "${actual}" = "100" ]
+}
+
+@test "injector/deployment: default startup successThreshold" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/injector-deployment.yaml  \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.containers[0].startupProbe.successThreshold' | tee /dev/stderr)
+  [ "${actual}" = "1" ]
+}
+
+@test "injector/deployment: custom startup successThreshold" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/injector-deployment.yaml \
+      --set 'injector.startupProbe.successThreshold=100' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.containers[0].startupProbe.successThreshold' | tee /dev/stderr)
+  [ "${actual}" = "100" ]
+}
+
+@test "injector/deployment: default startup timeoutSeconds" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/injector-deployment.yaml  \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.containers[0].startupProbe.timeoutSeconds' | tee /dev/stderr)
+  [ "${actual}" = "5" ]
+}
+
+@test "injector/deployment: custom startup timeoutSeconds" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/injector-deployment.yaml \
+      --set 'injector.startupProbe.timeoutSeconds=100' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.containers[0].startupProbe.timeoutSeconds' | tee /dev/stderr)
+  [ "${actual}" = "100" ]
+}
+
 @test "injector/deployment: default logLevel" {
   cd `chart_dir`
   local object=$(helm template \

--- a/test/unit/injector-deployment.bats
+++ b/test/unit/injector-deployment.bats
@@ -275,289 +275,133 @@ load _helpers
   [ "${value}" = "auth/k8s" ]
 }
 
-@test "injector/deployment: default liveness failureThreshold" {
+@test "injector/deployment: default livenessProbe settings" {
   cd `chart_dir`
-  local actual=$(helm template \
+  local object=$(helm template \
       --show-only templates/injector-deployment.yaml  \
       . | tee /dev/stderr |
-      yq -r '.spec.template.spec.containers[0].livenessProbe.failureThreshold' | tee /dev/stderr)
-  [ "${actual}" = "2" ]
+      yq -r '.spec.template.spec.containers[0].livenessProbe' | tee /dev/stderr)
+
+  local actual=$(echo "$object" | yq '.failureThreshold' | tee /dev/stderr)
+    [ "${actual}" = "2" ]
+  local actual=$(echo "$object" | yq '.initialDelaySeconds' | tee /dev/stderr)
+    [ "${actual}" = "5" ]
+  local actual=$(echo "$object" | yq '.periodSeconds' | tee /dev/stderr)
+    [ "${actual}" = "2" ]
+  local actual=$(echo "$object" | yq '.successThreshold' | tee /dev/stderr)
+    [ "${actual}" = "1" ]
+  local actual=$(echo "$object" | yq '.timeoutSeconds' | tee /dev/stderr)
+    [ "${actual}" = "5" ]
 }
 
-@test "injector/deployment: custom liveness failureThreshold" {
+@test "injector/deployment: can set livenessProbe settings" {
   cd `chart_dir`
-  local actual=$(helm template \
-      --show-only templates/injector-deployment.yaml \
+  local object=$(helm template \
+      --show-only templates/injector-deployment.yaml  \
       --set 'injector.livenessProbe.failureThreshold=100' \
-      . | tee /dev/stderr |
-      yq -r '.spec.template.spec.containers[0].livenessProbe.failureThreshold' | tee /dev/stderr)
-  [ "${actual}" = "100" ]
-}
-
-@test "injector/deployment: default liveness initialDelaySeconds" {
-  cd `chart_dir`
-  local actual=$(helm template \
-      --show-only templates/injector-deployment.yaml  \
-      . | tee /dev/stderr |
-      yq -r '.spec.template.spec.containers[0].livenessProbe.initialDelaySeconds' | tee /dev/stderr)
-  [ "${actual}" = "5" ]
-}
-
-@test "injector/deployment: custom liveness initialDelaySeconds" {
-  cd `chart_dir`
-  local actual=$(helm template \
-      --show-only templates/injector-deployment.yaml \
       --set 'injector.livenessProbe.initialDelaySeconds=100' \
-      . | tee /dev/stderr |
-      yq -r '.spec.template.spec.containers[0].livenessProbe.initialDelaySeconds' | tee /dev/stderr)
-  [ "${actual}" = "100" ]
-}
-
-@test "injector/deployment: default liveness periodSeconds" {
-  cd `chart_dir`
-  local actual=$(helm template \
-      --show-only templates/injector-deployment.yaml  \
-      . | tee /dev/stderr |
-      yq -r '.spec.template.spec.containers[0].livenessProbe.periodSeconds' | tee /dev/stderr)
-  [ "${actual}" = "2" ]
-}
-
-@test "injector/deployment: custom liveness periodSeconds" {
-  cd `chart_dir`
-  local actual=$(helm template \
-      --show-only templates/injector-deployment.yaml \
       --set 'injector.livenessProbe.periodSeconds=100' \
-      . | tee /dev/stderr |
-      yq -r '.spec.template.spec.containers[0].livenessProbe.periodSeconds' | tee /dev/stderr)
-  [ "${actual}" = "100" ]
-}
-
-@test "injector/deployment: default liveness successThreshold" {
-  cd `chart_dir`
-  local actual=$(helm template \
-      --show-only templates/injector-deployment.yaml  \
-      . | tee /dev/stderr |
-      yq -r '.spec.template.spec.containers[0].livenessProbe.successThreshold' | tee /dev/stderr)
-  [ "${actual}" = "1" ]
-}
-
-@test "injector/deployment: custom liveness successThreshold" {
-  cd `chart_dir`
-  local actual=$(helm template \
-      --show-only templates/injector-deployment.yaml \
       --set 'injector.livenessProbe.successThreshold=100' \
-      . | tee /dev/stderr |
-      yq -r '.spec.template.spec.containers[0].livenessProbe.successThreshold' | tee /dev/stderr)
-  [ "${actual}" = "100" ]
-}
-
-@test "injector/deployment: default liveness timeoutSeconds" {
-  cd `chart_dir`
-  local actual=$(helm template \
-      --show-only templates/injector-deployment.yaml  \
-      . | tee /dev/stderr |
-      yq -r '.spec.template.spec.containers[0].livenessProbe.timeoutSeconds' | tee /dev/stderr)
-  [ "${actual}" = "5" ]
-}
-
-@test "injector/deployment: custom liveness timeoutSeconds" {
-  cd `chart_dir`
-  local actual=$(helm template \
-      --show-only templates/injector-deployment.yaml \
       --set 'injector.livenessProbe.timeoutSeconds=100' \
       . | tee /dev/stderr |
-      yq -r '.spec.template.spec.containers[0].livenessProbe.timeoutSeconds' | tee /dev/stderr)
-  [ "${actual}" = "100" ]
+      yq -r '.spec.template.spec.containers[0].livenessProbe' | tee /dev/stderr)
+
+  local actual=$(echo "$object" | yq '.failureThreshold' | tee /dev/stderr)
+    [ "${actual}" = "100" ]
+  local actual=$(echo "$object" | yq '.initialDelaySeconds' | tee /dev/stderr)
+    [ "${actual}" = "100" ]
+  local actual=$(echo "$object" | yq '.periodSeconds' | tee /dev/stderr)
+    [ "${actual}" = "100" ]
+  local actual=$(echo "$object" | yq '.successThreshold' | tee /dev/stderr)
+    [ "${actual}" = "100" ]
+  local actual=$(echo "$object" | yq '.timeoutSeconds' | tee /dev/stderr)
+    [ "${actual}" = "100" ]
 }
 
-@test "injector/deployment: default readiness failureThreshold" {
+@test "injector/deployment: default readinessProbe settings" {
   cd `chart_dir`
-  local actual=$(helm template \
+  local object=$(helm template \
       --show-only templates/injector-deployment.yaml  \
       . | tee /dev/stderr |
-      yq -r '.spec.template.spec.containers[0].readinessProbe.failureThreshold' | tee /dev/stderr)
-  [ "${actual}" = "2" ]
+      yq -r '.spec.template.spec.containers[0].readinessProbe' | tee /dev/stderr)
+
+  local actual=$(echo "$object" | yq '.failureThreshold' | tee /dev/stderr)
+    [ "${actual}" = "2" ]
+  local actual=$(echo "$object" | yq '.initialDelaySeconds' | tee /dev/stderr)
+    [ "${actual}" = "5" ]
+  local actual=$(echo "$object" | yq '.periodSeconds' | tee /dev/stderr)
+    [ "${actual}" = "2" ]
+  local actual=$(echo "$object" | yq '.successThreshold' | tee /dev/stderr)
+    [ "${actual}" = "1" ]
+  local actual=$(echo "$object" | yq '.timeoutSeconds' | tee /dev/stderr)
+    [ "${actual}" = "5" ]
 }
 
-@test "injector/deployment: custom readiness failureThreshold" {
+@test "injector/deployment: can set readinessProbe settings" {
   cd `chart_dir`
-  local actual=$(helm template \
-      --show-only templates/injector-deployment.yaml \
+  local object=$(helm template \
+      --show-only templates/injector-deployment.yaml  \
       --set 'injector.readinessProbe.failureThreshold=100' \
-      . | tee /dev/stderr |
-      yq -r '.spec.template.spec.containers[0].readinessProbe.failureThreshold' | tee /dev/stderr)
-  [ "${actual}" = "100" ]
-}
-
-@test "injector/deployment: default readiness initialDelaySeconds" {
-  cd `chart_dir`
-  local actual=$(helm template \
-      --show-only templates/injector-deployment.yaml  \
-      . | tee /dev/stderr |
-      yq -r '.spec.template.spec.containers[0].readinessProbe.initialDelaySeconds' | tee /dev/stderr)
-  [ "${actual}" = "5" ]
-}
-
-@test "injector/deployment: custom readiness initialDelaySeconds" {
-  cd `chart_dir`
-  local actual=$(helm template \
-      --show-only templates/injector-deployment.yaml \
       --set 'injector.readinessProbe.initialDelaySeconds=100' \
-      . | tee /dev/stderr |
-      yq -r '.spec.template.spec.containers[0].readinessProbe.initialDelaySeconds' | tee /dev/stderr)
-  [ "${actual}" = "100" ]
-}
-
-@test "injector/deployment: default readiness periodSeconds" {
-  cd `chart_dir`
-  local actual=$(helm template \
-      --show-only templates/injector-deployment.yaml  \
-      . | tee /dev/stderr |
-      yq -r '.spec.template.spec.containers[0].readinessProbe.periodSeconds' | tee /dev/stderr)
-  [ "${actual}" = "2" ]
-}
-
-@test "injector/deployment: custom readiness periodSeconds" {
-  cd `chart_dir`
-  local actual=$(helm template \
-      --show-only templates/injector-deployment.yaml \
       --set 'injector.readinessProbe.periodSeconds=100' \
-      . | tee /dev/stderr |
-      yq -r '.spec.template.spec.containers[0].readinessProbe.periodSeconds' | tee /dev/stderr)
-  [ "${actual}" = "100" ]
-}
-
-@test "injector/deployment: default readiness successThreshold" {
-  cd `chart_dir`
-  local actual=$(helm template \
-      --show-only templates/injector-deployment.yaml  \
-      . | tee /dev/stderr |
-      yq -r '.spec.template.spec.containers[0].readinessProbe.successThreshold' | tee /dev/stderr)
-  [ "${actual}" = "1" ]
-}
-
-@test "injector/deployment: custom readiness successThreshold" {
-  cd `chart_dir`
-  local actual=$(helm template \
-      --show-only templates/injector-deployment.yaml \
       --set 'injector.readinessProbe.successThreshold=100' \
-      . | tee /dev/stderr |
-      yq -r '.spec.template.spec.containers[0].readinessProbe.successThreshold' | tee /dev/stderr)
-  [ "${actual}" = "100" ]
-}
-
-@test "injector/deployment: default readiness timeoutSeconds" {
-  cd `chart_dir`
-  local actual=$(helm template \
-      --show-only templates/injector-deployment.yaml  \
-      . | tee /dev/stderr |
-      yq -r '.spec.template.spec.containers[0].readinessProbe.timeoutSeconds' | tee /dev/stderr)
-  [ "${actual}" = "5" ]
-}
-
-@test "injector/deployment: custom readiness timeoutSeconds" {
-  cd `chart_dir`
-  local actual=$(helm template \
-      --show-only templates/injector-deployment.yaml \
       --set 'injector.readinessProbe.timeoutSeconds=100' \
       . | tee /dev/stderr |
-      yq -r '.spec.template.spec.containers[0].readinessProbe.timeoutSeconds' | tee /dev/stderr)
-  [ "${actual}" = "100" ]
+      yq -r '.spec.template.spec.containers[0].readinessProbe' | tee /dev/stderr)
+
+  local actual=$(echo "$object" | yq '.failureThreshold' | tee /dev/stderr)
+    [ "${actual}" = "100" ]
+  local actual=$(echo "$object" | yq '.initialDelaySeconds' | tee /dev/stderr)
+    [ "${actual}" = "100" ]
+  local actual=$(echo "$object" | yq '.periodSeconds' | tee /dev/stderr)
+    [ "${actual}" = "100" ]
+  local actual=$(echo "$object" | yq '.successThreshold' | tee /dev/stderr)
+    [ "${actual}" = "100" ]
+  local actual=$(echo "$object" | yq '.timeoutSeconds' | tee /dev/stderr)
+    [ "${actual}" = "100" ]
 }
 
-@test "injector/deployment: default startup failureThreshold" {
+@test "injector/deployment: default startupProbe settings" {
   cd `chart_dir`
-  local actual=$(helm template \
+  local object=$(helm template \
       --show-only templates/injector-deployment.yaml  \
       . | tee /dev/stderr |
-      yq -r '.spec.template.spec.containers[0].startupProbe.failureThreshold' | tee /dev/stderr)
-  [ "${actual}" = "12" ]
+      yq -r '.spec.template.spec.containers[0].startupProbe' | tee /dev/stderr)
+
+  local actual=$(echo "$object" | yq '.failureThreshold' | tee /dev/stderr)
+    [ "${actual}" = "12" ]
+  local actual=$(echo "$object" | yq '.initialDelaySeconds' | tee /dev/stderr)
+    [ "${actual}" = "5" ]
+  local actual=$(echo "$object" | yq '.periodSeconds' | tee /dev/stderr)
+    [ "${actual}" = "5" ]
+  local actual=$(echo "$object" | yq '.successThreshold' | tee /dev/stderr)
+    [ "${actual}" = "1" ]
+  local actual=$(echo "$object" | yq '.timeoutSeconds' | tee /dev/stderr)
+    [ "${actual}" = "5" ]
 }
 
-@test "injector/deployment: custom startup failureThreshold" {
+@test "injector/deployment: can set startupProbe settings" {
   cd `chart_dir`
-  local actual=$(helm template \
-      --show-only templates/injector-deployment.yaml \
+  local object=$(helm template \
+      --show-only templates/injector-deployment.yaml  \
       --set 'injector.startupProbe.failureThreshold=100' \
-      . | tee /dev/stderr |
-      yq -r '.spec.template.spec.containers[0].startupProbe.failureThreshold' | tee /dev/stderr)
-  [ "${actual}" = "100" ]
-}
-
-@test "injector/deployment: default startup initialDelaySeconds" {
-  cd `chart_dir`
-  local actual=$(helm template \
-      --show-only templates/injector-deployment.yaml  \
-      . | tee /dev/stderr |
-      yq -r '.spec.template.spec.containers[0].startupProbe.initialDelaySeconds' | tee /dev/stderr)
-  [ "${actual}" = "5" ]
-}
-
-@test "injector/deployment: custom startup initialDelaySeconds" {
-  cd `chart_dir`
-  local actual=$(helm template \
-      --show-only templates/injector-deployment.yaml \
       --set 'injector.startupProbe.initialDelaySeconds=100' \
-      . | tee /dev/stderr |
-      yq -r '.spec.template.spec.containers[0].startupProbe.initialDelaySeconds' | tee /dev/stderr)
-  [ "${actual}" = "100" ]
-}
-
-@test "injector/deployment: default startup periodSeconds" {
-  cd `chart_dir`
-  local actual=$(helm template \
-      --show-only templates/injector-deployment.yaml  \
-      . | tee /dev/stderr |
-      yq -r '.spec.template.spec.containers[0].startupProbe.periodSeconds' | tee /dev/stderr)
-  [ "${actual}" = "5" ]
-}
-
-@test "injector/deployment: custom startup periodSeconds" {
-  cd `chart_dir`
-  local actual=$(helm template \
-      --show-only templates/injector-deployment.yaml \
       --set 'injector.startupProbe.periodSeconds=100' \
-      . | tee /dev/stderr |
-      yq -r '.spec.template.spec.containers[0].startupProbe.periodSeconds' | tee /dev/stderr)
-  [ "${actual}" = "100" ]
-}
-
-@test "injector/deployment: default startup successThreshold" {
-  cd `chart_dir`
-  local actual=$(helm template \
-      --show-only templates/injector-deployment.yaml  \
-      . | tee /dev/stderr |
-      yq -r '.spec.template.spec.containers[0].startupProbe.successThreshold' | tee /dev/stderr)
-  [ "${actual}" = "1" ]
-}
-
-@test "injector/deployment: custom startup successThreshold" {
-  cd `chart_dir`
-  local actual=$(helm template \
-      --show-only templates/injector-deployment.yaml \
       --set 'injector.startupProbe.successThreshold=100' \
-      . | tee /dev/stderr |
-      yq -r '.spec.template.spec.containers[0].startupProbe.successThreshold' | tee /dev/stderr)
-  [ "${actual}" = "100" ]
-}
-
-@test "injector/deployment: default startup timeoutSeconds" {
-  cd `chart_dir`
-  local actual=$(helm template \
-      --show-only templates/injector-deployment.yaml  \
-      . | tee /dev/stderr |
-      yq -r '.spec.template.spec.containers[0].startupProbe.timeoutSeconds' | tee /dev/stderr)
-  [ "${actual}" = "5" ]
-}
-
-@test "injector/deployment: custom startup timeoutSeconds" {
-  cd `chart_dir`
-  local actual=$(helm template \
-      --show-only templates/injector-deployment.yaml \
       --set 'injector.startupProbe.timeoutSeconds=100' \
       . | tee /dev/stderr |
-      yq -r '.spec.template.spec.containers[0].startupProbe.timeoutSeconds' | tee /dev/stderr)
-  [ "${actual}" = "100" ]
+      yq -r '.spec.template.spec.containers[0].startupProbe' | tee /dev/stderr)
+
+  local actual=$(echo "$object" | yq '.failureThreshold' | tee /dev/stderr)
+    [ "${actual}" = "100" ]
+  local actual=$(echo "$object" | yq '.initialDelaySeconds' | tee /dev/stderr)
+    [ "${actual}" = "100" ]
+  local actual=$(echo "$object" | yq '.periodSeconds' | tee /dev/stderr)
+    [ "${actual}" = "100" ]
+  local actual=$(echo "$object" | yq '.successThreshold' | tee /dev/stderr)
+    [ "${actual}" = "100" ]
+  local actual=$(echo "$object" | yq '.timeoutSeconds' | tee /dev/stderr)
+    [ "${actual}" = "100" ]
 }
 
 @test "injector/deployment: default logLevel" {

--- a/values.yaml
+++ b/values.yaml
@@ -93,6 +93,42 @@ injector:
       exitOnRetryFailure: true
       staticSecretRenderInterval: ""
 
+  # Used to enable a livenessProbe for the pods
+  livenessProbe:
+    # When a probe fails, Kubernetes will try failureThreshold times before giving up
+    failureThreshold: 2
+    # Number of seconds after the container has started before probe initiates
+    initialDelaySeconds: 5
+    # How often (in seconds) to perform the probe
+    periodSeconds: 2
+    # Minimum consecutive successes for the probe to be considered successful after having failed
+    successThreshold: 1
+    # Number of seconds after which the probe times out.
+    timeoutSeconds: 5
+  # Used to define custom readinessProbe settings
+  readinessProbe:
+    # When a probe fails, Kubernetes will try failureThreshold times before giving up
+    failureThreshold: 2
+    # Number of seconds after the container has started before probe initiates
+    initialDelaySeconds: 5
+    # How often (in seconds) to perform the probe
+    periodSeconds: 2
+    # Minimum consecutive successes for the probe to be considered successful after having failed
+    successThreshold: 1
+    # Number of seconds after which the probe times out.
+    timeoutSeconds: 5
+  # Used to define custom startupProbe settings
+  startupProbe:
+    # When a probe fails, Kubernetes will try failureThreshold times before giving up
+    failureThreshold: 12
+    # Number of seconds after the container has started before probe initiates
+    initialDelaySeconds: 5
+    # How often (in seconds) to perform the probe
+    periodSeconds: 5
+    # Minimum consecutive successes for the probe to be considered successful after having failed
+    successThreshold: 1
+    # Number of seconds after which the probe times out.
+    timeoutSeconds: 5
   # Mount Path of the Vault Kubernetes Auth Method.
   authPath: "auth/kubernetes"
 

--- a/values.yaml
+++ b/values.yaml
@@ -93,7 +93,7 @@ injector:
       exitOnRetryFailure: true
       staticSecretRenderInterval: ""
 
-  # Used to enable a livenessProbe for the pods
+  # Used to define custom livenessProbe settings
   livenessProbe:
     # When a probe fails, Kubernetes will try failureThreshold times before giving up
     failureThreshold: 2
@@ -129,7 +129,7 @@ injector:
     successThreshold: 1
     # Number of seconds after which the probe times out.
     timeoutSeconds: 5
-    
+
   # Mount Path of the Vault Kubernetes Auth Method.
   authPath: "auth/kubernetes"
 

--- a/values.yaml
+++ b/values.yaml
@@ -129,6 +129,7 @@ injector:
     successThreshold: 1
     # Number of seconds after which the probe times out.
     timeoutSeconds: 5
+    
   # Mount Path of the Vault Kubernetes Auth Method.
   authPath: "auth/kubernetes"
 


### PR DESCRIPTION
* startupProbe default is based on https://github.com/hashicorp/vault-k8s/issues/388#issuecomment-1274154311
* add injector deployment tests to test default and custom livenessProbe, readinessProbe, and startupProbe