### PR TITLE
ci: Fix yq command syntax

### DIFF
--- a/.github/workflows/update-helm-charts-index.yml
+++ b/.github/workflows/update-helm-charts-index.yml
@@ -16,7 +16,7 @@ jobs:
         run: |-
           export TAG=${{ github.ref_name }}
           git_tag=$(echo "${TAG#v}")
-          chart_tag=$(yq r Chart.yaml version)
+          chart_tag=$(yq '.version' Chart.yaml)
           if [ "${git_tag}" != "${chart_tag}" ]; then
             echo "chart version (${chart_tag}) did not match git version (${git_tag})"
             exit 1


### PR DESCRIPTION
The original CCI version used an older version of yq. The syntax changed and this was missed when ported.

This addresses the error:

```
Error: 1:1: invalid input text "r"
```