### PR TITLE
Allows the release namespace to be overridden

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ Features:
 
 Bugs:
 * server: Set the default for `prometheusRules.rules` to an empty list [GH-886](https://github.com/hashicorp/vault-helm/pull/886)
+* csi: Add namespace field to `csi-role` and `csi-rolebindings`. [GH-909](https://github.com/hashicorp/vault-helm/pull/909)
+
+Improvements:
+* global: Add `global.namespace` to override the helm installation namespace. [GH-909](https://github.com/hashicorp/vault-helm/pull/909)
 
 ## 0.24.1 (April 17, 2023)
 
@@ -44,11 +48,9 @@ Features:
 
 Bugs:
 * server: Quote `.server.ha.clusterAddr` value [GH-810](https://github.com/hashicorp/vault-helm/pull/810)
-* csi: Add namespace field to `csi-role` and `csi-rolebindings`. [GH-909](https://github.com/hashicorp/vault-helm/pull/909)
 
 Improvements:
 * injector: Add `ephemeralLimit` and `ephemeralRequest` as options for configuring Agent's ephemeral storage resources [GH-798](https://github.com/hashicorp/vault-helm/pull/798)
-* global: Add `global.namespace` to override the helm installation namespace. [GH-909](https://github.com/hashicorp/vault-helm/pull/909)
 
 ## 0.22.1 (October 26th, 2022)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## Unreleased
 
+Bugs:
+* csi: Add namespace field to `csi-role` and `csi-rolebindings`. [GH-909](https://github.com/hashicorp/vault-helm/pull/909)
+
+Improvements:
+* global: Add `global.namespace` to override the helm installation namespace. [GH-909](https://github.com/hashicorp/vault-helm/pull/909)
+
 ## 0.25.0 (June 26, 2023)
 
 Changes:
@@ -15,10 +21,6 @@ Improvements:
 
 Bugs:
 * server: Set the default for `prometheusRules.rules` to an empty list [GH-886](https://github.com/hashicorp/vault-helm/pull/886)
-* csi: Add namespace field to `csi-role` and `csi-rolebindings`. [GH-909](https://github.com/hashicorp/vault-helm/pull/909)
-
-Improvements:
-* global: Add `global.namespace` to override the helm installation namespace. [GH-909](https://github.com/hashicorp/vault-helm/pull/909)
 
 ## 0.24.1 (April 17, 2023)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,7 +48,7 @@ Bugs:
 
 Improvements:
 * injector: Add `ephemeralLimit` and `ephemeralRequest` as options for configuring Agent's ephemeral storage resources [GH-798](https://github.com/hashicorp/vault-helm/pull/798)
-* Add `namespaceOverride` to specify namespace from values or command line. [GH-909](https://github.com/hashicorp/vault-helm/pull/909)
+* global: Add `global.namespace` to override the helm installation namespace. [GH-909](https://github.com/hashicorp/vault-helm/pull/909)
 
 ## 0.22.1 (October 26th, 2022)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,9 +44,11 @@ Features:
 
 Bugs:
 * server: Quote `.server.ha.clusterAddr` value [GH-810](https://github.com/hashicorp/vault-helm/pull/810)
+* csi: Add namespace field to `csi-role` and `csi-rolebindings`. [GH-909](https://github.com/hashicorp/vault-helm/pull/909)
 
 Improvements:
 * injector: Add `ephemeralLimit` and `ephemeralRequest` as options for configuring Agent's ephemeral storage resources [GH-798](https://github.com/hashicorp/vault-helm/pull/798)
+* Add `namespaceOverride` to specify namespace from values or command line. [GH-909](https://github.com/hashicorp/vault-helm/pull/909)
 
 ## 0.22.1 (October 26th, 2022)
 

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -40,7 +40,7 @@ Expand the name of the chart.
 Allow the release namespace to be overridden
 */}}
 {{- define "vault.namespace" -}}
-{{- default .Release.Namespace .Values.namespaceOverride -}}
+{{- default .Release.Namespace .Values.global.namespace -}}
 {{- end -}}
 
 {{/*

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -37,6 +37,13 @@ Expand the name of the chart.
 {{- end -}}
 
 {{/*
+Allow the release namespace to be overridden
+*/}}
+{{- define "vault.namespace" -}}
+{{- default .Release.Namespace .Values.namespaceOverride -}}
+{{- end -}}
+
+{{/*
 Compute if the csi driver is enabled.
 */}}
 {{- define "vault.csiEnabled" -}}

--- a/templates/csi-agent-configmap.yaml
+++ b/templates/csi-agent-configmap.yaml
@@ -9,7 +9,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ template "vault.fullname" . }}-csi-provider-agent-config
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "vault.namespace" . }}
   labels:
     helm.sh/chart: {{ include "vault.chart" . }}
     app.kubernetes.io/name: {{ include "vault.name" . }}-csi-provider

--- a/templates/csi-agent-configmap.yaml
+++ b/templates/csi-agent-configmap.yaml
@@ -21,7 +21,7 @@ data:
         {{- if .Values.global.externalVaultAddr }}
         "address" = "{{ .Values.global.externalVaultAddr }}"
         {{- else }}
-        "address" = "{{ include "vault.scheme" . }}://{{ template "vault.fullname" . }}.{{ .Release.Namespace }}.svc:{{ .Values.server.service.port }}"
+        "address" = "{{ include "vault.scheme" . }}://{{ template "vault.fullname" . }}.{{ include "vault.namespace" . }}.svc:{{ .Values.server.service.port }}"
         {{- end }}
     }
 

--- a/templates/csi-clusterrolebinding.yaml
+++ b/templates/csi-clusterrolebinding.yaml
@@ -20,5 +20,5 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: {{ template "vault.fullname" . }}-csi-provider
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "vault.namespace" . }}
 {{- end }}

--- a/templates/csi-daemonset.yaml
+++ b/templates/csi-daemonset.yaml
@@ -71,7 +71,7 @@ spec:
             {{- else if .Values.global.externalVaultAddr }}
               value: "{{ .Values.global.externalVaultAddr }}"
             {{- else }}
-              value: {{ include "vault.scheme" . }}://{{ template "vault.fullname" . }}.{{ .Release.Namespace }}.svc:{{ .Values.server.service.port }}
+              value: {{ include "vault.scheme" . }}://{{ template "vault.fullname" . }}.{{ include "vault.namespace" . }}.svc:{{ .Values.server.service.port }}
             {{- end }}
           volumeMounts:
             - name: providervol

--- a/templates/csi-daemonset.yaml
+++ b/templates/csi-daemonset.yaml
@@ -9,7 +9,7 @@ apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: {{ template "vault.fullname" . }}-csi-provider
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "vault.namespace" . }}
   labels:
     app.kubernetes.io/name: {{ include "vault.name" . }}-csi-provider
     app.kubernetes.io/instance: {{ .Release.Name }}

--- a/templates/csi-role.yaml
+++ b/templates/csi-role.yaml
@@ -9,6 +9,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: {{ template "vault.fullname" . }}-csi-provider-role
+  namespace: {{ include "vault.namespace" . }}
   labels:
     app.kubernetes.io/name: {{ include "vault.name" . }}-csi-provider
     app.kubernetes.io/instance: {{ .Release.Name }}

--- a/templates/csi-rolebinding.yaml
+++ b/templates/csi-rolebinding.yaml
@@ -9,6 +9,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: {{ template "vault.fullname" . }}-csi-provider-rolebinding
+  namespace: {{ include "vault.namespace" . }}
   labels:
     app.kubernetes.io/name: {{ include "vault.name" . }}-csi-provider
     app.kubernetes.io/instance: {{ .Release.Name }}

--- a/templates/csi-rolebinding.yaml
+++ b/templates/csi-rolebinding.yaml
@@ -20,5 +20,5 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: {{ template "vault.fullname" . }}-csi-provider
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "vault.namespace" . }}
 {{- end }}

--- a/templates/csi-serviceaccount.yaml
+++ b/templates/csi-serviceaccount.yaml
@@ -9,7 +9,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ template "vault.fullname" . }}-csi-provider
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "vault.namespace" . }}
   labels:
     app.kubernetes.io/name: {{ include "vault.name" . }}-csi-provider
     app.kubernetes.io/instance: {{ .Release.Name }}

--- a/templates/injector-certs-secret.yaml
+++ b/templates/injector-certs-secret.yaml
@@ -10,7 +10,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: vault-injector-certs
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "vault.namespace" . }}
   labels:
     app.kubernetes.io/name: {{ include "vault.name" . }}-agent-injector
     app.kubernetes.io/instance: {{ .Release.Name }}

--- a/templates/injector-clusterrolebinding.yaml
+++ b/templates/injector-clusterrolebinding.yaml
@@ -20,5 +20,5 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: {{ template "vault.fullname" . }}-agent-injector
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "vault.namespace" . }}
 {{ end }}

--- a/templates/injector-deployment.yaml
+++ b/templates/injector-deployment.yaml
@@ -64,7 +64,7 @@ spec:
             {{- else if .Values.injector.externalVaultAddr }}
               value: "{{ .Values.injector.externalVaultAddr }}"
             {{- else }}
-              value: {{ include "vault.scheme" . }}://{{ template "vault.fullname" . }}.{{ .Release.Namespace }}.svc:{{ .Values.server.service.port }}
+              value: {{ include "vault.scheme" . }}://{{ template "vault.fullname" . }}.{{ include "vault.namespace" . }}.svc:{{ .Values.server.service.port }}
             {{- end }}
             - name: AGENT_INJECT_VAULT_AUTH_PATH
               value: {{ .Values.injector.authPath }}
