### PR TITLE
fix(test): add securityContext for Helm test

### DIFF
--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -563,6 +563,44 @@ securityContext for the statefulset vault container
   {{- end }}
 {{- end -}}
 
+{{/*
+securityContext for the test pod template.
+*/}}
+{{- define "server.test.securityContext.pod" -}}
+  {{- if .Values.server.statefulSet.securityContext.pod }}
+  securityContext:
+    {{- $tp := typeOf .Values.server.statefulSet.securityContext.pod }}
+    {{- if eq $tp "string" }}
+      {{- tpl .Values.server.statefulSet.securityContext.pod . | nindent 4 }}
+    {{- else }}
+      {{- toYaml .Values.server.statefulSet.securityContext.pod | nindent 4 }}
+    {{- end }}
+  {{- else if not .Values.global.openshift }}
+  securityContext:
+    runAsNonRoot: true
+    runAsGroup: {{ .Values.server.gid | default 1000 }}
+    runAsUser: {{ .Values.server.uid | default 100 }}
+    fsGroup: {{ .Values.server.gid | default 1000 }}
+  {{- end }}
+{{- end -}}
+
+{{/*
+securityContext for the test vault container
+*/}}
+{{- define "server.test.securityContext.container" -}}
+  {{- if .Values.server.statefulSet.securityContext.container }}
+      securityContext:
+        {{- $tp := typeOf .Values.server.statefulSet.securityContext.container }}
+        {{- if eq $tp "string" }}
+          {{- tpl .Values.server.statefulSet.securityContext.container . | nindent 8 }}
+        {{- else }}
+          {{- toYaml .Values.server.statefulSet.securityContext.container | nindent 8 }}
+        {{- end }}
+  {{- else if not .Values.global.openshift }}
+      securityContext:
+        allowPrivilegeEscalation: false
+  {{- end }}
+{{- end -}}
 
 {{/*
 Sets extra injector service account annotations

--- a/templates/tests/server-test.yaml
+++ b/templates/tests/server-test.yaml
@@ -15,6 +15,7 @@ metadata:
     "helm.sh/hook": test
 spec:
   {{- include "imagePullSecrets" . | nindent 2 }}
+  {{- template "server.test.securityContext.pod" . }}
   containers:
     - name: {{ .Release.Name }}-server-test
       image: {{ .Values.server.image.repository }}:{{ .Values.server.image.tag | default "latest" }}
@@ -43,6 +44,7 @@ spec:
           fi
 
           exit 0
+      {{- template "server.test.securityContext.container" . }}
       volumeMounts:
         {{- if .Values.server.volumeMounts }}
           {{- toYaml .Values.server.volumeMounts | nindent 8}}


### PR DESCRIPTION
When running tests with Helm the same securityContext also should apply.
Therefore this change will add the securityContext from the values file also to the Helm tests.

The change will use the securityContext of the server statefulSet.
This results from the fact that the same image is used in the test.

<hr />

Marco Lecheler [marco.lecheler@mercedes-benz.com](mailto:marco.lecheler@mercedes-benz.com) Mercedes-Benz Tech Innovation GmbH ([ProviderInformation](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md))