### PR TITLE
Updating GHA and default Vault version

### DIFF
--- a/.github/workflows/acceptance.yaml
+++ b/.github/workflows/acceptance.yaml
@@ -7,19 +7,19 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        kind-k8s-version: [1.20.15, 1.21.14, 1.22.15, 1.23.12, 1.24.6, 1.25.3]
+        kind-k8s-version: [1.22.17, 1.23.17, 1.24.12, 1.25.8, 1.26.3]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
       - name: Setup test tools
         uses: ./.github/workflows/setup-test-tools
 
       - name: Create K8s Kind Cluster
-        uses: helm/kind-action@v1.4.0
+        uses: helm/kind-action@d8ccf8fb623ce1bb360ae2f45f323d9d5c5e9f00 # v1.5.0
         with:
           config: test/kind/config.yaml
           node_image: kindest/node:v${{ matrix.kind-k8s-version }}
-          version: v0.16.0
+          version: v0.17.0
 
       - run: bats --tap --timing ./test/acceptance
         env:

--- a/.github/workflows/jira.yaml
+++ b/.github/workflows/jira.yaml
@@ -1,3 +1,4 @@
+name: Jira Sync
 on:
   issues:
     types: [opened, closed, deleted, reopened]
@@ -5,68 +6,12 @@ on:
     types: [opened, closed, reopened]
   issue_comment: # Also triggers when commenting on a PR from the conversation view
     types: [created]
-
-name: Jira Sync
-
 jobs:
   sync:
-    runs-on: ubuntu-latest
-    name: Jira sync
-    steps:
-    - name: Login
-      uses: atlassian/gajira-login@v2.0.0
-      env:
-        JIRA_BASE_URL: ${{ secrets.JIRA_SYNC_BASE_URL }}
-        JIRA_USER_EMAIL: ${{ secrets.JIRA_SYNC_USER_EMAIL }}
-        JIRA_API_TOKEN: ${{ secrets.JIRA_SYNC_API_TOKEN }}
-
-    - name: Preprocess
-      if: github.event.action == 'opened' || github.event.action == 'created'
-      id: preprocess
-      run: |
-        if [[ "${{ github.event_name }}" == "pull_request_target" ]]; then
-          echo "::set-output name=type::PR"
-        else
-          echo "::set-output name=type::ISS"
-        fi
-
-    - name: Create ticket
-      if: github.event.action == 'opened'
-      uses: tomhjp/gh-action-jira-create@v0.2.0
-      with:
-        project: VAULT
-        issuetype: "GH Issue"
-        summary: "${{ github.event.repository.name }} [${{ steps.preprocess.outputs.type }} #${{ github.event.issue.number || github.event.pull_request.number }}]: ${{ github.event.issue.title || github.event.pull_request.title }}"
-        description: "${{ github.event.issue.body || github.event.pull_request.body }}\n\n_Created from GitHub Action for ${{ github.event.issue.html_url || github.event.pull_request.html_url }} from ${{ github.actor }}_"
-        # customfield_10089 is Issue Link custom field
-        # customfield_10091 is team custom field
-        extraFields: '{"fixVersions": [{"name": "TBD"}], "customfield_10091": ["ecosystem", "foundations"], "customfield_10089": "${{ github.event.issue.html_url || github.event.pull_request.html_url }}"}'
-
-    - name: Search
-      if: github.event.action != 'opened'
-      id: search
-      uses: tomhjp/gh-action-jira-search@v0.2.1
-      with:
-        # cf[10089] is Issue Link custom field
-        jql: 'project = "VAULT" and cf[10089]="${{ github.event.issue.html_url || github.event.pull_request.html_url }}"'
-
-    - name: Sync comment
-      if: github.event.action == 'created' && steps.search.outputs.issue
-      uses: tomhjp/gh-action-jira-comment@v0.2.0
-      with:
-        issue: ${{ steps.search.outputs.issue }}
-        comment: "${{ github.actor }} ${{ github.event.review.state || 'commented' }}:\n\n${{ github.event.comment.body || github.event.review.body }}\n\n${{ github.event.comment.html_url || github.event.review.html_url }}"
-
-    - name: Close ticket
-      if: (github.event.action == 'closed' || github.event.action == 'deleted') && steps.search.outputs.issue
-      uses: atlassian/gajira-transition@v2.0.1
-      with:
-        issue: ${{ steps.search.outputs.issue }}
-        transition: Closed
-
-    - name: Reopen ticket
-      if: github.event.action == 'reopened' && steps.search.outputs.issue
-      uses: atlassian/gajira-transition@v2.0.1
-      with:
-        issue: ${{ steps.search.outputs.issue }}
-        transition: "Pending Triage"
+    uses: hashicorp/vault-workflows-common/.github/workflows/jira.yaml@main
+    secrets:
+      JIRA_SYNC_BASE_URL: ${{ secrets.JIRA_SYNC_BASE_URL }}
+      JIRA_SYNC_USER_EMAIL: ${{ secrets.JIRA_SYNC_USER_EMAIL }}
+      JIRA_SYNC_API_TOKEN: ${{ secrets.JIRA_SYNC_API_TOKEN }}
+    with:
+      teams-array: '["ecosystem", "foundations"]'