@@ -79,7 +79,7 @@ spec:
             - name: AGENT_INJECT_TLS_AUTO
               value: {{ template "vault.fullname" . }}-agent-injector-cfg
             - name: AGENT_INJECT_TLS_AUTO_HOSTS
-              value: {{ template "vault.fullname" . }}-agent-injector-svc,{{ template "vault.fullname" . }}-agent-injector-svc.{{ .Release.Namespace }},{{ template "vault.fullname" . }}-agent-injector-svc.{{ .Release.Namespace }}.svc
+              value: {{ template "vault.fullname" . }}-agent-injector-svc,{{ template "vault.fullname" . }}-agent-injector-svc.{{ include "vault.namespace" . }},{{ template "vault.fullname" . }}-agent-injector-svc.{{ include "vault.namespace" . }}.svc
             {{- end }}
             - name: AGENT_INJECT_LOG_FORMAT
               value: {{ .Values.injector.logFormat | default "standard" }}

--- a/templates/injector-deployment.yaml
+++ b/templates/injector-deployment.yaml
@@ -10,7 +10,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "vault.fullname" . }}-agent-injector
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "vault.namespace" . }}
   labels:
     app.kubernetes.io/name: {{ include "vault.name" . }}-agent-injector
     app.kubernetes.io/instance: {{ .Release.Name }}

--- a/templates/injector-disruptionbudget.yaml
+++ b/templates/injector-disruptionbudget.yaml
@@ -8,7 +8,7 @@ apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: {{ template "vault.fullname" . }}-agent-injector
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "vault.namespace" . }}
   labels:
     helm.sh/chart: {{ include "vault.chart" . }}
     app.kubernetes.io/name: {{ include "vault.name" . }}-agent-injector

--- a/templates/injector-mutating-webhook.yaml
+++ b/templates/injector-mutating-webhook.yaml
@@ -28,7 +28,7 @@ webhooks:
     clientConfig:
       service:
         name: {{ template "vault.fullname" . }}-agent-injector-svc
-        namespace: {{ .Release.Namespace }}
+        namespace: {{ include "vault.namespace" . }}
         path: "/mutate"
       caBundle: {{ .Values.injector.certs.caBundle | quote }}
     rules:

--- a/templates/injector-psp-role.yaml
+++ b/templates/injector-psp-role.yaml
@@ -10,7 +10,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: {{ template "vault.fullname" . }}-agent-injector-psp
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "vault.namespace" . }}
   labels:
     app.kubernetes.io/name: {{ include "vault.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}

--- a/templates/injector-psp-rolebinding.yaml
+++ b/templates/injector-psp-rolebinding.yaml
@@ -10,7 +10,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: {{ template "vault.fullname" . }}-agent-injector-psp
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "vault.namespace" . }}
   labels:
     app.kubernetes.io/name: {{ include "vault.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}

--- a/templates/injector-role.yaml
+++ b/templates/injector-role.yaml
@@ -10,7 +10,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: {{ template "vault.fullname" . }}-agent-injector-leader-elector-role
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "vault.namespace" . }}
   labels:
     app.kubernetes.io/name: {{ include "vault.name" . }}-agent-injector
     app.kubernetes.io/instance: {{ .Release.Name }}

--- a/templates/injector-rolebinding.yaml
+++ b/templates/injector-rolebinding.yaml
@@ -10,7 +10,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: {{ template "vault.fullname" . }}-agent-injector-leader-elector-binding
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "vault.namespace" . }}
   labels:
     app.kubernetes.io/name: {{ include "vault.name" . }}-agent-injector
     app.kubernetes.io/instance: {{ .Release.Name }}
@@ -22,6 +22,6 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: {{ template "vault.fullname" . }}-agent-injector
-    namespace: {{ .Release.Namespace }}
+    namespace: {{ include "vault.namespace" . }}
 {{- end }}
 {{- end }}

--- a/templates/injector-service.yaml
+++ b/templates/injector-service.yaml
@@ -9,7 +9,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ template "vault.fullname" . }}-agent-injector-svc
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "vault.namespace" . }}
   labels:
     app.kubernetes.io/name: {{ include "vault.name" . }}-agent-injector
     app.kubernetes.io/instance: {{ .Release.Name }}

--- a/templates/injector-serviceaccount.yaml
+++ b/templates/injector-serviceaccount.yaml
@@ -9,7 +9,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ template "vault.fullname" . }}-agent-injector
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "vault.namespace" . }}
   labels:
     app.kubernetes.io/name: {{ include "vault.name" . }}-agent-injector
     app.kubernetes.io/instance: {{ .Release.Name }}

--- a/templates/prometheus-servicemonitor.yaml
+++ b/templates/prometheus-servicemonitor.yaml
@@ -45,5 +45,5 @@ spec:
       insecureSkipVerify: true
   namespaceSelector:
     matchNames:
-      - {{ .Release.Namespace }}
+      - {{ include "vault.namespace" . }}
 {{ end }}

--- a/templates/server-clusterrolebinding.yaml
+++ b/templates/server-clusterrolebinding.yaml
@@ -25,5 +25,5 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: {{ template "vault.serviceAccount.name" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "vault.namespace" . }}
 {{ end }}

--- a/templates/server-config-configmap.yaml
+++ b/templates/server-config-configmap.yaml
@@ -12,7 +12,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ template "vault.fullname" . }}-config
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "vault.namespace" . }}
   labels:
     helm.sh/chart: {{ include "vault.chart" . }}
     app.kubernetes.io/name: {{ include "vault.name" . }}

--- a/templates/server-discovery-role.yaml
+++ b/templates/server-discovery-role.yaml
@@ -10,7 +10,7 @@ SPDX-License-Identifier: MPL-2.0
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "vault.namespace" . }}
   name: {{ template "vault.fullname" . }}-discovery-role
   labels:
     helm.sh/chart: {{ include "vault.chart" . }}

--- a/templates/server-discovery-rolebinding.yaml
+++ b/templates/server-discovery-rolebinding.yaml
@@ -15,7 +15,7 @@ apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: RoleBinding
 metadata:
   name: {{ template "vault.fullname" . }}-discovery-rolebinding
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "vault.namespace" . }}
   labels:
     helm.sh/chart: {{ include "vault.chart" . }}
     app.kubernetes.io/name: {{ include "vault.name" . }}
@@ -28,7 +28,7 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: {{ template "vault.serviceAccount.name" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "vault.namespace" . }}
 {{ end }}
 {{ end }}
 {{ end }}

--- a/templates/server-disruptionbudget.yaml
+++ b/templates/server-disruptionbudget.yaml
@@ -13,7 +13,7 @@ apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: {{ template "vault.fullname" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "vault.namespace" . }}
   labels:
     helm.sh/chart: {{ include "vault.chart" . }}
     app.kubernetes.io/name: {{ include "vault.name" . }}

--- a/templates/server-ha-active-service.yaml
+++ b/templates/server-ha-active-service.yaml
@@ -14,7 +14,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ template "vault.fullname" . }}-active
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "vault.namespace" . }}
   labels:
     helm.sh/chart: {{ include "vault.chart" . }}
     app.kubernetes.io/name: {{ include "vault.name" . }}

--- a/templates/server-ha-standby-service.yaml
+++ b/templates/server-ha-standby-service.yaml
@@ -14,7 +14,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ template "vault.fullname" . }}-standby
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "vault.namespace" . }}
   labels:
     helm.sh/chart: {{ include "vault.chart" . }}
     app.kubernetes.io/name: {{ include "vault.name" . }}

--- a/templates/server-headless-service.yaml
+++ b/templates/server-headless-service.yaml
@@ -12,7 +12,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ template "vault.fullname" . }}-internal
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "vault.namespace" . }}
   labels:
     helm.sh/chart: {{ include "vault.chart" . }}
     app.kubernetes.io/name: {{ include "vault.name" . }}

--- a/templates/server-ingress.yaml
+++ b/templates/server-ingress.yaml
@@ -21,7 +21,7 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ template "vault.fullname" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "vault.namespace" . }}
   labels:
     helm.sh/chart: {{ include "vault.chart" . }}
     app.kubernetes.io/name: {{ include "vault.name" . }}

--- a/templates/server-psp-role.yaml
+++ b/templates/server-psp-role.yaml
@@ -10,7 +10,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: {{ template "vault.fullname" . }}-psp
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "vault.namespace" . }}
   labels:
     app.kubernetes.io/name: {{ include "vault.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}

--- a/templates/server-psp-rolebinding.yaml
+++ b/templates/server-psp-rolebinding.yaml
@@ -10,7 +10,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: {{ template "vault.fullname" . }}-psp
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "vault.namespace" . }}
   labels:
     app.kubernetes.io/name: {{ include "vault.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}

--- a/templates/server-route.yaml
+++ b/templates/server-route.yaml
@@ -14,7 +14,7 @@ kind: Route
 apiVersion: route.openshift.io/v1
 metadata:
   name: {{ template "vault.fullname" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "vault.namespace" . }}
   labels:
     helm.sh/chart: {{ include "vault.chart" . }}
     app.kubernetes.io/name: {{ include "vault.name" . }}

--- a/templates/server-service.yaml
+++ b/templates/server-service.yaml
@@ -12,7 +12,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ template "vault.fullname" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "vault.namespace" . }}
   labels:
     helm.sh/chart: {{ include "vault.chart" . }}
     app.kubernetes.io/name: {{ include "vault.name" . }}

