### PR TITLE
Add role for creating CSI's HMAC secret key

### DIFF
--- a/templates/csi-daemonset.yaml
+++ b/templates/csi-daemonset.yaml
@@ -54,6 +54,11 @@ spec:
           args:
             - --endpoint=/provider/vault.sock
             - --debug={{ .Values.csi.debug }}
+            {{- if (eq .Values.csi.hmacSecretName "") }}
+            - --hmac-secret-name={{- include "vault.name" . }}-csi-provider-hmac-key
+            {{- else }}
+            - --hmac-secret-name={{ .Values.csi.hmacSecretName }}
+            {{- end }}
             {{- if .Values.csi.extraArgs }}
             {{- toYaml .Values.csi.extraArgs | nindent 12 }}
             {{- end }}

--- a/templates/csi-daemonset.yaml
+++ b/templates/csi-daemonset.yaml
@@ -54,10 +54,10 @@ spec:
           args:
             - --endpoint=/provider/vault.sock
             - --debug={{ .Values.csi.debug }}
-            {{- if (eq .Values.csi.hmacSecretName "") }}
-            - --hmac-secret-name={{- include "vault.name" . }}-csi-provider-hmac-key
-            {{- else }}
+            {{- if .Values.csi.hmacSecretName }}
             - --hmac-secret-name={{ .Values.csi.hmacSecretName }}
+            {{- else }}
+            - --hmac-secret-name={{- include "vault.name" . }}-csi-provider-hmac-key
             {{- end }}
             {{- if .Values.csi.extraArgs }}
             {{- toYaml .Values.csi.extraArgs | nindent 12 }}

--- a/templates/csi-role.yaml
+++ b/templates/csi-role.yaml
@@ -18,10 +18,10 @@ rules:
   resources: ["secrets"]
   verbs: ["get"]
   resourceNames:
-    {{- if (eq .Values.csi.hmacSecretName "") }}
-    - {{ include "vault.name" . }}-csi-provider-hmac-key
-    {{- else }}
+    {{- if .Values.csi.hmacSecretName }}
     - {{ .Values.csi.hmacSecretName }}
+    {{- else }}
+    - {{ include "vault.name" . }}-csi-provider-hmac-key
     {{- end }}
 # 'create' permissions cannot be restricted by resource name:
 # https://kubernetes.io/docs/reference/access-authn-authz/rbac/#referring-to-resources

--- a/templates/csi-role.yaml
+++ b/templates/csi-role.yaml
@@ -1,0 +1,31 @@
+{{/*
+Copyright (c) HashiCorp, Inc.
+SPDX-License-Identifier: MPL-2.0
+*/}}
+
+{{- template "vault.csiEnabled" . -}}
+{{- if .csiEnabled -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ template "vault.fullname" . }}-csi-provider-role
+  labels:
+    app.kubernetes.io/name: {{ include "vault.name" . }}-csi-provider
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+rules:
+- apiGroups: [""]
+  resources: ["secrets"]
+  verbs: ["get"]
+  resourceNames:
+    {{- if (eq .Values.csi.hmacSecretName "") }}
+    - {{ include "vault.name" . }}-csi-provider-hmac-key
+    {{- else }}
+    - {{ .Values.csi.hmacSecretName }}
+    {{- end }}
+# 'create' permissions cannot be restricted by resource name:
+# https://kubernetes.io/docs/reference/access-authn-authz/rbac/#referring-to-resources
+- apiGroups: [""]
+  resources: ["secrets"]
+  verbs: ["create"]
+{{- end }}

--- a/templates/csi-rolebinding.yaml
+++ b/templates/csi-rolebinding.yaml
@@ -1,0 +1,24 @@
+{{/*
+Copyright (c) HashiCorp, Inc.
+SPDX-License-Identifier: MPL-2.0
+*/}}
+
+{{- template "vault.csiEnabled" . -}}
+{{- if .csiEnabled -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ template "vault.fullname" . }}-csi-provider-rolebinding
+  labels:
+    app.kubernetes.io/name: {{ include "vault.name" . }}-csi-provider
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ template "vault.fullname" . }}-csi-provider-role
+subjects:
+- kind: ServiceAccount
+  name: {{ template "vault.fullname" . }}-csi-provider
+  namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/test/unit/csi-daemonset.bats
+++ b/test/unit/csi-daemonset.bats
@@ -168,6 +168,25 @@ load _helpers
   [ "${actual}" = "--debug=true" ]
 }
 
