### PR TITLE
csi: update affinity and nodeselector schema

### DIFF
--- a/test/unit/csi-daemonset.bats
+++ b/test/unit/csi-daemonset.bats
@@ -373,9 +373,9 @@ load _helpers
   local actual=$(helm template \
       --show-only templates/csi-daemonset.yaml  \
       --set 'csi.enabled=true' \
-      --set "csi.pod.nodeSelector[0].foo=bar,csi.pod.nodeSelector[1].baz=qux" \
+      --set "csi.pod.nodeSelector.foo=bar,csi.pod.nodeSelector.baz=qux" \
       . | tee /dev/stderr |
-      yq '.spec.template.spec.nodeSelector[0].foo == "bar" and .spec.template.spec.nodeSelector[1].baz == "qux"' | tee /dev/stderr)
+      yq '.spec.template.spec.nodeSelector.foo == "bar" and .spec.template.spec.nodeSelector.baz == "qux"' | tee /dev/stderr)
   [ "${actual}" = "true" ]
 }
 

--- a/values.schema.json
+++ b/values.schema.json
@@ -139,7 +139,7 @@
                         "affinity": {
                             "type": [
                               "null",
-                              "array",
+                              "object",
                               "string"
                             ]
                         },
@@ -155,7 +155,7 @@
                         "nodeSelector": {
                             "type": [
                               "null",
-                              "array",
+                              "object",
                               "string"
                             ]
                         },

--- a/values.yaml
+++ b/values.yaml
@@ -1070,7 +1070,7 @@ csi:
     # Example:
     # nodeSelector:
     #   beta.kubernetes.io/arch: amd64
-    nodeSelector: []
+    nodeSelector: {}
 
     # Affinity Settings
     # This should be either a multi-line string or YAML matching the PodSpec's affinity field.


### PR DESCRIPTION
Looks like the top-level objects for [affinity](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity) and [nodeselector](https://kubernetes.io/docs/tasks/configure-pod-container/assign-pods-nodes/#create-a-pod-that-gets-scheduled-to-your-chosen-node) are objects instead of arrays.