--- a/templates/server-serviceaccount.yaml
+++ b/templates/server-serviceaccount.yaml
@@ -9,7 +9,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ template "vault.serviceAccount.name" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "vault.namespace" . }}
   labels:
     helm.sh/chart: {{ include "vault.chart" . }}
     app.kubernetes.io/name: {{ include "vault.name" . }}

--- a/templates/server-statefulset.yaml
+++ b/templates/server-statefulset.yaml
@@ -12,7 +12,7 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: {{ template "vault.fullname" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "vault.namespace" . }}
   labels:
     app.kubernetes.io/name: {{ include "vault.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}

--- a/templates/tests/server-test.yaml
+++ b/templates/tests/server-test.yaml
@@ -10,7 +10,7 @@ apiVersion: v1
 kind: Pod
 metadata:
   name: "{{ .Release.Name }}-server-test"
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "vault.namespace" . }}
   annotations:
     "helm.sh/hook": test
 spec:

--- a/templates/tests/server-test.yaml
+++ b/templates/tests/server-test.yaml
@@ -21,7 +21,7 @@ spec:
       imagePullPolicy: {{ .Values.server.image.pullPolicy }}
       env:
         - name: VAULT_ADDR
-          value: {{ include "vault.scheme" . }}://{{ template "vault.fullname" . }}.{{ .Release.Namespace }}.svc:{{ .Values.server.service.port }}
+          value: {{ include "vault.scheme" . }}://{{ template "vault.fullname" . }}.{{ include "vault.namespace" . }}.svc:{{ .Values.server.service.port }}
         {{- include "vault.extraEnvironmentVars" .Values.server | nindent 8 }}
       command:
         - /bin/sh

--- a/templates/ui-service.yaml
+++ b/templates/ui-service.yaml
@@ -12,7 +12,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ template "vault.fullname" . }}-ui
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "vault.namespace" . }}
   labels:
     helm.sh/chart: {{ include "vault.chart" . }}
     app.kubernetes.io/name: {{ include "vault.name" . }}-ui

--- a/test/unit/csi-agent-configmap.bats
+++ b/test/unit/csi-agent-configmap.bats
@@ -33,7 +33,7 @@ load _helpers
   local actual=$(helm template \
       --show-only templates/csi-agent-configmap.yaml \
       --set "csi.enabled=true" \
-      --set 'namespaceOverride=bar' \
+      --set 'global.namespace=bar' \
       --namespace foo \
       . | tee /dev/stderr |
       yq -r '.metadata.namespace' | tee /dev/stderr)

--- a/test/unit/csi-agent-configmap.bats
+++ b/test/unit/csi-agent-configmap.bats
@@ -21,6 +21,25 @@ load _helpers
   [ "${actual}" = "release-name-vault-csi-provider-agent-config" ]
 }
 
+@test "csi/Agent-ConfigMap: namespace" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/csi-agent-configmap.yaml \
+      --set "csi.enabled=true" \
+      --namespace foo \
+      . | tee /dev/stderr |
+      yq -r '.metadata.namespace' | tee /dev/stderr)
+  [ "${actual}" = "foo" ]
+  local actual=$(helm template \
+      --show-only templates/csi-agent-configmap.yaml \
+      --set "csi.enabled=true" \
+      --set 'namespaceOverride=bar' \
+      --namespace foo \
+      . | tee /dev/stderr |
+      yq -r '.metadata.namespace' | tee /dev/stderr)
+  [ "${actual}" = "bar" ]
+}
+
 @test "csi/Agent-ConfigMap: Vault addr not affected by injector setting" {
   cd `chart_dir`
   local actual=$(helm template \

--- a/test/unit/csi-clusterrolebinding.bats
+++ b/test/unit/csi-clusterrolebinding.bats
@@ -56,7 +56,7 @@ load _helpers
   local actual=$(helm template \
       --show-only templates/csi-clusterrolebinding.yaml \
       --set "csi.enabled=true" \
-      --set 'namespaceOverride=bar' \
+      --set 'global.namespace=bar' \
       --namespace foo \
       . | tee /dev/stderr |
       yq -r '.subjects[0].namespace' | tee /dev/stderr)

--- a/test/unit/csi-clusterrolebinding.bats
+++ b/test/unit/csi-clusterrolebinding.bats
@@ -42,3 +42,23 @@ load _helpers
       yq -r '.subjects[0].name' | tee /dev/stderr)
   [ "${actual}" = "release-name-vault-csi-provider" ]
 }
+
+# ClusterRoleBinding service account namespace
+@test "csi/ClusterRoleBinding: service account namespace" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/csi-clusterrolebinding.yaml \
+      --set "csi.enabled=true" \
+      --namespace foo \
+      . | tee /dev/stderr |
+      yq -r '.subjects[0].namespace' | tee /dev/stderr)
+  [ "${actual}" = "foo" ]
+  local actual=$(helm template \
+      --show-only templates/csi-clusterrolebinding.yaml \
+      --set "csi.enabled=true" \
+      --set 'namespaceOverride=bar' \
+      --namespace foo \
+      . | tee /dev/stderr |
+      yq -r '.subjects[0].namespace' | tee /dev/stderr)
+  [ "${actual}" = "bar" ]
+}

--- a/test/unit/csi-daemonset.bats
+++ b/test/unit/csi-daemonset.bats
@@ -43,7 +43,7 @@ load _helpers
   local actual=$(helm template \
       --show-only templates/csi-daemonset.yaml \
       --set "csi.enabled=true" \
-      --set 'namespaceOverride=bar' \
+      --set 'global.namespace=bar' \
       --namespace foo \
       . | tee /dev/stderr |
       yq -r '.metadata.namespace' | tee /dev/stderr)

--- a/test/unit/csi-daemonset.bats
+++ b/test/unit/csi-daemonset.bats
@@ -30,6 +30,26 @@ load _helpers
   [ "${actual}" = "true" ]
 }
 
+# namespace
+@test "csi/daemonset: namespace" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/csi-daemonset.yaml \
+      --set "csi.enabled=true" \
+      --namespace foo \
+      . | tee /dev/stderr |
+      yq -r '.metadata.namespace' | tee /dev/stderr)
+  [ "${actual}" = "foo" ]
+  local actual=$(helm template \
+      --show-only templates/csi-daemonset.yaml \
+      --set "csi.enabled=true" \
+      --set 'namespaceOverride=bar' \
+      --namespace foo \
+      . | tee /dev/stderr |
+      yq -r '.metadata.namespace' | tee /dev/stderr)
+  [ "${actual}" = "bar" ]
+}
+
 # priorityClassName
 
 @test "csi/daemonset: priorityClassName not set by default" {

--- a/test/unit/csi-role.bats
+++ b/test/unit/csi-role.bats
@@ -27,6 +27,25 @@ load _helpers
   [ "${actual}" = "vault-csi-provider-hmac-key" ]
 }
 
+@test "csi/Role: namespace" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/csi-role.yaml \
+      --set "csi.enabled=true" \
+      --namespace foo \
+      . | tee /dev/stderr |
+      yq -r '.metadata.namespace' | tee /dev/stderr)
+  [ "${actual}" = "foo" ]
+  local actual=$(helm template \
+      --show-only templates/csi-role.yaml \
+      --set "csi.enabled=true" \
+      --set 'namespaceOverride=bar' \
+      --namespace foo \
+      . | tee /dev/stderr |
+      yq -r '.metadata.namespace' | tee /dev/stderr)
+  [ "${actual}" = "bar" ]
+}
+
 @test "csi/Role: HMAC secret name configurable" {
   cd `chart_dir`
   local actual=$(helm template \

--- a/test/unit/csi-role.bats
+++ b/test/unit/csi-role.bats
@@ -39,7 +39,7 @@ load _helpers
   local actual=$(helm template \
       --show-only templates/csi-role.yaml \
       --set "csi.enabled=true" \
-      --set 'namespaceOverride=bar' \
+      --set 'global.namespace=bar' \
       --namespace foo \
       . | tee /dev/stderr |
       yq -r '.metadata.namespace' | tee /dev/stderr)

--- a/test/unit/csi-rolebinding.bats
+++ b/test/unit/csi-rolebinding.bats
@@ -33,7 +33,7 @@ load _helpers
   local actual=$(helm template \
       --show-only templates/csi-rolebinding.yaml \
       --set "csi.enabled=true" \
-      --set 'namespaceOverride=bar' \
+      --set 'global.namespace=bar' \
       --namespace foo \
       . | tee /dev/stderr |
       yq -r '.metadata.namespace' | tee /dev/stderr)

--- a/test/unit/csi-rolebinding.bats
+++ b/test/unit/csi-rolebinding.bats
@@ -20,3 +20,22 @@ load _helpers
       yq -r '.metadata.name' | tee /dev/stderr)
   [ "${actual}" = "release-name-vault-csi-provider-rolebinding" ]
 }
+
+@test "csi/RoleBinding: namespace" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/csi-rolebinding.yaml \
+      --set "csi.enabled=true" \
+      --namespace foo \
+      . | tee /dev/stderr |
+      yq -r '.metadata.namespace' | tee /dev/stderr)
+  [ "${actual}" = "foo" ]
+  local actual=$(helm template \
+      --show-only templates/csi-rolebinding.yaml \
+      --set "csi.enabled=true" \
+      --set 'namespaceOverride=bar' \
+      --namespace foo \
+      . | tee /dev/stderr |
+      yq -r '.metadata.namespace' | tee /dev/stderr)
+  [ "${actual}" = "bar" ]
+}

