### PR TITLE
Convert hashicorp/vault-helm to GitHub Actions

### DIFF
--- a/.github/workflows/manual-trigger-update-helm-charts-index.yml
+++ b/.github/workflows/manual-trigger-update-helm-charts-index.yml
@@ -1,0 +1,44 @@
+name: hashicorp/vault-helm/manual-trigger-update-helm-charts-index
+on:
+  workflow_dispatch:
+    inputs:
+      release-tag:
+        required: true
+        description: The tag to release, including v, e.g. v0.22.1
+jobs:
+  update-helm-charts-index:
+    if: ${{ inputs.release-tag }}
+    runs-on: ubuntu-latest
+    container:
+      image: docker.mirror.hashicorp.services/cimg/go:1.19.2
+    steps:
+    - uses: actions/checkout@v3.4.0
+    - name: verify Chart version matches tag version
+      run: |-
+        go install github.com/mikefarah/yq/v2@latest
+        export TAG=${RELEASE_TAG:-${{ github.ref }}}
+        git_tag=$(echo "${TAG#v}")
+        chart_tag=$(yq r Chart.yaml version)
+        if [ "${git_tag}" != "${chart_tag}" ]; then
+          echo "chart version (${chart_tag}) did not match git version (${git_tag})"
+          exit 1
+        fi
+      env:
+        RELEASE_TAG: "${{ inputs.release-tag }}"
+    - name: install gh tool
+      run: |-
+        version="2.22.1"
+        curl --show-error --silent --location --output "gh.tar.gz" "https://github.com/cli/cli/releases/download/v${version}/gh_${version}_linux_amd64.tar.gz"
+        tar -xvzf gh.tar.gz && mkdir -p bin && mv "gh_${version}_linux_amd64/bin/gh" bin/
+    - name: update helm-charts index
+      run: |-
+        export GITHUB_TOKEN="${HELM_CHARTS_GITHUB_TOKEN}"
+        ./bin/gh workflow run publish-charts.yml \
+          --repo hashicorp/helm-charts \
+          --ref main \
+          -f SOURCE_TAG="${{ github.ref }}" \
+          -f SOURCE_REPO="${CIRCLE_PROJECT_USERNAME}/${{ github.repository }}"
+      env:
+        RELEASE_TAG: "${{ inputs.release-tag }}"
+#     # This item has no matching transformer
+#     - circleci_slack_status:

--- a/.github/workflows/update-helm-charts-index.yml
+++ b/.github/workflows/update-helm-charts-index.yml
@@ -1,0 +1,45 @@
+name: hashicorp/vault-helm/update-helm-charts-index
+on:
+  workflow_dispatch:
+    inputs:
+      release-tag:
+        required: true
+        description: The tag to release, including v, e.g. v0.22.1
+jobs:
+  update-helm-charts-index:
+    if: # GitHub does not currently support regular expressions inside if conditions
+#         (github.ref == 'refs/tags//^v.*/') && (github.ref != 'refs/heads//.*/')
+    runs-on: ubuntu-latest
+    container:
+      image: docker.mirror.hashicorp.services/cimg/go:1.19.2
+    steps:
+    - uses: actions/checkout@v3.4.0
+    - name: verify Chart version matches tag version
+      run: |-
+        go install github.com/mikefarah/yq/v2@latest
+        export TAG=${RELEASE_TAG:-${{ github.ref }}}
+        git_tag=$(echo "${TAG#v}")
+        chart_tag=$(yq r Chart.yaml version)
+        if [ "${git_tag}" != "${chart_tag}" ]; then
+          echo "chart version (${chart_tag}) did not match git version (${git_tag})"
+          exit 1
+        fi
+      env:
+        RELEASE_TAG: "${{ inputs.release-tag }}"
+    - name: install gh tool
+      run: |-
+        version="2.22.1"
+        curl --show-error --silent --location --output "gh.tar.gz" "https://github.com/cli/cli/releases/download/v${version}/gh_${version}_linux_amd64.tar.gz"
+        tar -xvzf gh.tar.gz && mkdir -p bin && mv "gh_${version}_linux_amd64/bin/gh" bin/
+    - name: update helm-charts index
+      run: |-
+        export GITHUB_TOKEN="${HELM_CHARTS_GITHUB_TOKEN}"
+        ./bin/gh workflow run publish-charts.yml \
+          --repo hashicorp/helm-charts \
+          --ref main \
+          -f SOURCE_TAG="${{ github.ref }}" \
+          -f SOURCE_REPO="${CIRCLE_PROJECT_USERNAME}/${{ github.repository }}"
+      env:
+        RELEASE_TAG: "${{ inputs.release-tag }}"
+#     # This item has no matching transformer
+#     - circleci_slack_status:


### PR DESCRIPTION
Pipeline migrated from [CircleCI](https://app.circleci.com/pipelines/github/hashicorp/vault-helm) :tada: