### PR TITLE
feat: add hostAliases for statefulset

### DIFF
--- a/templates/server-statefulset.yaml
+++ b/templates/server-statefulset.yaml
@@ -61,6 +61,10 @@ spec:
         {{ template "vault.volumes" . }}
         - name: home
           emptyDir: {}
+      {{- if .Values.server.hostAliases }}
+      hostAliases:
+        {{ toYaml .Values.server.hostAliases | nindent 8}}
+      {{- end }}          
       {{- if .Values.server.extraInitContainers }}
       initContainers:
         {{ toYaml .Values.server.extraInitContainers | nindent 8}}

--- a/test/unit/server-statefulset.bats
+++ b/test/unit/server-statefulset.bats
@@ -1827,6 +1827,28 @@ load _helpers
 }
 
 #--------------------------------------------------------------------
+# hostAliases
+
+@test "server/StatefulSet: server.hostAliases not set" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/server-statefulset.yaml \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.hostAliases' | tee /dev/stderr)
+  [ "${actual}" = "null" ]
+}
+
+@test "server/StatefulSet: server.hostAliases is set" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/server-statefulset.yaml \
+      --set 'server.hostAliases[0]=foo' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.hostAliases[]' | tee /dev/stderr)
+  [ "${actual}" = "foo" ]
+}
+
+#--------------------------------------------------------------------
 # extraPorts
 
 @test "server/standalone-StatefulSet: adds extra ports" {

--- a/values.schema.json
+++ b/values.schema.json
@@ -740,6 +740,9 @@
                         }
                     }
                 },
+                "hostAliases": {
+                    "type": "array"
+                },
                 "image": {
                     "type": "object",
                     "properties": {

--- a/values.yaml
+++ b/values.yaml
@@ -444,7 +444,11 @@ server:
     #  - secretName: chart-example-tls
     #    hosts:
     #      - chart-example.local
-
+  # hostAliases is a list of aliases to be added to /etc/hosts. Specified as a YAML list.
+  hostAliases: []
+  # - ip: 127.0.0.1
+  #   hostnames:
+  #     - chart-example.local
   # OpenShift only - create a route to expose the service
   # By default the created route will be of type passthrough
   route:


### PR DESCRIPTION
Add hostAliases to the helm chart to allow adding custom entries to /etc/hosts

Useful when configuring LDAP sign method.