--- a/test/unit/csi-serviceaccount.bats
+++ b/test/unit/csi-serviceaccount.bats
@@ -45,7 +45,7 @@ load _helpers
   local actual=$(helm template \
       --show-only templates/csi-serviceaccount.yaml \
       --set "csi.enabled=true" \
-      --set 'namespaceOverride=bar' \
+      --set 'global.namespace=bar' \
       --namespace foo \
       . | tee /dev/stderr |
       yq -r '.metadata.namespace' | tee /dev/stderr)

--- a/test/unit/csi-serviceaccount.bats
+++ b/test/unit/csi-serviceaccount.bats
@@ -32,6 +32,26 @@ load _helpers
   [ "${actual}" = "release-name-vault-csi-provider" ]
 }
 
+# serviceAccountNamespace namespace
+@test "csi/daemonset: serviceAccountNamespace namespace" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/csi-serviceaccount.yaml \
+      --set "csi.enabled=true" \
+      --namespace foo \
+      . | tee /dev/stderr |
+      yq -r '.metadata.namespace' | tee /dev/stderr)
+  [ "${actual}" = "foo" ]
+  local actual=$(helm template \
+      --show-only templates/csi-serviceaccount.yaml \
+      --set "csi.enabled=true" \
+      --set 'namespaceOverride=bar' \
+      --namespace foo \
+      . | tee /dev/stderr |
+      yq -r '.metadata.namespace' | tee /dev/stderr)
+  [ "${actual}" = "bar" ]
+}
+
 @test "csi/serviceAccount: specify annotations" {
   cd `chart_dir`
   local actual=$(helm template \

--- a/test/unit/injector-clusterrolebinding.bats
+++ b/test/unit/injector-clusterrolebinding.bats
@@ -20,3 +20,22 @@ load _helpers
       yq 'length > 0' | tee /dev/stderr)
   [ "${actual}" = "false" ]
 }
+
+@test "injector/ClusterRoleBinding: service account namespace" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/injector-clusterrolebinding.yaml \
+      --set "injector.enabled=true" \
+      --namespace foo \
+      . | tee /dev/stderr |
+      yq -r '.subjects[0].namespace' | tee /dev/stderr)
+  [ "${actual}" = "foo" ]
+  local actual=$(helm template \
+      --show-only templates/injector-clusterrolebinding.yaml \
+      --set "injector.enabled=true" \
+      --set 'namespaceOverride=bar' \
+      --namespace foo \
+      . | tee /dev/stderr |
+      yq -r '.subjects[0].namespace' | tee /dev/stderr)
+  [ "${actual}" = "bar" ]
+}

--- a/test/unit/injector-clusterrolebinding.bats
+++ b/test/unit/injector-clusterrolebinding.bats
@@ -33,7 +33,7 @@ load _helpers
   local actual=$(helm template \
       --show-only templates/injector-clusterrolebinding.yaml \
       --set "injector.enabled=true" \
-      --set 'namespaceOverride=bar' \
+      --set 'global.namespace=bar' \
       --namespace foo \
       . | tee /dev/stderr |
       yq -r '.subjects[0].namespace' | tee /dev/stderr)

--- a/test/unit/injector-deployment.bats
+++ b/test/unit/injector-deployment.bats
@@ -42,6 +42,25 @@ load _helpers
   [ "${actual}" = "true" ]
 }
 
+@test "injector/deployment: namespace" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/injector-deployment.yaml  \
+      --set 'injector.enabled=true' \
+      --namespace foo \
+      . | tee /dev/stderr |
+      yq -r '.metadata.namespace' | tee /dev/stderr)
+  [ "${actual}" = "foo" ]
+  local actual=$(helm template \
+      --show-only templates/injector-deployment.yaml  \
+      --set 'injector.enabled=true' \
+      --set 'namespaceOverride=bar' \
+      --namespace foo \
+      . | tee /dev/stderr |
+      yq -r '.metadata.namespace' | tee /dev/stderr)
+  [ "${actual}" = "bar" ]
+}
+
 @test "injector/deployment: image defaults to injector.image" {
   cd `chart_dir`
   local actual=$(helm template \

--- a/test/unit/injector-deployment.bats
+++ b/test/unit/injector-deployment.bats
@@ -54,7 +54,7 @@ load _helpers
   local actual=$(helm template \
       --show-only templates/injector-deployment.yaml  \
       --set 'injector.enabled=true' \
-      --set 'namespaceOverride=bar' \
+      --set 'global.namespace=bar' \
       --namespace foo \
       . | tee /dev/stderr |
       yq -r '.metadata.namespace' | tee /dev/stderr)

--- a/test/unit/injector-disruptionbudget.bats
+++ b/test/unit/injector-disruptionbudget.bats
@@ -23,7 +23,7 @@ load _helpers
   local actual=$(helm template \
       --show-only templates/injector-disruptionbudget.yaml \
       --set 'injector.podDisruptionBudget.minAvailable=2' \
-      --set 'namespaceOverride=bar' \
+      --set 'global.namespace=bar' \
       --namespace foo \
       . | tee /dev/stderr |
       yq -r '.metadata.namespace' | tee /dev/stderr)

--- a/test/unit/injector-disruptionbudget.bats
+++ b/test/unit/injector-disruptionbudget.bats
@@ -11,6 +11,25 @@ load _helpers
   [ "${actual}" = "false" ]
 }
 
+@test "injector/DisruptionBudget: namespace" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/injector-disruptionbudget.yaml \
+      --set 'injector.podDisruptionBudget.minAvailable=2' \
+      --namespace foo \
+      . | tee /dev/stderr |
+      yq -r '.metadata.namespace' | tee /dev/stderr)
+  [ "${actual}" = "foo" ]
+  local actual=$(helm template \
+      --show-only templates/injector-disruptionbudget.yaml \
+      --set 'injector.podDisruptionBudget.minAvailable=2' \
+      --set 'namespaceOverride=bar' \
+      --namespace foo \
+      . | tee /dev/stderr |
+      yq -r '.metadata.namespace' | tee /dev/stderr)
+  [ "${actual}" = "bar" ]
+}
+
 @test "injector/DisruptionBudget: configure with injector.podDisruptionBudget minAvailable" {
   cd `chart_dir`
   local actual=$(helm template \

--- a/test/unit/injector-leader-elector.bats
+++ b/test/unit/injector-leader-elector.bats
@@ -99,14 +99,7 @@ load _helpers
   local actual=$( (helm template \
       --show-only templates/injector-certs-secret.yaml \
       --set "injector.replicas=2" \
-      --namespace foo \
-      . || echo "---") | tee /dev/stderr |
-      yq '.metadata.namespace' | tee /dev/stderr)
-  [ "${actual}" = "foo" ]
-  local actual=$( (helm template \
-      --show-only templates/injector-certs-secret.yaml \
-      --set "injector.replicas=2" \
-      --set 'namespaceOverride=bar' \
+      --set 'global.namespace=bar' \
       --namespace foo \
       . || echo "---") | tee /dev/stderr |
       yq '.metadata.namespace' | tee /dev/stderr)
@@ -165,14 +158,7 @@ load _helpers
   local actual=$( (helm template \
       --show-only templates/injector-role.yaml \
       --set "injector.replicas=2" \
-      --namespace foo \
-      . || echo "---") | tee /dev/stderr |
-      yq '.metadata.namespace' | tee /dev/stderr)
-  [ "${actual}" = "foo" ]
-  local actual=$( (helm template \
-      --show-only templates/injector-role.yaml \
-      --set "injector.replicas=2" \
-      --set 'namespaceOverride=bar' \
+      --set 'global.namespace=bar' \
       --namespace foo \
       . || echo "---") | tee /dev/stderr |
       yq '.metadata.namespace' | tee /dev/stderr)
@@ -231,14 +217,7 @@ load _helpers
   local actual=$( (helm template \
       --show-only templates/injector-rolebinding.yaml \
       --set "injector.replicas=2" \
-      --namespace foo \
-      . || echo "---") | tee /dev/stderr |
-      yq '.metadata.namespace' | tee /dev/stderr)
-  [ "${actual}" = "foo" ]
-  local actual=$( (helm template \
-      --show-only templates/injector-rolebinding.yaml \
-      --set "injector.replicas=2" \
-      --set 'namespaceOverride=bar' \
+      --set 'global.namespace=bar' \
       --namespace foo \
       . || echo "---") | tee /dev/stderr |
       yq '.metadata.namespace' | tee /dev/stderr)

--- a/test/unit/injector-leader-elector.bats
+++ b/test/unit/injector-leader-elector.bats
@@ -95,7 +95,7 @@ load _helpers
       --namespace foo \
       . || echo "---") | tee /dev/stderr |
       yq '.metadata.namespace' | tee /dev/stderr)
-  [ "${actual}" = "foo" ]
+  [ "${actual}" = "\"foo\"" ]
   local actual=$( (helm template \
       --show-only templates/injector-certs-secret.yaml \
       --set "injector.replicas=2" \
@@ -103,7 +103,7 @@ load _helpers
       --namespace foo \
       . || echo "---") | tee /dev/stderr |
       yq '.metadata.namespace' | tee /dev/stderr)
-  [ "${actual}" = "bar" ]
+  [ "${actual}" = "\"bar\"" ]
 }
 
 @test "injector/role: created/skipped as appropriate" {
@@ -154,7 +154,7 @@ load _helpers
       --namespace foo \
       . || echo "---") | tee /dev/stderr |
       yq '.metadata.namespace' | tee /dev/stderr)
