### PR TITLE
feat(Prometheus/ServiceMonitor): add configurable tlsConfig & bearerTokenFile for authentication

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -3,7 +3,7 @@
 
 apiVersion: v2
 name: vault
-version: 0.25.0
+version: 0.26.0
 appVersion: 1.14.0
 kubeVersion: ">= 1.20.0-0"
 description: Official HashiCorp Vault Chart

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -3,7 +3,7 @@
 
 apiVersion: v2
 name: vault
-version: 0.28.0
+version: 0.27.0
 appVersion: 1.15.2
 kubeVersion: ">= 1.20.0-0"
 description: Official HashiCorp Vault Chart

--- a/templates/prometheus-servicemonitor.yaml
+++ b/templates/prometheus-servicemonitor.yaml
@@ -36,13 +36,22 @@ spec:
   - port: {{ include "vault.scheme" . }}
     interval: {{ .Values.serverTelemetry.serviceMonitor.interval }}
     scrapeTimeout: {{ .Values.serverTelemetry.serviceMonitor.scrapeTimeout }}
+    {{- if .Values.serverTelemetry.serviceMonitor.bearerTokenFile }}
+    bearerTokenFile: {{ .Values.serverTelemetry.serviceMonitor.bearerTokenFile }}
+    {{- end }}
     scheme: {{ include "vault.scheme" . | lower }}
     path: /v1/sys/metrics
     params:
       format:
       - prometheus
+    {{- $tlsConfig := .Values.serverTelemetry.serviceMonitor.tlsConfig }}
+    {{- if $tlsConfig }}
+    tlsConfig:
+    {{- toYaml $tlsConfig | nindent 6 }}
+    {{- else }}
     tlsConfig:
       insecureSkipVerify: true
+    {{- end }}
   namespaceSelector:
     matchNames:
       - {{ include "vault.namespace" . }}

--- a/test/unit/prometheus-servicemonitor.bats
+++ b/test/unit/prometheus-servicemonitor.bats
@@ -123,3 +123,45 @@ load _helpers
   [ "$(echo "$output" | yq -r '.spec.endpoints | length')" = "1" ]
   [ "$(echo "$output" | yq -r '.spec.endpoints[0].port')" = "https" ]
 }
+
+@test "prometheus/ServiceMonitor-server: tlsConfig default" {
+  cd `chart_dir`
+  local output=$( (helm template \
+      --show-only templates/prometheus-servicemonitor.yaml \
+      --set 'serverTelemetry.serviceMonitor.enabled=true' \
+      . ) | tee /dev/stderr)
+
+  [ "$(echo "$output" | yq -r '.spec.endpoints[0].tlsConfig.insecureSkipVerify')" = "true" ]
+}
+
+@test "prometheus/ServiceMonitor-server: tlsConfig override" {
+  cd `chart_dir`
+  local output=$( (helm template \
+      --show-only templates/prometheus-servicemonitor.yaml \
+      --set 'serverTelemetry.serviceMonitor.tlsConfig.ca=ca.crt' \
+      --set 'serverTelemetry.serviceMonitor.enabled=true' \
+      . ) | tee /dev/stderr)
+
+  [ "$(echo "$output" | yq -r '.spec.endpoints[0].tlsConfig.ca')" = "ca.crt" ]
+}
+
+@test "prometheus/ServiceMonitor-server: bearerTokenFile default" {
+  cd `chart_dir`
+  local output=$( (helm template \
+      --show-only templates/prometheus-servicemonitor.yaml \
+      --set 'serverTelemetry.serviceMonitor.enabled=true' \
+      . ) | tee /dev/stderr)
+
+  [ "$(echo "$output" | yq -r '.spec.endpoints[0] | has("bearerToken")')" = "false" ]
+}
+
+@test "prometheus/ServiceMonitor-server: bearerTokenFile set" {
+  cd `chart_dir`
+  local output=$( (helm template \
+      --show-only templates/prometheus-servicemonitor.yaml \
+      --set 'serverTelemetry.serviceMonitor.enabled=true' \
+      --set 'serverTelemetry.serviceMonitor.bearerTokenFile=tokenfile' \
+      . ) | tee /dev/stderr)
+
+  [ "$(echo "$output" | yq -r '.spec.endpoints[0].bearerTokenFile')" = "tokenfile" ]
+}

--- a/test/unit/prometheus-servicemonitor.bats
+++ b/test/unit/prometheus-servicemonitor.bats
@@ -152,7 +152,7 @@ load _helpers
       --set 'serverTelemetry.serviceMonitor.enabled=true' \
       . ) | tee /dev/stderr)
 
-  [ "$(echo "$output" | yq -r '.spec.endpoints[0] | has("bearerToken")')" = "false" ]
+  [ "$(echo "$output" | yq -r '.spec.endpoints[0] | has("bearerTokenFile")')" = "false" ]
 }
 
 @test "prometheus/ServiceMonitor-server: bearerTokenFile set" {

--- a/values.yaml
+++ b/values.yaml
@@ -1201,6 +1201,12 @@ serverTelemetry:
     # Timeout for Prometheus scrapes
     scrapeTimeout: 10s
 
+    # tlsConfig used for connecting to the Vault API
+    tlsConfig: {}
+
+    # bearerTokenfile used for authentication to the Vault metrics API
+    bearerTokenFile: ""
+
   prometheusRules:
       # The Prometheus operator *must* be installed before enabling this feature,
       # if not the chart will fail to install due to missing CustomResourceDefinitions

--- a/values.yaml
+++ b/values.yaml
@@ -1234,8 +1234,8 @@ csi:
 # https://developer.hashicorp.com/vault/docs/configuration/telemetry
 # https://developer.hashicorp.com/vault/docs/internals/telemetry
 serverTelemetry:
-  # Enable support for the Prometheus Operator. Currently, this chart does not support
-  # authenticating to Vault's metrics endpoint, so the following `telemetry{}` must be included
+  # Enable support for the Prometheus Operator. If bearerTokenFile is not set for authenticating
+  # to Vault's metrics endpoint, the following Vault server `telemetry{}` config must be included
   # in the `listener "tcp"{}` stanza
   #  telemetry {
   #    unauthenticated_metrics_access = "true"


### PR DESCRIPTION
This implements a configurable `tlsConfig` for the `serviceMonitor` used to grab metrics from the Vault API.

Additionally it adds the possibility to set a `bearerTokenFile` for authentication purposes.