--- a/.github/workflows/setup-test-tools/action.yaml
+++ b/.github/workflows/setup-test-tools/action.yaml
@@ -4,7 +4,7 @@ description: Install bats and python-yq
 runs:
   using: "composite"
   steps:
-    - uses: actions/setup-node@v2
+    - uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c # v3.6.0
       with:
         node-version: '16'
     - run: npm install -g bats@${BATS_VERSION}
@@ -13,7 +13,7 @@ runs:
         BATS_VERSION: '1.8.2'
     - run: bats -v
       shell: bash
-    - uses: actions/setup-python@v4
+    - uses: actions/setup-python@d27e3f3d7c64b4bbf8e4abfb9b63b83e846e0435 # v4.5.0
       with:
         python-version: '3.10'
     - run: pip install yq

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -6,7 +6,7 @@ jobs:
   bats-unit-tests:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
       - uses: ./.github/workflows/setup-test-tools
       - run: bats --tap --timing ./test/unit
 
@@ -15,10 +15,10 @@ jobs:
     env:
       CHART_VERIFIER_VERSION: '1.2.1'
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
       - name: Setup test tools
         uses: ./.github/workflows/setup-test-tools
-      - uses: actions/setup-go@v3
+      - uses: actions/setup-go@6edd4406fa81c3da01a34fa6f6343087c207a568 # v3.5.0
         with:
           go-version: '1.19.2'
       - run: go install github.com/redhat-certification/chart-verifier@${CHART_VERIFIER_VERSION}

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -13,7 +13,7 @@ jobs:
   chart-verifier:
     runs-on: ubuntu-latest
     env:
-      CHART_VERIFIER_VERSION: '1.2.1'
+      CHART_VERIFIER_VERSION: '1.10.1'
     steps:
       - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
       - name: Setup test tools

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 ## Unreleased
 
 Changes:
-* Earliest Kubernetes version tested is now 1.20
+* Earliest Kubernetes version tested is now 1.22
+* `vault` updated to 1.13.1
 
 Features:
 * server: New `extraPorts` option for adding ports to the Vault server statefulset [GH-841](https://github.com/hashicorp/vault-helm/pull/841)

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -5,7 +5,7 @@ apiVersion: v2
 name: vault
 version: 0.23.0
 appVersion: 1.12.1
-kubeVersion: ">= 1.20.0-0"
+kubeVersion: ">= 1.22.0-0"
 description: Official HashiCorp Vault Chart
 home: https://www.vaultproject.io
 icon: https://github.com/hashicorp/vault/raw/f22d202cde2018f9455dec755118a9b84586e082/Vault_PrimaryLogo_Black.png

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -15,3 +15,5 @@ sources:
   - https://github.com/hashicorp/vault-helm
   - https://github.com/hashicorp/vault-k8s
   - https://github.com/hashicorp/vault-csi-provider
+annotations:
+  charts.openshift.io/name: HashiCorp Vault

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -4,7 +4,7 @@
 apiVersion: v2
 name: vault
 version: 0.23.0
-appVersion: 1.12.1
+appVersion: 1.13.1
 kubeVersion: ">= 1.22.0-0"
 description: Official HashiCorp Vault Chart
 home: https://www.vaultproject.io

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ LOCAL_ACCEPTANCE_TESTS?=false
 KIND_CLUSTER_NAME?=vault-helm
 
 # kind k8s version
-KIND_K8S_VERSION?=v1.25.0
+KIND_K8S_VERSION?=v1.26.3
 
 # Generate json schema for chart values. See test/README.md for more details.
 values-schema:

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ this README. Please refer to the Kubernetes and Helm documentation.
 The versions required are:
 
   * **Helm 3.6+**
-  * **Kubernetes 1.20+** - This is the earliest version of Kubernetes tested.
+  * **Kubernetes 1.22+** - This is the earliest version of Kubernetes tested.
     It is possible that this chart works with earlier versions but it is
     untested.
 

--- a/templates/injector-disruptionbudget.yaml
+++ b/templates/injector-disruptionbudget.yaml
@@ -4,7 +4,7 @@ SPDX-License-Identifier: MPL-2.0
 */}}
 
 {{- if .Values.injector.podDisruptionBudget }}