-  [ "${actual}" = "foo" ]
+  [ "${actual}" = "\"foo\"" ]
   local actual=$( (helm template \
       --show-only templates/injector-role.yaml \
       --set "injector.replicas=2" \
@@ -162,7 +162,7 @@ load _helpers
       --namespace foo \
       . || echo "---") | tee /dev/stderr |
       yq '.metadata.namespace' | tee /dev/stderr)
-  [ "${actual}" = "bar" ]
+  [ "${actual}" = "\"bar\"" ]
 }
 
 @test "injector/rolebinding: created/skipped as appropriate" {
@@ -213,7 +213,7 @@ load _helpers
       --namespace foo \
       . || echo "---") | tee /dev/stderr |
       yq '.metadata.namespace' | tee /dev/stderr)
-  [ "${actual}" = "foo" ]
+  [ "${actual}" = "\"foo\"" ]
   local actual=$( (helm template \
       --show-only templates/injector-rolebinding.yaml \
       --set "injector.replicas=2" \
@@ -221,5 +221,5 @@ load _helpers
       --namespace foo \
       . || echo "---") | tee /dev/stderr |
       yq '.metadata.namespace' | tee /dev/stderr)
-  [ "${actual}" = "bar" ]
+  [ "${actual}" = "\"bar\"" ]
 }

--- a/test/unit/injector-leader-elector.bats
+++ b/test/unit/injector-leader-elector.bats
@@ -95,7 +95,22 @@ load _helpers
       --namespace foo \
       . || echo "---") | tee /dev/stderr |
       yq '.metadata.namespace' | tee /dev/stderr)
-  [ "${actual}" = "\"foo\"" ]
+  [ "${actual}" = "foo" ]
+  local actual=$( (helm template \
+      --show-only templates/injector-certs-secret.yaml \
+      --set "injector.replicas=2" \
+      --namespace foo \
+      . || echo "---") | tee /dev/stderr |
+      yq '.metadata.namespace' | tee /dev/stderr)
+  [ "${actual}" = "foo" ]
+  local actual=$( (helm template \
+      --show-only templates/injector-certs-secret.yaml \
+      --set "injector.replicas=2" \
+      --set 'namespaceOverride=bar' \
+      --namespace foo \
+      . || echo "---") | tee /dev/stderr |
+      yq '.metadata.namespace' | tee /dev/stderr)
+  [ "${actual}" = "bar" ]
 }
 
 @test "injector/role: created/skipped as appropriate" {
@@ -146,7 +161,22 @@ load _helpers
       --namespace foo \
       . || echo "---") | tee /dev/stderr |
       yq '.metadata.namespace' | tee /dev/stderr)
-  [ "${actual}" = "\"foo\"" ]
+  [ "${actual}" = "foo" ]
+  local actual=$( (helm template \
+      --show-only templates/injector-role.yaml \
+      --set "injector.replicas=2" \
+      --namespace foo \
+      . || echo "---") | tee /dev/stderr |
+      yq '.metadata.namespace' | tee /dev/stderr)
+  [ "${actual}" = "foo" ]
+  local actual=$( (helm template \
+      --show-only templates/injector-role.yaml \
+      --set "injector.replicas=2" \
+      --set 'namespaceOverride=bar' \
+      --namespace foo \
+      . || echo "---") | tee /dev/stderr |
+      yq '.metadata.namespace' | tee /dev/stderr)
+  [ "${actual}" = "bar" ]
 }
 
 @test "injector/rolebinding: created/skipped as appropriate" {
@@ -197,5 +227,20 @@ load _helpers
       --namespace foo \
       . || echo "---") | tee /dev/stderr |
       yq '.metadata.namespace' | tee /dev/stderr)
-  [ "${actual}" = "\"foo\"" ]
+  [ "${actual}" = "foo" ]
+  local actual=$( (helm template \
+      --show-only templates/injector-rolebinding.yaml \
+      --set "injector.replicas=2" \
+      --namespace foo \
+      . || echo "---") | tee /dev/stderr |
+      yq '.metadata.namespace' | tee /dev/stderr)
+  [ "${actual}" = "foo" ]
+  local actual=$( (helm template \
+      --show-only templates/injector-rolebinding.yaml \
+      --set "injector.replicas=2" \
+      --set 'namespaceOverride=bar' \
+      --namespace foo \
+      . || echo "---") | tee /dev/stderr |
+      yq '.metadata.namespace' | tee /dev/stderr)
+  [ "${actual}" = "bar" ]
 }

--- a/test/unit/injector-mutating-webhook.bats
+++ b/test/unit/injector-mutating-webhook.bats
@@ -39,7 +39,7 @@ load _helpers
       --namespace foo \
       . | tee /dev/stderr |
       yq '.webhooks[0].clientConfig.service.namespace' | tee /dev/stderr)
-  [ "${actual}" = "foo" ]
+  [ "${actual}" = "\"foo\"" ]
   local actual=$(helm template \
       --show-only templates/injector-mutating-webhook.yaml  \
       --set 'injector.enabled=true' \
@@ -47,7 +47,7 @@ load _helpers
       --namespace foo \
       . | tee /dev/stderr |
       yq '.webhooks[0].clientConfig.service.namespace' | tee /dev/stderr)
-  [ "${actual}" = "bar" ]
+  [ "${actual}" = "\"bar\"" ]
 }
 
 @test "injector/MutatingWebhookConfiguration: caBundle is empty string" {

--- a/test/unit/injector-mutating-webhook.bats
+++ b/test/unit/injector-mutating-webhook.bats
@@ -39,7 +39,22 @@ load _helpers
       --namespace foo \
       . | tee /dev/stderr |
       yq '.webhooks[0].clientConfig.service.namespace' | tee /dev/stderr)
-  [ "${actual}" = "\"foo\"" ]
+  [ "${actual}" = "foo" ]
+  local actual=$(helm template \
+      --show-only templates/injector-mutating-webhook.yaml  \
+      --set 'injector.enabled=true' \
+      --namespace foo \
+      . | tee /dev/stderr |
+      yq '.webhooks[0].clientConfig.service.namespace' | tee /dev/stderr)
+  [ "${actual}" = "foo" ]
+  local actual=$(helm template \
+      --show-only templates/injector-mutating-webhook.yaml  \
+      --set 'injector.enabled=true' \
+      --set 'namespaceOverride=bar' \
+      --namespace foo \
+      . | tee /dev/stderr |
+      yq '.webhooks[0].clientConfig.service.namespace' | tee /dev/stderr)
+  [ "${actual}" = "bar" ]
 }
 
 @test "injector/MutatingWebhookConfiguration: caBundle is empty string" {

--- a/test/unit/injector-mutating-webhook.bats
+++ b/test/unit/injector-mutating-webhook.bats
@@ -43,14 +43,7 @@ load _helpers
   local actual=$(helm template \
       --show-only templates/injector-mutating-webhook.yaml  \
       --set 'injector.enabled=true' \
-      --namespace foo \
-      . | tee /dev/stderr |
-      yq '.webhooks[0].clientConfig.service.namespace' | tee /dev/stderr)
-  [ "${actual}" = "foo" ]
-  local actual=$(helm template \
-      --show-only templates/injector-mutating-webhook.yaml  \
-      --set 'injector.enabled=true' \
-      --set 'namespaceOverride=bar' \
+      --set 'global.namespace=bar' \
       --namespace foo \
       . | tee /dev/stderr |
       yq '.webhooks[0].clientConfig.service.namespace' | tee /dev/stderr)

--- a/test/unit/injector-psp-role.bats
+++ b/test/unit/injector-psp-role.bats
@@ -33,3 +33,24 @@ load _helpers
       yq 'length > 0' | tee /dev/stderr)
   [ "${actual}" = "true" ]
 }
+
+@test "injector/PodSecurityPolicy-Role: namespace" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/injector-psp-role.yaml  \
+      --set 'injector.enabled=true' \
+      --set 'global.psp.enable=true' \
+      --namespace foo \
+      . | tee /dev/stderr |
+      yq -r '.metadata.namespace' | tee /dev/stderr)
+  [ "${actual}" = "foo" ]
+  local actual=$(helm template \
+      --show-only templates/injector-psp-role.yaml  \
+      --set 'injector.enabled=true' \
+      --set 'global.psp.enable=true' \
+      --set 'namespaceOverride=bar' \
+      --namespace foo \
+      . | tee /dev/stderr |
+      yq -r '.metadata.namespace' | tee /dev/stderr)
+  [ "${actual}" = "bar" ]
+}

--- a/test/unit/injector-psp-role.bats
+++ b/test/unit/injector-psp-role.bats
@@ -48,7 +48,7 @@ load _helpers
       --show-only templates/injector-psp-role.yaml  \
       --set 'injector.enabled=true' \
       --set 'global.psp.enable=true' \
-      --set 'namespaceOverride=bar' \
+      --set 'global.namespace=bar' \
       --namespace foo \
       . | tee /dev/stderr |
       yq -r '.metadata.namespace' | tee /dev/stderr)

--- a/test/unit/injector-psp-rolebinding.bats
+++ b/test/unit/injector-psp-rolebinding.bats
@@ -33,3 +33,24 @@ load _helpers
       yq 'length > 0' | tee /dev/stderr)
   [ "${actual}" = "true" ]
 }
