### PR TITLE
chore: bump vault from 1.14.0 -> 1.14.1

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -3,8 +3,8 @@
 
 apiVersion: v2
 name: vault
-version: 0.25.0
-appVersion: 1.14.0
+version: 0.25.1
+appVersion: 1.14.1
 kubeVersion: ">= 1.20.0-0"
 description: Official HashiCorp Vault Chart
 home: https://www.vaultproject.io

--- a/values.openshift.yaml
+++ b/values.openshift.yaml
@@ -13,9 +13,9 @@ injector:
 
   agentImage:
     repository: "registry.connect.redhat.com/hashicorp/vault"
-    tag: "1.14.0-ubi"
+    tag: "1.14.1-ubi"
 
 server:
   image:
     repository: "registry.connect.redhat.com/hashicorp/vault"
-    tag: "1.14.0-ubi"
+    tag: "1.14.1-ubi"

--- a/values.yaml
+++ b/values.yaml
@@ -76,7 +76,7 @@ injector:
   # required.
   agentImage:
     repository: "hashicorp/vault"
-    tag: "1.14.0"
+    tag: "1.14.1"
 
   # The default values for the injected Vault Agent containers.
   agentDefaults:
@@ -377,7 +377,7 @@ server:
 
   image:
     repository: "hashicorp/vault"
-    tag: "1.14.0"
+    tag: "1.14.1"
     # Overrides the default Image Pull Policy
     pullPolicy: IfNotPresent
 
@@ -1089,7 +1089,7 @@ csi:
 
     image:
       repository: "hashicorp/vault"
-      tag: "1.14.0"
+      tag: "1.14.1"
       pullPolicy: IfNotPresent
 
     logFormat: standard


### PR DESCRIPTION
Updating to the latest tag 1.14.1

https://github.com/hashicorp/vault/releases