### PR TITLE
Add hostAliases to chart

### DIFF
--- a/templates/server-statefulset.yaml
+++ b/templates/server-statefulset.yaml
@@ -61,6 +61,10 @@ spec:
         {{ template "vault.volumes" . }}
         - name: home
           emptyDir: {}
+      {{- if .Values.server.hostAliases }}
+      hostAliases:
+        {{ toYaml .Values.server.hostAliases | nindent 8}}
+      {{- end }}
       {{- if .Values.server.extraInitContainers }}
       initContainers:
         {{ toYaml .Values.server.extraInitContainers | nindent 8}}

--- a/values.schema.json
+++ b/values.schema.json
@@ -723,6 +723,12 @@
                         }
                     }
                 },
+		"hostAliases": {
+                    "type": [
+			"null",
+	                "array"
+		    ]
+	        },
                 "image": {
                     "type": "object",
                     "properties": {

--- a/values.yaml
+++ b/values.yaml
@@ -442,6 +442,12 @@ server:
     #    hosts:
     #      - chart-example.local
 
+  # hostAliases is a list of aliases to be added to /etc/hosts. Specified as a YAML list.
+  hostAliases: null
+    # - ip: 127.0.0.1
+    #   hostnames:
+    #     - chart-example.local
+
   # OpenShift only - create a route to expose the service
   # By default the created route will be of type passthrough
   route:


### PR DESCRIPTION
Add [hostAliases](https://kubernetes.io/docs/tasks/network/customize-hosts-file-for-pods/) to the Vault Helm Chart so that custom entries can be added to /etc/hosts via values.yaml.

Comes in handy for adding host entries to 127.0.0.1 (e.g. to use a 'normal' cert rather than an IP SAN cert) and possibly other uses.