+
+@test "injector/PodSecurityPolicy-RoleBinding: namespace" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/injector-psp-rolebinding.yaml  \
+      --set 'injector.enabled=true' \
+      --set 'global.psp.enable=true' \
+      --namespace foo \
+      . | tee /dev/stderr |
+      yq -r '.metadata.namespace' | tee /dev/stderr)
+  [ "${actual}" = "foo" ]
+  local actual=$(helm template \
+      --show-only templates/injector-psp-rolebinding.yaml  \
+      --set 'injector.enabled=true' \
+      --set 'global.psp.enable=true' \
+      --set 'namespaceOverride=bar' \
+      --namespace foo \
+      . | tee /dev/stderr |
+      yq -r '.metadata.namespace' | tee /dev/stderr)
+  [ "${actual}" = "bar" ]
+}

--- a/test/unit/injector-psp-rolebinding.bats
+++ b/test/unit/injector-psp-rolebinding.bats
@@ -48,7 +48,7 @@ load _helpers
       --show-only templates/injector-psp-rolebinding.yaml  \
       --set 'injector.enabled=true' \
       --set 'global.psp.enable=true' \
-      --set 'namespaceOverride=bar' \
+      --set 'global.namespace=bar' \
       --namespace foo \
       . | tee /dev/stderr |
       yq -r '.metadata.namespace' | tee /dev/stderr)

--- a/test/unit/injector-service.bats
+++ b/test/unit/injector-service.bats
@@ -18,6 +18,23 @@ load _helpers
   [ "${actual}" = "true" ]
 }
 
+@test "injector/Service: namespace" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/injector-service.yaml \
+      --namespace foo \
+      . | tee /dev/stderr |
+      yq -r '.metadata.namespace' | tee /dev/stderr)
+  [ "${actual}" = "foo" ]
+  local actual=$(helm template \
+      --show-only templates/injector-service.yaml \
+      --set 'namespaceOverride=bar' \
+      --namespace foo \
+      . | tee /dev/stderr |
+      yq -r '.metadata.namespace' | tee /dev/stderr)
+  [ "${actual}" = "bar" ]
+}
+
 @test "injector/Service: service with default port" {
   cd `chart_dir`
   local actual=$(helm template \

--- a/test/unit/injector-service.bats
+++ b/test/unit/injector-service.bats
@@ -28,7 +28,7 @@ load _helpers
   [ "${actual}" = "foo" ]
   local actual=$(helm template \
       --show-only templates/injector-service.yaml \
-      --set 'namespaceOverride=bar' \
+      --set 'global.namespace=bar' \
       --namespace foo \
       . | tee /dev/stderr |
       yq -r '.metadata.namespace' | tee /dev/stderr)

--- a/test/unit/injector-serviceaccount.bats
+++ b/test/unit/injector-serviceaccount.bats
@@ -21,6 +21,23 @@ load _helpers
   [ "${actual}" = "false" ]
 }
 
+@test "injector/ServiceAccount: namespace" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/injector-serviceaccount.yaml \
+      --namespace foo \
+      . | tee /dev/stderr |
+      yq -r '.metadata.namespace' | tee /dev/stderr)
+  [ "${actual}" = "foo" ]
+  local actual=$(helm template \
+      --show-only templates/injector-serviceaccount.yaml \
+      --set 'namespaceOverride=bar' \
+      --namespace foo \
+      . | tee /dev/stderr |
+      yq -r '.metadata.namespace' | tee /dev/stderr)
+  [ "${actual}" = "bar" ]
+}
+
 @test "injector/ServiceAccount: generic annotations" {
   cd `chart_dir`
   local actual=$(helm template \

--- a/test/unit/injector-serviceaccount.bats
+++ b/test/unit/injector-serviceaccount.bats
@@ -31,7 +31,7 @@ load _helpers
   [ "${actual}" = "foo" ]
   local actual=$(helm template \
       --show-only templates/injector-serviceaccount.yaml \
-      --set 'namespaceOverride=bar' \
+      --set 'global.namespace=bar' \
       --namespace foo \
       . | tee /dev/stderr |
       yq -r '.metadata.namespace' | tee /dev/stderr)

--- a/test/unit/server-clusterrolebinding.bats
+++ b/test/unit/server-clusterrolebinding.bats
@@ -71,3 +71,20 @@ load _helpers
       yq 'length > 0' | tee /dev/stderr)
   [ "${actual}" = "true" ]
 }
+
+@test "server/ClusterRoleBinding: service account namespace" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/server-clusterrolebinding.yaml \
+      --namespace foo \
+      . | tee /dev/stderr |
+      yq -r '.subjects[0].namespace' | tee /dev/stderr)
+  [ "${actual}" = "foo" ]
+  local actual=$(helm template \
+      --show-only templates/server-clusterrolebinding.yaml \
+      --set 'namespaceOverride=bar' \
+      --namespace foo \
+      . | tee /dev/stderr |
+      yq -r '.subjects[0].namespace' | tee /dev/stderr)
+  [ "${actual}" = "bar" ]
+}

--- a/test/unit/server-clusterrolebinding.bats
+++ b/test/unit/server-clusterrolebinding.bats
@@ -82,7 +82,7 @@ load _helpers
   [ "${actual}" = "foo" ]
   local actual=$(helm template \
       --show-only templates/server-clusterrolebinding.yaml \
-      --set 'namespaceOverride=bar' \
+      --set 'global.namespace=bar' \
       --namespace foo \
       . | tee /dev/stderr |
       yq -r '.subjects[0].namespace' | tee /dev/stderr)

--- a/test/unit/server-configmap.bats
+++ b/test/unit/server-configmap.bats
@@ -75,6 +75,23 @@ load _helpers
   [ "${actual}" = "false" ]
 }
 
+@test "server/ConfigMap: namespace" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/server-config-configmap.yaml \
+      --namespace foo \
+      . | tee /dev/stderr |
+      yq -r '.metadata.namespace' | tee /dev/stderr)
+  [ "${actual}" = "foo" ]
+  local actual=$(helm template \
+      --show-only templates/server-config-configmap.yaml \
+      --set 'namespaceOverride=bar' \
+      --namespace foo \
+      . | tee /dev/stderr |
+      yq -r '.metadata.namespace' | tee /dev/stderr)
+  [ "${actual}" = "bar" ]
+}
+
 @test "server/ConfigMap: standalone extraConfig is set" {
   cd `chart_dir`
   local actual=$(helm template \

--- a/test/unit/server-configmap.bats
+++ b/test/unit/server-configmap.bats
@@ -85,7 +85,7 @@ load _helpers
   [ "${actual}" = "foo" ]
   local actual=$(helm template \
       --show-only templates/server-config-configmap.yaml \
-      --set 'namespaceOverride=bar' \
+      --set 'global.namespace=bar' \
       --namespace foo \
       . | tee /dev/stderr |
       yq -r '.metadata.namespace' | tee /dev/stderr)

--- a/test/unit/server-discovery-role.bats
+++ b/test/unit/server-discovery-role.bats
@@ -52,7 +52,7 @@ load _helpers
   local actual=$(helm template \
       --show-only templates/server-discovery-role.yaml \
       --set 'server.ha.enabled=true' \
-      --set 'namespaceOverride=bar' \
+      --set 'global.namespace=bar' \
       --namespace foo \
       . | tee /dev/stderr |
       yq -r '.metadata.namespace' | tee /dev/stderr)

--- a/test/unit/server-discovery-role.bats
+++ b/test/unit/server-discovery-role.bats
@@ -39,3 +39,22 @@ load _helpers
       yq 'length > 0' | tee /dev/stderr)
   [ "${actual}" = "false" ]
 }
+
+@test "server/DiscoveryRole: namespace" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/server-discovery-role.yaml \
+      --set 'server.ha.enabled=true' \
+      --namespace foo \
+      . | tee /dev/stderr |
+      yq -r '.metadata.namespace' | tee /dev/stderr)
+  [ "${actual}" = "foo" ]
+  local actual=$(helm template \
+      --show-only templates/server-discovery-role.yaml \
+      --set 'server.ha.enabled=true' \
+      --set 'namespaceOverride=bar' \
+      --namespace foo \
+      . | tee /dev/stderr |
+      yq -r '.metadata.namespace' | tee /dev/stderr)
+  [ "${actual}" = "bar" ]
+}

--- a/test/unit/server-discovery-rolebinding.bats
+++ b/test/unit/server-discovery-rolebinding.bats
@@ -52,7 +52,7 @@ load _helpers
   local actual=$(helm template \
       --show-only templates/server-discovery-rolebinding.yaml \
       --set 'server.ha.enabled=true' \
-      --set 'namespaceOverride=bar' \
+      --set 'global.namespace=bar' \
       --namespace foo \
       . | tee /dev/stderr |
       yq -r '.metadata.namespace' | tee /dev/stderr)

--- a/test/unit/server-discovery-rolebinding.bats
+++ b/test/unit/server-discovery-rolebinding.bats
@@ -39,3 +39,22 @@ load _helpers
       yq 'length > 0' | tee /dev/stderr)
   [ "${actual}" = "false" ]
 }
+
+@test "server/DiscoveryRoleBinding: namespace" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/server-discovery-rolebinding.yaml \
+      --set 'server.ha.enabled=true' \
+      --namespace foo \
+      . | tee /dev/stderr |
+      yq -r '.metadata.namespace' | tee /dev/stderr)
+  [ "${actual}" = "foo" ]
+  local actual=$(helm template \
+      --show-only templates/server-discovery-rolebinding.yaml \
+      --set 'server.ha.enabled=true' \
+      --set 'namespaceOverride=bar' \
+      --namespace foo \
+      . | tee /dev/stderr |
+      yq -r '.metadata.namespace' | tee /dev/stderr)
+  [ "${actual}" = "bar" ]
+}