-apiVersion: {{ ge .Capabilities.KubeVersion.Minor "21" | ternary "policy/v1" "policy/v1beta1" }}
+apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: {{ template "vault.fullname" . }}-agent-injector

--- a/templates/server-disruptionbudget.yaml
+++ b/templates/server-disruptionbudget.yaml
@@ -9,7 +9,7 @@ SPDX-License-Identifier: MPL-2.0
 {{- if and (eq .mode "ha") (eq (.Values.server.ha.disruptionBudget.enabled | toString) "true") -}}
 # PodDisruptionBudget to prevent degrading the server cluster through
 # voluntary cluster changes.
-apiVersion: {{ ge .Capabilities.KubeVersion.Minor "21" | ternary "policy/v1" "policy/v1beta1" }}
+apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: {{ template "vault.fullname" . }}

--- a/templates/server-ingress.yaml
+++ b/templates/server-ingress.yaml
@@ -17,13 +17,7 @@ SPDX-License-Identifier: MPL-2.0
 {{- $servicePort := .Values.server.service.port -}}
 {{- $pathType := .Values.server.ingress.pathType -}}
 {{- $kubeVersion := .Capabilities.KubeVersion.Version }}
-{{ if semverCompare ">= 1.19.0-0" $kubeVersion }}
 apiVersion: networking.k8s.io/v1
-{{ else if .Capabilities.APIVersions.Has "networking.k8s.io/v1beta1" }}
-apiVersion: networking.k8s.io/v1beta1
-{{ else }}
-apiVersion: extensions/v1beta1
-{{ end }}
 kind: Ingress
 metadata:
   name: {{ template "vault.fullname" . }}

--- a/test/acceptance/server-ha-enterprise-dr.bats
+++ b/test/acceptance/server-ha-enterprise-dr.bats
@@ -7,7 +7,7 @@ load _helpers
 
   helm install "$(name_prefix)-east" \
     --set='server.image.repository=hashicorp/vault-enterprise' \
-    --set='server.image.tag=1.12.1-ent' \
+    --set='server.image.tag=1.13.1-ent' \
     --set='injector.enabled=false' \
     --set='server.ha.enabled=true' \
     --set='server.ha.raft.enabled=true' \
@@ -75,7 +75,7 @@ load _helpers
   helm install "$(name_prefix)-west" \
     --set='injector.enabled=false' \
     --set='server.image.repository=hashicorp/vault-enterprise' \
-    --set='server.image.tag=1.12.1-ent' \
+    --set='server.image.tag=1.13.1-ent' \
     --set='server.ha.enabled=true' \
     --set='server.ha.raft.enabled=true' \
     --set='server.enterpriseLicense.secretName=vault-license' .

--- a/test/acceptance/server-ha-enterprise-perf.bats
+++ b/test/acceptance/server-ha-enterprise-perf.bats
@@ -8,7 +8,7 @@ load _helpers
   helm install "$(name_prefix)-east" \
     --set='injector.enabled=false' \
     --set='server.image.repository=hashicorp/vault-enterprise' \
