### PR TITLE
Allow additional annotations for standby and active services via config

### DIFF
--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -711,6 +711,33 @@ Sets extra vault server Service annotations
 {{- end -}}
 
 {{/*
+Sets extra vault server Service (active) annotations
+*/}}
+{{- define "vault.service.active.annotations" -}}
+  {{- if .Values.server.service.active.annotations }}
+    {{- $tp := typeOf .Values.server.service.active.annotations }}
+    {{- if eq $tp "string" }}
+      {{- tpl .Values.server.service.active.annotations . | nindent 4 }}
+    {{- else }}
+      {{- toYaml .Values.server.service.active.annotations | nindent 4 }}
+    {{- end }}
+  {{- end }}
+{{- end -}}
+{{/*
+Sets extra vault server Service annotations
+*/}}
+{{- define "vault.service.standby.annotations" -}}
+  {{- if .Values.server.service.standby.annotations }}
+    {{- $tp := typeOf .Values.server.service.standby.annotations }}
+    {{- if eq $tp "string" }}
+      {{- tpl .Values.server.service.standby.annotations . | nindent 4 }}
+    {{- else }}
+      {{- toYaml .Values.server.service.standby.annotations | nindent 4 }}
+    {{- end }}
+  {{- end }}
+{{- end -}}
+
+{{/*
 Sets PodSecurityPolicy annotations
 */}}
 {{- define "vault.psp.annotations" -}}

--- a/templates/server-ha-active-service.yaml
+++ b/templates/server-ha-active-service.yaml
@@ -22,8 +22,8 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     vault-active: "true"
   annotations:
-{{ template "vault.service.active.annotations" .}}
-{{ template "vault.service.annotations" .}}
+{{- template "vault.service.active.annotations" . }}
+{{- template "vault.service.annotations" . }}
 spec:
   {{- if .Values.server.service.type}}
   type: {{ .Values.server.service.type }}

--- a/templates/server-ha-active-service.yaml
+++ b/templates/server-ha-active-service.yaml
@@ -22,6 +22,7 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     vault-active: "true"
   annotations:
+{{ template "vault.service.active.annotations" .}}
 {{ template "vault.service.annotations" .}}
 spec:
   {{- if .Values.server.service.type}}

--- a/templates/server-ha-standby-service.yaml
+++ b/templates/server-ha-standby-service.yaml
@@ -21,6 +21,7 @@ metadata:
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
   annotations:
+{{ template "vault.service.standby.annotations" .}}
 {{ template "vault.service.annotations" .}}
 spec:
   {{- if .Values.server.service.type}}

--- a/templates/server-ha-standby-service.yaml
+++ b/templates/server-ha-standby-service.yaml
@@ -21,8 +21,8 @@ metadata:
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
   annotations:
-{{ template "vault.service.standby.annotations" .}}
-{{ template "vault.service.annotations" .}}
+{{- template "vault.service.standby.annotations" . }}
+{{- template "vault.service.annotations" . }}
 spec:
   {{- if .Values.server.service.type}}
   type: {{ .Values.server.service.type }}

--- a/test/unit/server-ha-active-service.bats
+++ b/test/unit/server-ha-active-service.bats
@@ -23,7 +23,21 @@ load _helpers
       yq -r '.metadata.annotations["vaultIsAwesome"]' | tee /dev/stderr)
   [ "${actual}" = "true" ]
 }