--- a/test/unit/server-ha-active-service.bats
+++ b/test/unit/server-ha-active-service.bats
@@ -47,6 +47,25 @@ load _helpers
   [ "${actual}" = "false" ]
 }
 
+@test "server/ha-active-Service: namespace" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/server-ha-active-service.yaml \
+      --set 'server.ha.enabled=true' \
+      --namespace foo \
+      . | tee /dev/stderr |
+      yq -r '.metadata.namespace' | tee /dev/stderr)
+  [ "${actual}" = "foo" ]
+  local actual=$(helm template \
+      --show-only templates/server-ha-active-service.yaml \
+      --set 'server.ha.enabled=true' \
+      --set 'namespaceOverride=bar' \
+      --namespace foo \
+      . | tee /dev/stderr |
+      yq -r '.metadata.namespace' | tee /dev/stderr)
+  [ "${actual}" = "bar" ]
+}
+
 @test "server/ha-active-Service: type empty by default" {
   cd `chart_dir`
   local actual=$(helm template \

--- a/test/unit/server-ha-active-service.bats
+++ b/test/unit/server-ha-active-service.bats
@@ -59,7 +59,7 @@ load _helpers
   local actual=$(helm template \
       --show-only templates/server-ha-active-service.yaml \
       --set 'server.ha.enabled=true' \
-      --set 'namespaceOverride=bar' \
+      --set 'global.namespace=bar' \
       --namespace foo \
       . | tee /dev/stderr |
       yq -r '.metadata.namespace' | tee /dev/stderr)

--- a/test/unit/server-ha-disruptionbudget.bats
+++ b/test/unit/server-ha-disruptionbudget.bats
@@ -53,6 +53,25 @@ load _helpers
   [ "${actual}" = "false" ]
 }
 
+@test "server/DisruptionBudget: namespace" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/server-disruptionbudget.yaml  \
+      --set 'server.ha.enabled=true' \
+      --namespace foo \
+      . | tee /dev/stderr |
+      yq -r '.metadata.namespace' | tee /dev/stderr)
+  [ "${actual}" = "foo" ]
+  local actual=$(helm template \
+      --show-only templates/server-disruptionbudget.yaml  \
+      --set 'server.ha.enabled=true' \
+      --set 'namespaceOverride=bar' \
+      --namespace foo \
+      . | tee /dev/stderr |
+      yq -r '.metadata.namespace' | tee /dev/stderr)
+  [ "${actual}" = "bar" ]
+}
+
 @test "server/DisruptionBudget: correct maxUnavailable with n=1" {
   cd `chart_dir`
   local actual=$(helm template \

--- a/test/unit/server-ha-disruptionbudget.bats
+++ b/test/unit/server-ha-disruptionbudget.bats
@@ -65,7 +65,7 @@ load _helpers
   local actual=$(helm template \
       --show-only templates/server-disruptionbudget.yaml  \
       --set 'server.ha.enabled=true' \
-      --set 'namespaceOverride=bar' \
+      --set 'global.namespace=bar' \
       --namespace foo \
       . | tee /dev/stderr |
       yq -r '.metadata.namespace' | tee /dev/stderr)

--- a/test/unit/server-ha-standby-service.bats
+++ b/test/unit/server-ha-standby-service.bats
@@ -70,7 +70,7 @@ load _helpers
   local actual=$(helm template \
       --show-only templates/server-ha-standby-service.yaml \
       --set 'server.ha.enabled=true' \
-      --set 'namespaceOverride=bar' \
+      --set 'global.namespace=bar' \
       --namespace foo \
       . | tee /dev/stderr |
       yq -r '.metadata.namespace' | tee /dev/stderr)

--- a/test/unit/server-ha-standby-service.bats
+++ b/test/unit/server-ha-standby-service.bats
@@ -58,6 +58,25 @@ load _helpers
   [ "${actual}" = "false" ]
 }
 
+@test "server/ha-standby-Service: namespace" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/server-ha-standby-service.yaml \
+      --set 'server.ha.enabled=true' \
+      --namespace foo \
+      . | tee /dev/stderr |
+      yq -r '.metadata.namespace' | tee /dev/stderr)
+  [ "${actual}" = "foo" ]
+  local actual=$(helm template \
+      --show-only templates/server-ha-standby-service.yaml \
+      --set 'server.ha.enabled=true' \
+      --set 'namespaceOverride=bar' \
+      --namespace foo \
+      . | tee /dev/stderr |
+      yq -r '.metadata.namespace' | tee /dev/stderr)
+  [ "${actual}" = "bar" ]
+}
+
 @test "server/ha-standby-Service: type empty by default" {
   cd `chart_dir`
   local actual=$(helm template \

--- a/test/unit/server-headless-service.bats
+++ b/test/unit/server-headless-service.bats
@@ -35,3 +35,22 @@ load _helpers
       yq -r '.spec.selector["app.kubernetes.io/instance"]' | tee /dev/stderr)
   [ "${actual}" = "release-name" ]
 }
+
+@test "server/headless-Service: namespace" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/server-headless-service.yaml \
+      --set 'server.ha.enabled=true' \
+      --namespace foo \
+      . | tee /dev/stderr |
+      yq -r '.metadata.namespace' | tee /dev/stderr)
+  [ "${actual}" = "foo" ]
+  local actual=$(helm template \
+      --show-only templates/server-headless-service.yaml \
+      --set 'server.ha.enabled=true' \
+      --set 'namespaceOverride=bar' \
+      --namespace foo \
+      . | tee /dev/stderr |
+      yq -r '.metadata.namespace' | tee /dev/stderr)
+  [ "${actual}" = "bar" ]
+}

--- a/test/unit/server-headless-service.bats
+++ b/test/unit/server-headless-service.bats
@@ -48,7 +48,7 @@ load _helpers
   local actual=$(helm template \
       --show-only templates/server-headless-service.yaml \
       --set 'server.ha.enabled=true' \
-      --set 'namespaceOverride=bar' \
+      --set 'global.namespace=bar' \
       --namespace foo \
       . | tee /dev/stderr |
       yq -r '.metadata.namespace' | tee /dev/stderr)

--- a/test/unit/server-ingress.bats
+++ b/test/unit/server-ingress.bats
@@ -11,6 +11,25 @@ load _helpers
   [ "${actual}" = "false" ]
 }
 
+@test "server/ingress: namespace" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/server-ingress.yaml  \
+      --set 'server.ingress.enabled=true' \
+      --namespace foo \
+      . | tee /dev/stderr |
+      yq -r '.metadata.namespace' | tee /dev/stderr)
+  [ "${actual}" = "foo" ]
+  local actual=$(helm template \
+      --show-only templates/server-ingress.yaml  \
+      --set 'server.ingress.enabled=true' \
+      --set 'namespaceOverride=bar' \
+      --namespace foo \
+      . | tee /dev/stderr |
+      yq -r '.metadata.namespace' | tee /dev/stderr)
+  [ "${actual}" = "bar" ]
+}
+
 @test "server/ingress: disable by injector.externalVaultAddr" {
   cd `chart_dir`
   local actual=$( (helm template \

--- a/test/unit/server-ingress.bats
+++ b/test/unit/server-ingress.bats
@@ -23,7 +23,7 @@ load _helpers
   local actual=$(helm template \
       --show-only templates/server-ingress.yaml  \
       --set 'server.ingress.enabled=true' \
-      --set 'namespaceOverride=bar' \
+      --set 'global.namespace=bar' \
       --namespace foo \
       . | tee /dev/stderr |
       yq -r '.metadata.namespace' | tee /dev/stderr)

--- a/test/unit/server-psp-role.bats
+++ b/test/unit/server-psp-role.bats
@@ -122,7 +122,7 @@ load _helpers
   local actual=$(helm template \
       --show-only templates/server-psp-role.yaml \
       --set 'global.psp.enable=true' \
-      --set 'namespaceOverride=bar' \
+      --set 'global.namespace=bar' \
       --namespace foo \
       . | tee /dev/stderr |
       yq -r '.metadata.namespace' | tee /dev/stderr)

--- a/test/unit/server-psp-role.bats
+++ b/test/unit/server-psp-role.bats
@@ -109,3 +109,22 @@ load _helpers
       yq 'length > 0' | tee /dev/stderr)
   [ "${actual}" = "false" ]
 }
+
+@test "server/PSP-Role: namespace" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/server-psp-role.yaml \
+      --set 'global.psp.enable=true' \
+      --namespace foo \
+      . | tee /dev/stderr |
+      yq -r '.metadata.namespace' | tee /dev/stderr)
+  [ "${actual}" = "foo" ]
+  local actual=$(helm template \
+      --show-only templates/server-psp-role.yaml \
+      --set 'global.psp.enable=true' \
+      --set 'namespaceOverride=bar' \
+      --namespace foo \
+      . | tee /dev/stderr |
+      yq -r '.metadata.namespace' | tee /dev/stderr)
+  [ "${actual}" = "bar" ]
+}

--- a/test/unit/server-psp-rolebinding.bats
+++ b/test/unit/server-psp-rolebinding.bats
@@ -122,7 +122,7 @@ load _helpers
   local actual=$(helm template \
       --show-only templates/server-psp-rolebinding.yaml \
       --set 'global.psp.enable=true' \
-      --set 'namespaceOverride=bar' \
+      --set 'global.namespace=bar' \
       --namespace foo \
       . | tee /dev/stderr |
       yq -r '.metadata.namespace' | tee /dev/stderr)

