### PR TITLE
chore(test): use vault.fullname in Helm test

### DIFF
--- a/templates/tests/server-test.yaml
+++ b/templates/tests/server-test.yaml
@@ -9,7 +9,7 @@ SPDX-License-Identifier: MPL-2.0
 apiVersion: v1
 kind: Pod
 metadata:
-  name: "{{ .Release.Name }}-server-test"
+  name: {{ template "vault.fullname" . }}-server-test
   namespace: {{ .Release.Namespace }}
   annotations:
     "helm.sh/hook": test

--- a/test/unit/server-test.bats
+++ b/test/unit/server-test.bats
@@ -37,6 +37,33 @@ load _helpers
 
 #--------------------------------------------------------------------
 
+@test "server/standalone-server-test-Pod: default metadata.name" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/tests/server-test.yaml  \
+      . | tee /dev/stderr |
+      yq -r '.metadata.name' | tee /dev/stderr)
+  [ "${actual}" = "release-name-vault-server-test" ]
+}
+
+@test "server/standalone-server-test-Pod: release metadata.name vault" {
+  cd `chart_dir`
+  local actual=$(helm template vault \
+      --show-only templates/tests/server-test.yaml  \
+      . | tee /dev/stderr |
+      yq -r '.metadata.name' | tee /dev/stderr)
+  [ "${actual}" = "vault-server-test" ]
+}
+
+@test "server/standalone-server-test-Pod: release metadata.name foo" {
+  cd `chart_dir`
+  local actual=$(helm template foo \
+      --show-only templates/tests/server-test.yaml  \
+      . | tee /dev/stderr |
+      yq -r '.metadata.name' | tee /dev/stderr)
+  [ "${actual}" = "foo-vault-server-test" ]
+}
+
 @test "server/standalone-server-test-Pod: default server.standalone.enabled" {
   cd `chart_dir`
   local actual=$(helm template \


### PR DESCRIPTION
Currently the Helm chart does not use a consistent naming convention for the testing.

When running `helm test myrelease` a pod with name `myrelease-server-test` is created.
There is no direct appearance that this is related to the vault chart in the name.

This PR changes the name to the same convention as other resources.
The name then will be e.g. `myrelease-vault-server-test`.

<hr />

Marco Lecheler [marco.lecheler@mercedes-benz.com](mailto:marco.lecheler@mercedes-benz.com) Mercedes-Benz Tech Innovation GmbH ([ProviderInformation](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md))