### PR TITLE
feat: add podSelector for networkPolicy

### DIFF
--- a/templates/server-network-policy.yaml
+++ b/templates/server-network-policy.yaml
@@ -19,6 +19,10 @@ spec:
   ingress:
     - from:
         - namespaceSelector: {}
+          {{- if .Values.server.networkPolicy.podSelector }}
+          podSelector:
+            {{- toYaml .Values.server.networkPolicy.podSelector | nindent 14 }}
+          {{- end }}
       ports:
       - port: 8200
         protocol: TCP

--- a/templates/server-network-policy.yaml
+++ b/templates/server-network-policy.yaml
@@ -16,18 +16,7 @@ spec:
     matchLabels:
       app.kubernetes.io/name: {{ template "vault.name" . }}
       app.kubernetes.io/instance: {{ .Release.Name }}
-  ingress:
-    - from:
-        - namespaceSelector: {}
-          {{- if .Values.server.networkPolicy.podSelector }}
-          podSelector:
-            {{- toYaml .Values.server.networkPolicy.podSelector | nindent 14 }}
-          {{- end }}
-      ports:
-      - port: 8200
-        protocol: TCP
-      - port: 8201
-        protocol: TCP
+  ingress: {{- toYaml .Values.server.networkPolicy.ingress | nindent 4 }}
   {{- if .Values.server.networkPolicy.egress }}
   egress:
   {{- toYaml .Values.server.networkPolicy.egress | nindent 4 }}

--- a/test/unit/server-network-policy.bats
+++ b/test/unit/server-network-policy.bats
@@ -21,11 +21,11 @@ load _helpers
   [ "${actual}" = "true" ]
 }
 
-@test "server/network-policy: podSelector enabled by server.networkPolicy.podSelector" {
+@test "server/network-policy: ingress changed by server.networkPolicy.ingress" {
   cd `chart_dir`
   local actual=$(helm template \
       --set 'server.networkPolicy.enabled=true' \
-      --set 'server.networkPolicy.podSelector.matchLabels.foo=bar' \
+      --set 'server.networkPolicy.ingress[0].from[0].podSelector.matchLabels.foo=bar' \
       --show-only templates/server-network-policy.yaml \
       . | tee /dev/stderr |
       yq -r '.spec.ingress[0].from[0].podSelector.matchLabels.foo' | tee /dev/stderr)

--- a/test/unit/server-network-policy.bats
+++ b/test/unit/server-network-policy.bats
@@ -21,6 +21,17 @@ load _helpers
   [ "${actual}" = "true" ]
 }
 
+@test "server/network-policy: podSelector enabled by server.networkPolicy.podSelector" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --set 'server.networkPolicy.enabled=true' \
+      --set 'server.networkPolicy.podSelector.matchLabels.foo=bar' \
+      --show-only templates/server-network-policy.yaml \
+      . | tee /dev/stderr |
+      yq -r '.spec.ingress[0].from[0].podSelector.matchLabels.foo' | tee /dev/stderr)
+  [ "${actual}" = "bar" ]
+}
+
 @test "server/network-policy: egress enabled by server.networkPolicy.egress" {
   cd `chart_dir`
   local actual=$(helm template \

--- a/values.yaml
+++ b/values.yaml
@@ -630,6 +630,11 @@ server:
     #   ports:
     #   - protocol: TCP
     #     port: 443
+    podSelector: {}
+    # Restrict traffic to vault pods only with given labels
+    # podSelector:
+    #   matchLabels:
+    #     vault-access: "true"
 
   # Priority class for server pods
   priorityClassName: ""

--- a/values.yaml
+++ b/values.yaml
@@ -630,11 +630,14 @@ server:
     #   ports:
     #   - protocol: TCP
     #     port: 443
-    podSelector: {}
-    # Restrict traffic to vault pods only with given labels
-    # podSelector:
-    #   matchLabels:
-    #     vault-access: "true"
+    ingress:
+      - from:
+          - namespaceSelector: {}
+        ports:
+        - port: 8200
+          protocol: TCP
+        - port: 8201
+          protocol: TCP
 
   # Priority class for server pods
   priorityClassName: ""


### PR DESCRIPTION
Hello everyone,

I'd like to have the option to limit which pods are allowed to access the Vault instance.
Therefore the NetworkPolicy should be expandable to support a custom podSelector (matchLabels).

Currently (and now with the default values) the Vault pod can be reached by any other pod.

<hr />

Marco Lecheler [marco.lecheler@mercedes-benz.com](mailto:marco.lecheler@mercedes-benz.com) Mercedes-Benz Tech Innovation GmbH ([ProviderInformation](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md))