-    --set='server.image.tag=1.12.1-ent' \
+    --set='server.image.tag=1.13.1-ent' \
     --set='server.ha.enabled=true' \
     --set='server.ha.raft.enabled=true' \
     --set='server.enterpriseLicense.secretName=vault-license' .
@@ -75,7 +75,7 @@ load _helpers
   helm install "$(name_prefix)-west" \
     --set='injector.enabled=false' \
     --set='server.image.repository=hashicorp/vault-enterprise' \
-    --set='server.image.tag=1.12.1-ent' \
+    --set='server.image.tag=1.13.1-ent' \
     --set='server.ha.enabled=true' \
     --set='server.ha.raft.enabled=true' \
     --set='server.enterpriseLicense.secretName=vault-license' .

--- a/test/chart/verifier.bats
+++ b/test/chart/verifier.bats
@@ -6,9 +6,9 @@ setup_file() {
     cd `chart_dir`
     export VERIFY_OUTPUT="/$BATS_RUN_TMPDIR/verify.json"
     export CHART_VOLUME=vault-helm-chart-src
-    local IMAGE="quay.io/redhat-certification/chart-verifier:1.2.1"
+    local IMAGE="quay.io/redhat-certification/chart-verifier:1.10.1"
     # chart-verifier requires an openshift version if a cluster isn't available
-    local OPENSHIFT_VERSION="4.8"
+    local OPENSHIFT_VERSION="4.12"
     local DISABLED_TESTS="chart-testing"
 
     local run_cmd="chart-verifier"
@@ -40,7 +40,7 @@ teardown_file() {
 }
 
 @test "has-kubeversion" {
-    check_result v1.0/has-kubeversion
+    check_result v1.1/has-kubeversion
 }
 
 @test "is-helm-v3" {
@@ -76,10 +76,19 @@ teardown_file() {
 }
 
 @test "images-are-certified" {
-    check_result v1.0/images-are-certified
+    check_result v1.1/images-are-certified
+}
+
+@test "required-annotations-present" {
+    check_result v1.0/required-annotations-present
 }
 
 @test "chart-testing" {
     skip "Skipping since this test requires a kubernetes/openshift cluster"
     check_result v1.0/chart-testing
+}
+
+@test "signature-is-valid" {
+    skip "Chart is not signed : Signature verification not required"
+    check_result v1.0/signature-is-valid
 }

--- a/test/unit/injector-disruptionbudget.bats
+++ b/test/unit/injector-disruptionbudget.bats
@@ -31,18 +31,7 @@ load _helpers
   [ "${actual}" = "true" ]
 }
 
-@test "injector/DisruptionBudget: test is apiVersion is set correctly < version 1.21 of kube" {
-  cd `chart_dir`
-  local actual=$(helm template \
-      --show-only templates/injector-disruptionbudget.yaml \
-      --set 'injector.podDisruptionBudget.minAvailable=2' \
-      --kube-version 1.20.15 \
-      . | tee /dev/stderr |
-      yq '.apiVersion == "policy/v1beta1"' | tee /dev/stderr)
-  [ "${actual}" = "true" ]
-}
-
-@test "injector/DisruptionBudget: test is apiVersion is set correctly >= version 1.21 of kube" {
+@test "injector/DisruptionBudget: apiVersion is set correctly >= version 1.21 of kube" {
   cd `chart_dir`
   local actual=$(helm template \
       --show-only templates/injector-disruptionbudget.yaml \

--- a/test/unit/server-ha-disruptionbudget.bats
+++ b/test/unit/server-ha-disruptionbudget.bats
@@ -98,19 +98,7 @@ load _helpers
   [ "${actual}" = "2" ]
 }
 
-@test "server/DisruptionBudget: test is apiVersion is set correctly < version 1.21 of kube" {
-  cd `chart_dir`
-  local actual=$(helm template \
-      --show-only templates/server-disruptionbudget.yaml \
-      --set 'server.ha.enabled=true' \
-      --set 'server.ha.replicas=1' \
-      --kube-version 1.20.15 \
-      . | tee /dev/stderr |
-      yq '.apiVersion == "policy/v1beta1"' | tee /dev/stderr)
-  [ "${actual}" = "true" ]
-}
-
-@test "server/DisruptionBudget: test is apiVersion is set correctly >= version 1.21 of kube" {
+@test "server/DisruptionBudget: apiVersion is set correctly >= version 1.21 of kube" {
   cd `chart_dir`
   local actual=$(helm template \
       --show-only templates/server-disruptionbudget.yaml \

--- a/test/unit/server-ingress.bats
+++ b/test/unit/server-ingress.bats
@@ -197,7 +197,7 @@ load _helpers
   [ "${actual}" = "release-name-vault" ]
 }
 
-@test "server/ingress: k8s 1.20.15 uses correct service format when not ha - yaml" {
+@test "server/ingress: k8s 1.26.3 uses correct service format when not ha - yaml" {
   cd `chart_dir`
 
   local actual=$(helm template \
@@ -206,7 +206,7 @@ load _helpers
       --set 'server.dev.enabled=false' \
       --set 'server.ha.enabled=false' \
       --set 'server.service.enabled=true' \
-      --kube-version 1.20.15 \
+      --kube-version 1.26.3 \
       . | tee /dev/stderr |
       yq -r '.spec.rules[0].http.paths[0].backend.service.name' | tee /dev/stderr)
   [ "${actual}" = "release-name-vault" ]
@@ -227,14 +227,14 @@ load _helpers
   [ "${actual}" = "release-name-vault" ]
 }
 
-@test "server/ingress: pathType is added to Kubernetes version == 1.20.15" {
+@test "server/ingress: pathType is added to Kubernetes version == 1.26.3" {
   cd `chart_dir`
 
   local actual=$(helm template \
       --show-only templates/server-ingress.yaml \
       --set 'server.ingress.enabled=true' \
       --set server.ingress.pathType=ImplementationSpecific \
-      --kube-version 1.20.15 \
+      --kube-version 1.26.3 \
       . | tee /dev/stderr |
       yq -r '.spec.rules[0].http.paths[0].pathType' | tee /dev/stderr)
   [ "${actual}" = "ImplementationSpecific" ]
@@ -247,7 +247,7 @@ load _helpers
       --show-only templates/server-ingress.yaml \
       --set 'server.ingress.enabled=true' \
       --set server.ingress.pathType=Prefix \
-      --kube-version 1.20.0 \
+      --kube-version 1.26.3 \
       . | tee /dev/stderr |
       yq -r '.spec.rules[0].http.paths[0].pathType' | tee /dev/stderr)
   [ "${actual}" = "Prefix" ]

--- a/values.openshift.yaml
+++ b/values.openshift.yaml
@@ -13,9 +13,9 @@ injector:
 
   agentImage:
     repository: "registry.connect.redhat.com/hashicorp/vault"
-    tag: "1.12.1-ubi"
+    tag: "1.13.1-ubi"
 
 server:
   image:
     repository: "registry.connect.redhat.com/hashicorp/vault"
-    tag: "1.12.1-ubi"
+    tag: "1.13.1-ubi"

--- a/values.yaml
+++ b/values.yaml
@@ -73,7 +73,7 @@ injector:
   # required.
   agentImage:
     repository: "hashicorp/vault"
-    tag: "1.12.1"
+    tag: "1.13.1"
 
   # The default values for the injected Vault Agent containers.
   agentDefaults:
@@ -372,7 +372,7 @@ server:
 
   image:
     repository: "hashicorp/vault"
-    tag: "1.12.1"
+    tag: "1.13.1"
     # Overrides the default Image Pull Policy
     pullPolicy: IfNotPresent
 


### PR DESCRIPTION
Test with [latest kind k8s versions](https://hub.docker.com/r/kindest/node/tags) 1.22-1.26. Remove support for old disruptionbudget and ingress APIs (pre 1.22). 

Pin all actions to SHAs, and use the common jira sync.

Update the default Vault version to v1.13.1. 

Update chart-verifier used in tests to 1.10.1, also add an openshift name annotation to Chart.yaml (one of the required checks).