+@test "server/ha-active-Service: with both annotations set" {
+  cd `chart_dir`
+  local object=$(helm template \
+      --show-only templates/server-ha-active-service.yaml \
+      --set 'server.ha.enabled=true' \
+      --set 'server.service.active.annotations=vaultIsAwesome: true' \
+      --set 'server.service.annotations=vaultIsNotAwesome: false' \
+      . | tee /dev/stderr |
+      yq -r '.metadata' | tee /dev/stderr)
 
+  local actual=$(echo "$object" | yq '.annotations["vaultIsAwesome"]' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+  actual=$(echo "$object" | yq '.annotations["vaultIsNotAwesome"]' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+}
 @test "server/ha-active-Service: disable with ha.enabled false" {
   cd `chart_dir`
   local actual=$( (helm template \

--- a/test/unit/server-ha-active-service.bats
+++ b/test/unit/server-ha-active-service.bats
@@ -13,6 +13,17 @@ load _helpers
   [ "${actual}" = "true" ]
 }
 
+@test "server/ha-active-Service: with active annotations" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/server-ha-active-service.yaml \
+      --set 'server.ha.enabled=true' \
+      --set 'server.service.active.annotations=vaultIsAwesome: true' \
+      . | tee /dev/stderr |
+      yq -r '.metadata.annotations["vaultIsAwesome"]' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}
+
 @test "server/ha-active-Service: disable with ha.enabled false" {
   cd `chart_dir`
   local actual=$( (helm template \

--- a/test/unit/server-ha-standby-service.bats
+++ b/test/unit/server-ha-standby-service.bats
@@ -24,6 +24,28 @@ load _helpers
   [ "${actual}" = "true" ]
 }
 
+@test "server/ha-standby-Service: with standby annotations string" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/server-ha-standby-service.yaml \
+      --set 'server.ha.enabled=true' \
+      --set 'server.service.standby.annotations=vaultIsAwesome: true' \
+      . | tee /dev/stderr |
+      yq -r '.metadata.annotations["vaultIsAwesome"]' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}
+
+@test "server/ha-standby-Service: with standby annotations yaml" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/server-ha-standby-service.yaml \
+      --set 'server.ha.enabled=true' \
+      --set 'server.service.standby.annotations.vaultIsAwesome=true' \
+      . | tee /dev/stderr |
+      yq -r '.metadata.annotations["vaultIsAwesome"]' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}
+
 @test "server/ha-standby-Service: disable with ha.enabled false" {
   cd `chart_dir`
   local actual=$( (helm template \

--- a/test/unit/server-ha-standby-service.bats
+++ b/test/unit/server-ha-standby-service.bats
@@ -45,7 +45,21 @@ load _helpers
       yq -r '.metadata.annotations["vaultIsAwesome"]' | tee /dev/stderr)
   [ "${actual}" = "true" ]
 }
+@test "server/ha-standby-Service: with both annotations set" {
+  cd `chart_dir`
+  local object=$(helm template \
+      --show-only templates/server-ha-standby-service.yaml \
+      --set 'server.ha.enabled=true' \
+      --set 'server.service.standby.annotations=vaultIsAwesome: true' \
+      --set 'server.service.annotations=vaultIsNotAwesome: false' \
+      . | tee /dev/stderr |
+      yq -r '.metadata' | tee /dev/stderr)
 
+  local actual=$(echo "$object" | yq '.annotations["vaultIsAwesome"]' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+  actual=$(echo "$object" | yq '.annotations["vaultIsNotAwesome"]' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+}
 @test "server/ha-standby-Service: disable with ha.enabled false" {
   cd `chart_dir`
   local actual=$( (helm template \

--- a/values.schema.json
+++ b/values.schema.json
@@ -922,6 +922,12 @@
                             "properties": {
                                 "enabled": {
                                     "type": "boolean"
+                                },
+                                "annotations": {
+                                    "type": [
+                                        "object",
+                                        "string"
+                                    ]
                                 }
                             }
                         },
@@ -956,6 +962,12 @@
                             "properties": {
                                 "enabled": {
                                     "type": "boolean"
+                                },
+                                "annotations": {
+                                    "type": [
+                                        "object",
+                                        "string"
+                                    ]
                                 }
                             }
                         },

--- a/values.yaml
+++ b/values.yaml
@@ -658,22 +658,20 @@ server:
   service:
     enabled: true
     # Enable or disable the vault-active service, which selects Vault pods that
-    # have labelled themselves as the cluster leader with `vault-active: "true"`.
-    # Also helps in to add extra annotations for the service definition.
+    # have labeled themselves as the cluster leader with `vault-active: "true"`.
     active:
       enabled: true
-    # Extra annotations for the service definition. This can either be YAML or a
-    # YAML-formatted multi-line templated string map of the annotations to apply
-    # to the service.
+      # Extra annotations for the service definition. This can either be YAML or a
+      # YAML-formatted multi-line templated string map of the annotations to apply
+      # to the active service.
       annotations: {}
     # Enable or disable the vault-standby service, which selects Vault pods that
-    # have labelled themselves as a cluster follower with `vault-active: "false"`.
-    # Also helps in to add extra annotations for the service definition.
+    # have labeled themselves as a cluster follower with `vault-active: "false"`.
     standby:
       enabled: true
-    # Extra annotations for the service definition. This can either be YAML or a
-    # YAML-formatted multi-line templated string map of the annotations to apply
-    # to the service.
+      # Extra annotations for the service definition. This can either be YAML or a
+      # YAML-formatted multi-line templated string map of the annotations to apply
+      # to the standby service.
       annotations: {}
     # If enabled, the service selectors will include `app.kubernetes.io/instance: {{ .Release.Name }}`
     # When disabled, services may select Vault pods not deployed from the chart.

--- a/values.yaml
+++ b/values.yaml
@@ -658,13 +658,23 @@ server:
   service:
     enabled: true
     # Enable or disable the vault-active service, which selects Vault pods that
-    # have labelled themselves as the cluster leader with `vault-active: "true"`
+    # have labelled themselves as the cluster leader with `vault-active: "true"`.
+    # Also helps in to add extra annotations for the service definition.
     active:
       enabled: true
+    # Extra annotations for the service definition. This can either be YAML or a
+    # YAML-formatted multi-line templated string map of the annotations to apply
+    # to the service.
+      annotations: {}
     # Enable or disable the vault-standby service, which selects Vault pods that
-    # have labelled themselves as a cluster follower with `vault-active: "false"`
+    # have labelled themselves as a cluster follower with `vault-active: "false"`.
+    # Also helps in to add extra annotations for the service definition.
     standby:
       enabled: true
+    # Extra annotations for the service definition. This can either be YAML or a
+    # YAML-formatted multi-line templated string map of the annotations to apply
+    # to the service.
+      annotations: {}
     # If enabled, the service selectors will include `app.kubernetes.io/instance: {{ .Release.Name }}`
     # When disabled, services may select Vault pods not deployed from the chart.
     # Does not affect the headless vault-internal service with `ClusterIP: None`


### PR DESCRIPTION
Revival of https://github.com/hashicorp/vault-helm/pull/546

Currently there is no ability to annotate services for active and standby services, as they inherit their settings from the main server service configuration. This is a problem,  when you need to attach different annotations to the different services. Instead of just allowing for setting of annotations, I opted to allow configuring the services for more flexibility.

Helps to close https://github.com/hashicorp/vault-helm/issues/674

Partially resolves https://github.com/hashicorp/vault-helm/issues/588

Thanks @jamesgoodhouse