+# HMAC secret arg
+@test "csi/daemonset: HMAC secret arg is configurable" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/csi-daemonset.yaml \
+      --set "csi.enabled=true" \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.containers[0].args[2]' | tee /dev/stderr)
+  [ "${actual}" = "--hmac-secret-name=vault-csi-provider-hmac-key" ]
+
+  local actual=$(helm template \
+      --show-only templates/csi-daemonset.yaml \
+      --set "csi.enabled=true" \
+      --set "csi.hmacSecretName=foo" \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.containers[0].args[2]' | tee /dev/stderr)
+  [ "${actual}" = "--hmac-secret-name=foo" ]
+}
+
 # Extra args
 @test "csi/daemonset: extra args can be passed" {
   cd `chart_dir`

--- a/test/unit/csi-daemonset.bats
+++ b/test/unit/csi-daemonset.bats
@@ -195,7 +195,7 @@ load _helpers
       --set "csi.enabled=true" \
       . | tee /dev/stderr |
       yq -r '.spec.template.spec.containers[0].args | length' | tee /dev/stderr)
-  [ "${actual}" = "2" ]
+  [ "${actual}" = "3" ]
 
   local object=$(helm template \
       --show-only templates/csi-daemonset.yaml \
@@ -205,15 +205,15 @@ load _helpers
       yq -r '.spec.template.spec.containers[0]')
   local actual=$(echo $object |
       yq -r '.args | length' | tee /dev/stderr)
-  [ "${actual}" = "5" ]
-  local actual=$(echo $object |
-      yq -r '.args[2]' | tee /dev/stderr)
-  [ "${actual}" = "--foo=bar" ]
+  [ "${actual}" = "6" ]
   local actual=$(echo $object |
       yq -r '.args[3]' | tee /dev/stderr)
-  [ "${actual}" = "--bar baz" ]
+  [ "${actual}" = "--foo=bar" ]
   local actual=$(echo $object |
       yq -r '.args[4]' | tee /dev/stderr)
+  [ "${actual}" = "--bar baz" ]
+  local actual=$(echo $object |
+      yq -r '.args[5]' | tee /dev/stderr)
   [ "${actual}" = "first" ]
 }
 

--- a/test/unit/csi-role.bats
+++ b/test/unit/csi-role.bats
@@ -1,0 +1,39 @@
+#!/usr/bin/env bats
+
+load _helpers
+
+@test "csi/Role: disabled by default" {
+  cd `chart_dir`
+  local actual=$( (helm template \
+      --show-only templates/csi-role.yaml  \
+      . || echo "---") | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+}
+
+@test "csi/Role: names" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/csi-role.yaml \
+      --set "csi.enabled=true" \
+      . | tee /dev/stderr |
+      yq -r '.metadata.name' | tee /dev/stderr)
+  [ "${actual}" = "release-name-vault-csi-provider-role" ]
+  local actual=$(helm template \
+      --show-only templates/csi-role.yaml \
+      --set "csi.enabled=true" \
+      . | tee /dev/stderr |
+      yq -r '.rules[0].resourceNames[0]' | tee /dev/stderr)
+  [ "${actual}" = "vault-csi-provider-hmac-key" ]
+}
+
+@test "csi/Role: HMAC secret name configurable" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/csi-role.yaml \
+      --set "csi.enabled=true" \
+      --set 'csi.hmacSecretName=foo' \
+      . | tee /dev/stderr |
+      yq -r '.rules[0].resourceNames[0]' | tee /dev/stderr)
+  [ "${actual}" = "foo" ]
+}

--- a/test/unit/csi-rolebinding.bats
+++ b/test/unit/csi-rolebinding.bats
@@ -5,7 +5,7 @@ load _helpers
 @test "csi/RoleBinding: disabled by default" {
   cd `chart_dir`
   local actual=$( (helm template \
-      --show-only templates/csi-role.yaml  \
+      --show-only templates/csi-rolebinding.yaml  \
       . || echo "---") | tee /dev/stderr |
       yq 'length > 0' | tee /dev/stderr)
   [ "${actual}" = "false" ]

--- a/test/unit/csi-rolebinding.bats
+++ b/test/unit/csi-rolebinding.bats
@@ -1,0 +1,22 @@
+#!/usr/bin/env bats
+
+load _helpers
+
+@test "csi/RoleBinding: disabled by default" {
+  cd `chart_dir`
+  local actual=$( (helm template \
+      --show-only templates/csi-role.yaml  \
+      . || echo "---") | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+}
+
+@test "csi/RoleBinding: name" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/csi-rolebinding.yaml \
+      --set "csi.enabled=true" \
+      . | tee /dev/stderr |
+      yq -r '.metadata.name' | tee /dev/stderr)
+  [ "${actual}" = "release-name-vault-csi-provider-rolebinding" ]
+}

--- a/values.yaml
+++ b/values.yaml
@@ -1025,6 +1025,10 @@ csi:
   #     cpu: 50m
   #     memory: 128Mi
 
+  # Override the default secret name for the CSI Provider's HMAC key used for
+  # generating secret versions.
+  hmacSecretName: ""
+
   # Settings for the daemonSet used to run the provider.
   daemonSet:
     updateStrategy:


### PR DESCRIPTION
https://github.com/hashicorp/vault-csi-provider/pull/198 introduced the need to create a k8s secret for storing an HMAC key. This PR adds the role and role binding with permissions to do so while keeping the least privileges possible.