### PR TITLE
values.yaml updated to include explicit cluster_name

### DIFF
--- a/values.yaml
+++ b/values.yaml
@@ -3,6 +3,10 @@
 
 # Available parameters and their default values for the Vault chart.
 
+# Set cluster name instead of having it auto-generated.
+# examples may include: "vault1-gke-uswest", "vault2-eks-useast", etc.
+cluster_name: ""
+
 global:
   # enabled is the master enabled switch. Setting this to true or false
   # will enable or disable all the components within this chart by default.
@@ -834,6 +838,7 @@ server:
       # https://www.vaultproject.io/docs/platform/k8s/helm/run#protecting-sensitive-vault-configurations
       config: |
         ui = true
+        cluster_name = {{ .Values.cluster_name | default (printf "%s-k8s" (include "vault.name" .)) | quote }}
 
         listener "tcp" {
           tls_disable = 1


### PR DESCRIPTION
Setting an [explicit (HCL) `cluster_name`](https://developer.hashicorp.com/vault/docs/configuration#cluster_name) as part of the cluster roll-out / configuration is required without which an undesirable behavior arises where the reported Prometheus label does not correctly contain the cluster name - eg (at present):

```bash
curl -Lks ${VAULT_ADDR}v1/sys/metrics?format=prometheus | grep dr_primary{
  # vault_core_replication_dr_primary{cluster="",host="vault-2"} 0
```