### PR TITLE
Fix check if server.ha.replicas is a number when set in values.yaml

### DIFF
--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -167,7 +167,7 @@ Set's the replica count based on the different modes configured by user
   {{ if eq .mode "standalone" }}
     {{- default 1 -}}
   {{ else if eq .mode "ha" }}
-    {{- if kindIs "int64" .Values.server.ha.replicas -}}
+    {{- if or (kindIs "int64" .Values.server.ha.replicas) (kindIs "float64" .Values.server.ha.replicas) -}}
       {{- .Values.server.ha.replicas -}}
     {{ else }}
       {{- 3 -}}


### PR DESCRIPTION
The commits merged in #943 only work when using `--set 'server.ha.replicas=2'` from the CLI, not when `server.ha.replicas` is defined in `values.yaml`. This behaviour is expected and described in https://github.com/helm/helm/issues/12084. You can see this in action on [this playground](https://helm-playground.com/#t=N7C0AIBMFMDMEsB21wCICGBnWAbA9ugC6rigC%2BZAUOOCBPLOANZKQCSmauBhAbACwkAdADV0OAK7RMQxBIC2AI2gAnUhWo1aYNAE9p4dODlLVJclRohw0HJhQat2iKkR5Ch4wuUrzj5zaIkOpUdIHBFpSUYTAIyGhYSMQhmmEMzKwcaEkCwmKS0rLeqilOYaj6nEYmPn6W2jZ2DvVWOq7unjVmpQHQQSlhfREa0TqxSCgYmIruABZ1qTrpeGoAFCxBWajcRLngouJSMl0qAJTg65mcqDmC%2B-lHRaZnPa0ulZ3Fvj3Wtvbg-jeaDcHmqXwWQKGAx0UMilCwO0IAC4GoRoPIAA44IiTBH4IjCAFUeGYJIo6xozHYtEJUmIZJCIlRLAzQizcnAcCUrE42ms%2Bb7IlAA&v=HYVwtgRgpgTgXAAgCxA).

This passes the unit tests because they don't use values.yaml, so only the CLI behaviour is tested and this passed without raising issues.

By checking if the value is either `int64` or `float64`, both cases work. There are no other cases where a value is checked if it's `int64`, so this should not occur anywhere else in this chart.