### PR TITLE
Default prometheusRules.rules should be an empty list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Unreleased
 
+Bugs:
+* server: Set the default for `prometheusRules.rules` to an empty list [GH-886](https://github.com/hashicorp/vault-helm/pull/886)
+
 ## 0.24.1 (April 17, 2023)
 
 Bugs:

--- a/test/unit/prometheus-prometheusrules.bats
+++ b/test/unit/prometheus-prometheusrules.bats
@@ -6,7 +6,7 @@ load _helpers
   cd `chart_dir`
   local actual=$( (helm template \
       --show-only templates/prometheus-prometheusrules.yaml  \
-      --set 'serverTelemetry.prometheusRules.rules.foo=bar' \
+      --set 'serverTelemetry.prometheusRules.rules[0].foo=bar' \
       . || echo "---") | tee /dev/stderr |
       yq 'length > 0' | tee /dev/stderr)
   [ "${actual}" = "false" ]
@@ -26,16 +26,16 @@ load _helpers
   local output=$( (helm template \
       --show-only templates/prometheus-prometheusrules.yaml \
       --set 'serverTelemetry.prometheusRules.enabled=true' \
-      --set 'serverTelemetry.prometheusRules.rules.foo=bar' \
-      --set 'serverTelemetry.prometheusRules.rules.baz=qux' \
+      --set 'serverTelemetry.prometheusRules.rules[0].foo=bar' \
+      --set 'serverTelemetry.prometheusRules.rules[1].baz=qux' \
       .) | tee  /dev/stderr )
 
   [ "$(echo "$output" | yq -r '.spec.groups | length')" = "1" ]
   [ "$(echo "$output" | yq -r '.spec.groups[0] | length')" = "2" ]
   [ "$(echo "$output" | yq -r '.spec.groups[0].name')" = "release-name-vault" ]
   [ "$(echo "$output" | yq -r '.spec.groups[0].rules | length')" = "2" ]
-  [ "$(echo "$output" | yq -r '.spec.groups[0].rules.foo')" = "bar" ]
-  [ "$(echo "$output" | yq -r '.spec.groups[0].rules.baz')" = "qux" ]
+  [ "$(echo "$output" | yq -r '.spec.groups[0].rules[0].foo')" = "bar" ]
+  [ "$(echo "$output" | yq -r '.spec.groups[0].rules[1].baz')" = "qux" ]
 }
 
 @test "prometheus/PrometheusRules-server: assertSelectors default" {
@@ -43,7 +43,7 @@ load _helpers
   local output=$( (helm template \
       --show-only templates/prometheus-prometheusrules.yaml \
       --set 'serverTelemetry.prometheusRules.enabled=true' \
-      --set 'serverTelemetry.prometheusRules.rules.foo=bar' \
+      --set 'serverTelemetry.prometheusRules.rules[0].foo=bar' \
       . ) | tee /dev/stderr)
 
   [ "$(echo "$output" | yq -r '.metadata.labels | length')" = "5" ]
@@ -55,7 +55,7 @@ load _helpers
   local output=$( (helm template \
       --show-only templates/prometheus-prometheusrules.yaml \
       --set 'serverTelemetry.prometheusRules.enabled=true' \
-      --set 'serverTelemetry.prometheusRules.rules.foo=bar' \
+      --set 'serverTelemetry.prometheusRules.rules[0].foo=bar' \
       --set 'serverTelemetry.prometheusRules.selectors.baz=qux' \
       --set 'serverTelemetry.prometheusRules.selectors.bar=foo' \
       . ) | tee /dev/stderr)

--- a/values.schema.json
+++ b/values.schema.json
@@ -1060,6 +1060,25 @@
                 }
             }
         },
+        "serverTelemetry": {
+            "type": "object",
+            "properties": {
+                "prometheusRules": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean"
+                        },
+                        "rules": {
+                            "type": "array"
+                        },
+                        "selectors": {
+                            "type": "object"
+                        }
+                    }
+                }
+            }
+        },
         "ui": {
             "type": "object",
             "properties": {

--- a/values.yaml
+++ b/values.yaml
@@ -1198,7 +1198,7 @@ serverTelemetry:
       selectors: {}
 
       # Some example rules.
-      rules: {}
+      rules: []
       #  - alert: vault-HighResponseTime
       #    annotations:
       #      message: The response time of Vault is over 500ms on average over the last 5 minutes.


### PR DESCRIPTION
Revival of https://github.com/hashicorp/vault-helm/pull/823

Support for prometheus-operator was added in https://github.com/hashicorp/vault-helm/pull/772 and a default empty set of rules was defined as an empty map `{}`. However, as evidenced by the commented out rule examples below that very same values.yaml, this is expected to be a list, so `rules:` value should be set to an empty list `[]`.

Because of this Helm issues a warning if you actually define rules and pass them with a --values <filename>:

```
coalesce.go:220: warning: cannot overwrite table with non table for vault.serverTelemetry.prometheusRules.rules (map[])
```