### PR TITLE
Update actions, k8s and vault versions, and changelog

### DIFF
--- a/.github/actions/setup-test-tools/action.yaml
+++ b/.github/actions/setup-test-tools/action.yaml
@@ -6,7 +6,7 @@ description: Install bats and python-yq
 runs:
   using: "composite"
   steps:
-    - uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c # v3.6.0
+    - uses: actions/setup-node@5e21ff4d9bc1a8cf6de233a3057d20ec6b3fb69d # v3.8.1
       with:
         node-version: '16'
     - run: npm install -g bats@${BATS_VERSION}
@@ -15,7 +15,7 @@ runs:
         BATS_VERSION: '1.8.2'
     - run: bats -v
       shell: bash
-    - uses: actions/setup-python@d27e3f3d7c64b4bbf8e4abfb9b63b83e846e0435 # v4.5.0
+    - uses: actions/setup-python@65d7f2d534ac1bc67fcd62888c5f4f3d2cb2b236 # v4.7.1
       with:
         python-version: '3.10'
     - run: pip install yq

--- a/.github/workflows/acceptance.yaml
+++ b/.github/workflows/acceptance.yaml
@@ -5,18 +5,18 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        kind-k8s-version: [1.22.17, 1.23.17, 1.24.13, 1.25.9, 1.26.4, 1.27.2]
+        kind-k8s-version: [1.24.15, 1.25.11, 1.26.6, 1.27.3, 1.28.0]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
       - name: Setup test tools
         uses: ./.github/actions/setup-test-tools
       - name: Create K8s Kind Cluster
-        uses: helm/kind-action@fa81e57adff234b2908110485695db0f181f3c67 # v1.7.0
+        uses: helm/kind-action@dda0770415bac9fc20092cacbc54aa298604d140 # v1.8.0
         with:
           config: test/kind/config.yaml
           node_image: kindest/node:v${{ matrix.kind-k8s-version }}
-          version: v0.19.0
+          version: v0.20.0
       - run: bats --tap --timing ./test/acceptance
         env:
           VAULT_LICENSE_CI: ${{ secrets.VAULT_LICENSE_CI }}

--- a/.github/workflows/jira.yaml
+++ b/.github/workflows/jira.yaml
@@ -14,4 +14,4 @@ jobs:
       JIRA_SYNC_USER_EMAIL: ${{ secrets.JIRA_SYNC_USER_EMAIL }}
       JIRA_SYNC_API_TOKEN: ${{ secrets.JIRA_SYNC_API_TOKEN }}
     with:
-      teams-array: '["ecosystem", "foundations"]'
+      teams-array: '["ecosystem", "foundations-eco"]'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 ## Unreleased
 
 Changes:
-* `vault` updated to 1.15.0
-* `vault-k8s` updated to 1.3.0
+* Default `vault` version updated to 1.15.0
+* Default `vault-k8s` version updated to 1.3.0
 * Tested with Kubernetes versions 1.24-1.28
 
 Features:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,15 @@
 ## Unreleased
 
+Changes:
+* `vault` updated to 1.15.0
+* `vault-k8s` updated to 1.3.0
+* Tested with Kubernetes versions 1.24-1.28
+
 Features:
 * server: Add support for dual stack clusters [GH-833](https://github.com/hashicorp/vault-helm/pull/833)
 * server: Support `hostAliases` for the StatefulSet pods [GH-955](https://github.com/hashicorp/vault-helm/pull/955)
 * server: Add `server.service.active.annotations` and `server.service.standby.annotations` [GH-896](https://github.com/hashicorp/vault-helm/pull/896)
+* server: Add long-lived service account token option [GH-923](https://github.com/hashicorp/vault-helm/pull/923)
 
 Bugs:
 * csi: Add namespace field to `csi-role` and `csi-rolebindings`. [GH-909](https://github.com/hashicorp/vault-helm/pull/909)
@@ -11,6 +17,7 @@ Bugs:
 Improvements:
 * global: Add `global.namespace` to override the helm installation namespace. [GH-909](https://github.com/hashicorp/vault-helm/pull/909)
 * server: use vault.fullname in Helm test [GH-912](https://github.com/hashicorp/vault-helm/pull/912)
+* server: Allow scaling HA replicas to zero [GH-943](https://github.com/hashicorp/vault-helm/pull/943)
 
 ## 0.25.0 (June 26, 2023)
 

--- a/values.openshift.yaml
+++ b/values.openshift.yaml
@@ -9,13 +9,13 @@ global:
 injector:
   image:
     repository: "registry.connect.redhat.com/hashicorp/vault-k8s"
-    tag: "1.2.1-ubi"
+    tag: "1.3.0-ubi"
 
   agentImage:
     repository: "registry.connect.redhat.com/hashicorp/vault"
-    tag: "1.14.0-ubi"
+    tag: "1.15.0-ubi"
 
 server:
   image:
     repository: "registry.connect.redhat.com/hashicorp/vault"
-    tag: "1.14.0-ubi"
+    tag: "1.15.0-ubi"

--- a/values.yaml
+++ b/values.yaml
@@ -68,7 +68,7 @@ injector:
   # image sets the repo and tag of the vault-k8s image to use for the injector.
   image:
     repository: "hashicorp/vault-k8s"
-    tag: "1.2.1"
+    tag: "1.3.0"
     pullPolicy: IfNotPresent
 
   # agentImage sets the repo and tag of the Vault image to use for the Vault Agent
@@ -76,7 +76,7 @@ injector:
   # required.
   agentImage:
     repository: "hashicorp/vault"
-    tag: "1.14.0"
+    tag: "1.15.0"
 
   # The default values for the injected Vault Agent containers.
   agentDefaults:
@@ -1139,7 +1139,7 @@ csi:
 
     image:
       repository: "hashicorp/vault"
-      tag: "1.14.0"
+      tag: "1.15.0"
       pullPolicy: IfNotPresent
 
     logFormat: standard


### PR DESCRIPTION
Pin github actions to the latest trusted versions, test with k8s 1.24-1.28, update vault and vault-k8s defaults to latest releases.

Related to https://github.com/hashicorp/vault/pull/23645