### PR TITLE
publishNotReadyAddresses for headless service always true

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 Changes:
 * Latest Kubernetes version tested is now 1.27
+* server: Headless service ignores `server.service.publishNotReadyAddresses` setting and always sets it as `true` [GH-902](https://github.com/hashicorp/vault-helm/pull/902)
 
 Bugs:
 * server: Set the default for `prometheusRules.rules` to an empty list [GH-886](https://github.com/hashicorp/vault-helm/pull/886)

--- a/templates/server-headless-service.yaml
+++ b/templates/server-headless-service.yaml
@@ -23,7 +23,7 @@ metadata:
 {{ template "vault.service.annotations" .}}
 spec:
   clusterIP: None
-  publishNotReadyAddresses: {{ .Values.server.service.publishNotReadyAddresses }}
+  publishNotReadyAddresses: true
   ports:
     - name: "{{ include "vault.scheme" . }}"
       port: {{ .Values.server.service.port }}

--- a/test/unit/server-headless-service.bats
+++ b/test/unit/server-headless-service.bats
@@ -2,7 +2,7 @@
 
 load _helpers
 
-@test "server/headless-Service: publishNotReadyAddresses can be changed" {
+@test "server/headless-Service: publishNotReadyAddresses cannot be changed" {
   cd `chart_dir`
   local actual=$(helm template \
       --show-only templates/server-headless-service.yaml \
@@ -15,7 +15,7 @@ load _helpers
       --set 'server.service.publishNotReadyAddresses=false' \
       . | tee /dev/stderr |
       yq -r '.spec.publishNotReadyAddresses' | tee /dev/stderr)
-  [ "${actual}" = "false" ]
+  [ "${actual}" = "true" ]
 }
 
 @test "server/headless-Service: instance selector cannot be disabled" {

--- a/values.yaml
+++ b/values.yaml
@@ -673,7 +673,9 @@ server:
     # or NodePort.
     #type: ClusterIP
 
-    # Do not wait for pods to be ready
+    # Do not wait for pods to be ready before including them in the services'
+    # targets. Does not apply to the headless service, which is used for
+    # cluster-internal communication.
     publishNotReadyAddresses: true
 
     # The externalTrafficPolicy can be set to either Cluster or Local


### PR DESCRIPTION
The headless service pods should always be discoverable even if they're not ready, as it's used for cluster joining. However, vault, vault-active, and vault-standby services should be able to set `publishNotReadyAddresses` to false to ensure client requests are always routed to a ready pod. Before this PR, all services used the same values.yaml setting, so it wasn't possible to have different values for the different services. Ideally, it would be nice to set the default `publishNotReadyAddresses` value to be false at some point, but I just wanted to keep this PR to the minimum possible (minor) breaking change.