### PR TITLE
Prepare for 0.25.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,17 @@
 ## Unreleased
 
+## 0.25.0 (June 22, 2023)
+
 Changes:
 * Latest Kubernetes version tested is now 1.27
 * server: Headless service ignores `server.service.publishNotReadyAddresses` setting and always sets it as `true` [GH-902](https://github.com/hashicorp/vault-helm/pull/902)
+* `vault` updated to 1.14.0 [GH-916](https://github.com/hashicorp/vault-helm/pull/916)
+* `vault-csi-provider` updated to 1.4.0 [GH-916](https://github.com/hashicorp/vault-helm/pull/916)
 
-Features:
+Improvements:
 * CSI: Make `nodeSelector` and `affinity` configurable for CSI daemonset's pods [GH-862](https://github.com/hashicorp/vault-helm/pull/862)
+* injector: Add `ephemeralLimit` and `ephemeralRequest` as options for configuring Agent's ephemeral storage resources [GH-798](https://github.com/hashicorp/vault-helm/pull/798)
+* Minimum kubernetes version for chart reverted to 1.20.0 to allow installation on clusters older than the oldest tested version [GH-916](https://github.com/hashicorp/vault-helm/pull/916)
 
 Bugs:
 * server: Set the default for `prometheusRules.rules` to an empty list [GH-886](https://github.com/hashicorp/vault-helm/pull/886)
@@ -44,9 +50,6 @@ Features:
 
 Bugs:
 * server: Quote `.server.ha.clusterAddr` value [GH-810](https://github.com/hashicorp/vault-helm/pull/810)
-
-Improvements:
-* injector: Add `ephemeralLimit` and `ephemeralRequest` as options for configuring Agent's ephemeral storage resources [GH-798](https://github.com/hashicorp/vault-helm/pull/798)
 
 ## 0.22.1 (October 26th, 2022)
 

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -3,9 +3,9 @@
 
 apiVersion: v2
 name: vault
-version: 0.24.1
-appVersion: 1.13.1
-kubeVersion: ">= 1.22.0-0"
+version: 0.25.0
+appVersion: 1.14.0
+kubeVersion: ">= 1.20.0-0"
 description: Official HashiCorp Vault Chart
 home: https://www.vaultproject.io
 icon: https://github.com/hashicorp/vault/raw/f22d202cde2018f9455dec755118a9b84586e082/Vault_PrimaryLogo_Black.png

--- a/test/acceptance/server-ha-enterprise-dr.bats
+++ b/test/acceptance/server-ha-enterprise-dr.bats
@@ -7,7 +7,7 @@ load _helpers
 
   helm install "$(name_prefix)-east" \
     --set='server.image.repository=hashicorp/vault-enterprise' \
-    --set='server.image.tag=1.13.1-ent' \
+    --set="server.image.tag=$(yq -r '.server.image.tag' values.yaml)-ent" \
     --set='injector.enabled=false' \
     --set='server.ha.enabled=true' \
     --set='server.ha.raft.enabled=true' \
@@ -75,7 +75,7 @@ load _helpers
   helm install "$(name_prefix)-west" \
     --set='injector.enabled=false' \
     --set='server.image.repository=hashicorp/vault-enterprise' \
-    --set='server.image.tag=1.13.1-ent' \
+    --set="server.image.tag=$(yq -r '.server.image.tag' values.yaml)-ent" \
     --set='server.ha.enabled=true' \
     --set='server.ha.raft.enabled=true' \
     --set='server.enterpriseLicense.secretName=vault-license' .

--- a/test/acceptance/server-ha-enterprise-perf.bats
+++ b/test/acceptance/server-ha-enterprise-perf.bats
@@ -8,7 +8,7 @@ load _helpers
   helm install "$(name_prefix)-east" \
     --set='injector.enabled=false' \
     --set='server.image.repository=hashicorp/vault-enterprise' \
-    --set='server.image.tag=1.13.1-ent' \
+    --set="server.image.tag=$(yq -r '.server.image.tag' values.yaml)-ent" \
     --set='server.ha.enabled=true' \
     --set='server.ha.raft.enabled=true' \
     --set='server.enterpriseLicense.secretName=vault-license' .
@@ -75,7 +75,7 @@ load _helpers
   helm install "$(name_prefix)-west" \
     --set='injector.enabled=false' \
     --set='server.image.repository=hashicorp/vault-enterprise' \
-    --set='server.image.tag=1.13.1-ent' \
+    --set="server.image.tag=$(yq -r '.server.image.tag' values.yaml)-ent" \
     --set='server.ha.enabled=true' \
     --set='server.ha.raft.enabled=true' \
     --set='server.enterpriseLicense.secretName=vault-license' .

--- a/values.openshift.yaml
+++ b/values.openshift.yaml
@@ -13,9 +13,9 @@ injector:
 
   agentImage:
     repository: "registry.connect.redhat.com/hashicorp/vault"
-    tag: "1.13.1-ubi"
+    tag: "1.14.0-ubi"
 
 server:
   image:
     repository: "registry.connect.redhat.com/hashicorp/vault"
-    tag: "1.13.1-ubi"
+    tag: "1.14.0-ubi"

--- a/values.yaml
+++ b/values.yaml
@@ -73,7 +73,7 @@ injector:
   # required.
   agentImage:
     repository: "hashicorp/vault"
-    tag: "1.13.1"
+    tag: "1.14.0"
 
   # The default values for the injected Vault Agent containers.
   agentDefaults:
@@ -374,7 +374,7 @@ server:
 
   image:
     repository: "hashicorp/vault"
-    tag: "1.13.1"
+    tag: "1.14.0"
     # Overrides the default Image Pull Policy
     pullPolicy: IfNotPresent
 
@@ -1001,7 +1001,7 @@ csi:
 
   image:
     repository: "hashicorp/vault-csi-provider"
-    tag: "1.3.0"
+    tag: "1.4.0"
     pullPolicy: IfNotPresent
 
   # volumes is a list of volumes made available to all containers. These are rendered
@@ -1086,7 +1086,7 @@ csi:
 
     image:
       repository: "hashicorp/vault"
-      tag: "1.13.1"
+      tag: "1.14.0"
       pullPolicy: IfNotPresent
 
     logFormat: standard


### PR DESCRIPTION
# 0.25.0 (June 22, 2023)

## Changes

* Latest Kubernetes version tested is now 1.27
* server: Headless service ignores `server.service.publishNotReadyAddresses` setting and always sets it as `true` [GH-902](https://github.com/hashicorp/vault-helm/pull/902)
* `vault` updated to 1.14.0 [GH-916](https://github.com/hashicorp/vault-helm/pull/916)
* `vault-csi-provider` updated to 1.4.0 [GH-916](https://github.com/hashicorp/vault-helm/pull/916)

## Improvements

* CSI: Make `nodeSelector` and `affinity` configurable for CSI daemonset's pods [GH-862](https://github.com/hashicorp/vault-helm/pull/862)
* injector: Add `ephemeralLimit` and `ephemeralRequest` as options for configuring Agent's ephemeral storage resources [GH-798](https://github.com/hashicorp/vault-helm/pull/798)
* Minimum kubernetes version for chart reverted to 1.20.0 to allow installation on clusters older than the oldest tested version [GH-916](https://github.com/hashicorp/vault-helm/pull/916)

## Bugs

* server: Set the default for `prometheusRules.rules` to an empty list [GH-886](https://github.com/hashicorp/vault-helm/pull/886)

Closes #913 #915 