### PR TITLE
Prepare for 0.24.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+## 0.24.0 (April 6, 2023)
+
 Changes:
 * Earliest Kubernetes version tested is now 1.22
 * `vault` updated to 1.13.1

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -3,7 +3,7 @@
 
 apiVersion: v2
 name: vault
-version: 0.23.0
+version: 0.24.0
 appVersion: 1.13.1
 kubeVersion: ">= 1.22.0-0"
 description: Official HashiCorp Vault Chart

--- a/test/acceptance/csi.bats
+++ b/test/acceptance/csi.bats
@@ -14,7 +14,7 @@ load _helpers
   CSI_DRIVER_VERSION=1.3.2
   helm install secrets-store-csi-driver secrets-store-csi-driver \
     --repo https://kubernetes-sigs.github.io/secrets-store-csi-driver/charts \
-    --version=$(CSI_DRIVER_VERSION) \
+    --version=$CSI_DRIVER_VERSION \
     --wait --timeout=5m \
     --namespace=acceptance \
     --set linux.image.pullPolicy="IfNotPresent" \

--- a/values.openshift.yaml
+++ b/values.openshift.yaml
@@ -9,7 +9,7 @@ global:
 injector:
   image:
     repository: "registry.connect.redhat.com/hashicorp/vault-k8s"
-    tag: "1.1.0-ubi"
+    tag: "1.2.1-ubi"
 
   agentImage:
     repository: "registry.connect.redhat.com/hashicorp/vault"

--- a/values.yaml
+++ b/values.yaml
@@ -65,7 +65,7 @@ injector:
   # image sets the repo and tag of the vault-k8s image to use for the injector.
   image:
     repository: "hashicorp/vault-k8s"
-    tag: "1.1.0"
+    tag: "1.2.1"
     pullPolicy: IfNotPresent
 
   # agentImage sets the repo and tag of the Vault image to use for the Vault Agent


### PR DESCRIPTION
## 0.24.0 (April 6, 2023)

Changes:
* Earliest Kubernetes version tested is now 1.22
* `vault` updated to 1.13.1

Features:
* server: New `extraPorts` option for adding ports to the Vault server statefulset [GH-841](https://github.com/hashicorp/vault-helm/pull/841)
* server: Add configurable Port Number in readinessProbe and livenessProbe for the server-statefulset [GH-831](https://github.com/hashicorp/vault-helm/pull/831)
* injector: Make livenessProbe and readinessProbe configurable and add configurable startupProbe [GH-852](https://github.com/hashicorp/vault-helm/pull/852)
* csi: Add an Agent sidecar to Vault CSI Provider pods to provide lease caching and renewals [GH-749](https://github.com/hashicorp/vault-helm/pull/749)