--- a/test/unit/server-psp-rolebinding.bats
+++ b/test/unit/server-psp-rolebinding.bats
@@ -109,3 +109,22 @@ load _helpers
       yq 'length > 0' | tee /dev/stderr)
   [ "${actual}" = "false" ]
 }
+
+@test "server/PSP-RoleBinding: namespace" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/server-psp-rolebinding.yaml \
+      --set 'global.psp.enable=true' \
+      --namespace foo \
+      . | tee /dev/stderr |
+      yq -r '.metadata.namespace' | tee /dev/stderr)
+  [ "${actual}" = "foo" ]
+  local actual=$(helm template \
+      --show-only templates/server-psp-rolebinding.yaml \
+      --set 'global.psp.enable=true' \
+      --set 'namespaceOverride=bar' \
+      --namespace foo \
+      . | tee /dev/stderr |
+      yq -r '.metadata.namespace' | tee /dev/stderr)
+  [ "${actual}" = "bar" ]
+}

--- a/test/unit/server-route.bats
+++ b/test/unit/server-route.bats
@@ -24,6 +24,27 @@ load _helpers
   [ "${actual}" = "false" ]
 }
 
+@test "server/route: namespace" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/server-route.yaml  \
+      --set 'global.openshift=true' \
+      --set 'server.route.enabled=true' \
+      --namespace foo \
+      . | tee /dev/stderr |
+      yq -r '.metadata.namespace' | tee /dev/stderr)
+  [ "${actual}" = "foo" ]
+  local actual=$(helm template \
+      --show-only templates/server-route.yaml  \
+      --set 'global.openshift=true' \
+      --set 'server.route.enabled=true' \
+      --set 'namespaceOverride=bar' \
+      --namespace foo \
+      . | tee /dev/stderr |
+      yq -r '.metadata.namespace' | tee /dev/stderr)
+  [ "${actual}" = "bar" ]
+}
+
 @test "server/route: OpenShift - checking host entry gets added and path is /" {
   cd `chart_dir`
   local actual=$(helm template \

--- a/test/unit/server-route.bats
+++ b/test/unit/server-route.bats
@@ -38,7 +38,7 @@ load _helpers
       --show-only templates/server-route.yaml  \
       --set 'global.openshift=true' \
       --set 'server.route.enabled=true' \
-      --set 'namespaceOverride=bar' \
+      --set 'global.namespace=bar' \
       --namespace foo \
       . | tee /dev/stderr |
       yq -r '.metadata.namespace' | tee /dev/stderr)

--- a/test/unit/server-service.bats
+++ b/test/unit/server-service.bats
@@ -113,6 +113,25 @@ load _helpers
   [ "${actual}" = "false" ]
 }
 
+@test "server/Service: namespace" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/server-service.yaml  \
+      --set 'server.service.enabled=true' \
+      --namespace foo \
+      . | tee /dev/stderr |
+      yq -r '.metadata.namespace' | tee /dev/stderr)
+  [ "${actual}" = "foo" ]
+  local actual=$(helm template \
+      --show-only templates/server-service.yaml  \
+      --set 'server.service.enabled=true' \
+      --set 'namespaceOverride=bar' \
+      --namespace foo \
+      . | tee /dev/stderr |
+      yq -r '.metadata.namespace' | tee /dev/stderr)
+  [ "${actual}" = "bar" ]
+}
+
 @test "server/Service: disable with injector.externalVaultAddr" {
   cd `chart_dir`
   local actual=$( (helm template \

--- a/test/unit/server-service.bats
+++ b/test/unit/server-service.bats
@@ -125,7 +125,7 @@ load _helpers
   local actual=$(helm template \
       --show-only templates/server-service.yaml  \
       --set 'server.service.enabled=true' \
-      --set 'namespaceOverride=bar' \
+      --set 'global.namespace=bar' \
       --namespace foo \
       . | tee /dev/stderr |
       yq -r '.metadata.namespace' | tee /dev/stderr)

--- a/test/unit/server-serviceaccount.bats
+++ b/test/unit/server-serviceaccount.bats
@@ -42,7 +42,7 @@ load _helpers
   local actual=$(helm template \
       --show-only templates/server-serviceaccount.yaml  \
       --set 'server.serviceAccount.create=true' \
-      --set 'namespaceOverride=bar' \
+      --set 'global.namespace=bar' \
       --namespace foo \
       . | tee /dev/stderr |
       yq -r '.metadata.namespace' | tee /dev/stderr)

--- a/test/unit/server-serviceaccount.bats
+++ b/test/unit/server-serviceaccount.bats
@@ -30,6 +30,25 @@ load _helpers
 
 }
 
+@test "server/ServiceAccount: namespace" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/server-serviceaccount.yaml  \
+      --set 'server.serviceAccount.create=true' \
+      --namespace foo \
+      . | tee /dev/stderr |
+      yq -r '.metadata.namespace' | tee /dev/stderr)
+  [ "${actual}" = "foo" ]
+  local actual=$(helm template \
+      --show-only templates/server-serviceaccount.yaml  \
+      --set 'server.serviceAccount.create=true' \
+      --set 'namespaceOverride=bar' \
+      --namespace foo \
+      . | tee /dev/stderr |
+      yq -r '.metadata.namespace' | tee /dev/stderr)
+  [ "${actual}" = "bar" ]
+}
+
 @test "server/ServiceAccount: specify annotations" {
   cd `chart_dir`
   local actual=$(helm template \

--- a/test/unit/server-statefulset.bats
+++ b/test/unit/server-statefulset.bats
@@ -90,7 +90,7 @@ load _helpers
   local actual=$(helm template \
       --show-only templates/server-statefulset.yaml  \
       --set 'server.standalone.enabled=true' \
-      --set 'namespaceOverride=bar' \
+      --set 'global.namespace=bar' \
       --namespace foo \
       . | tee /dev/stderr |
       yq -r '.metadata.namespace' | tee /dev/stderr)

--- a/test/unit/server-statefulset.bats
+++ b/test/unit/server-statefulset.bats
@@ -78,6 +78,25 @@ load _helpers
   [ "${actual}" = "false" ]
 }
 
+@test "server/standalone-StatefulSet: namespace" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/server-statefulset.yaml  \
+      --set 'server.standalone.enabled=true' \
+      --namespace foo \
+      . | tee /dev/stderr |
+      yq -r '.metadata.namespace' | tee /dev/stderr)
+  [ "${actual}" = "foo" ]
+  local actual=$(helm template \
+      --show-only templates/server-statefulset.yaml  \
+      --set 'server.standalone.enabled=true' \
+      --set 'namespaceOverride=bar' \
+      --namespace foo \
+      . | tee /dev/stderr |
+      yq -r '.metadata.namespace' | tee /dev/stderr)
+  [ "${actual}" = "bar" ]
+}
+
 @test "server/standalone-StatefulSet: image defaults to server.image.repository:tag" {
   cd `chart_dir`
   local actual=$(helm template \

--- a/values.schema.json
+++ b/values.schema.json
@@ -2,6 +2,9 @@
     "$schema": "http://json-schema.org/schema#",
     "type": "object",
     "properties": {
+        "namespaceOverride": {
+            "type": "string"
+        },
         "csi": {
             "type": "object",
             "properties": {

--- a/values.schema.json
+++ b/values.schema.json
@@ -2,9 +2,6 @@
     "$schema": "http://json-schema.org/schema#",
     "type": "object",
     "properties": {
-        "namespaceOverride": {
-            "type": "string"
-        },
         "csi": {
             "type": "object",
             "properties": {
@@ -231,6 +228,9 @@
                 "enabled": {
                     "type": "boolean"
                 },
+                "namespace": {
+                    "type": "string"
+                },        
                 "externalVaultAddr": {
                     "type": "string"
                 },

--- a/values.yaml
+++ b/values.yaml
@@ -3,6 +3,10 @@
 
 # Available parameters and their default values for the Vault chart.
 
+# Allows to specify namespace other than Release.Namespace
+# If empty, default namespace would be Release.Namespace
+namespaceOverride: ""
+
 global:
   # enabled is the master enabled switch. Setting this to true or false
   # will enable or disable all the components within this chart by default.

--- a/values.yaml
+++ b/values.yaml
@@ -3,14 +3,14 @@
 
 # Available parameters and their default values for the Vault chart.
 
-# Allows to specify namespace other than Release.Namespace
-# If empty, default namespace would be Release.Namespace
-namespaceOverride: ""
 
 global:
   # enabled is the master enabled switch. Setting this to true or false
   # will enable or disable all the components within this chart by default.
   enabled: true
+
+  # The namespace to deploy to. Defaults to the `helm` installation namespace.
+  namespace: ""
 
   # Image pull secret to use for registry authentication.
   # Alternatively, the value may be specified as an array of strings.

--- a/values.yaml
+++ b/values.yaml
@@ -3,7 +3,6 @@
 
 # Available parameters and their default values for the Vault chart.
 
-
 global:
   # enabled is the master enabled switch. Setting this to true or false
   # will enable or disable all the components within this chart by default.


### PR DESCRIPTION
**Problem:**
- Vault can only be deployed in Release namespace.

**Root Cause:**
- namespace is hardcoded to `{{ .Release.Namespace }}`

**Solution:**
- Templatize namespaec in _helpers.tpl