### PR TITLE
Add persistentVolumeClaimRetentionPolicy variable to values.yaml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Unreleased
 
+Features:
+
+* server: Support setting `persistentVolumeClaimRetentionPolicy` on the StatefulSet [GH-965](https://github.com/hashicorp/vault-helm/pull/965)
+
 Improvements:
 
 * Support exec in the server liveness probe [GH-971](https://github.com/hashicorp/vault-helm/pull/971)

--- a/templates/server-statefulset.yaml
+++ b/templates/server-statefulset.yaml
@@ -24,6 +24,9 @@ spec:
   replicas: {{ template "vault.replicas" . }}
   updateStrategy:
     type: {{ .Values.server.updateStrategyType }}
+  {{- if and (semverCompare ">= 1.23-0" .Capabilities.KubeVersion.Version) (.Values.server.persistentVolumeClaimRetentionPolicy) }}
+  persistentVolumeClaimRetentionPolicy: {{ toYaml .Values.server.persistentVolumeClaimRetentionPolicy | nindent 4 }}
+  {{- end }}
   selector:
     matchLabels:
       app.kubernetes.io/name: {{ template "vault.name" . }}

--- a/test/unit/server-statefulset.bats
+++ b/test/unit/server-statefulset.bats
@@ -222,6 +222,73 @@ load _helpers
 }
 
 #--------------------------------------------------------------------
+# persistentVolumeClaimRetentionPolicy
+
+@test "server/standalone-StatefulSet: persistentVolumeClaimRetentionPolicy not set by default when kubernetes < 1.23" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/server-statefulset.yaml  \
+      --kube-version "1.22" \
+      . | tee /dev/stderr |
+      yq -r '.spec.persistentVolumeClaimRetentionPolicy' | tee /dev/stderr)
+  [ "${actual}" = "null" ]
+}
+
+@test "server/standalone-StatefulSet: unset persistentVolumeClaimRetentionPolicy.whenDeleted when kubernetes < 1.23" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/server-statefulset.yaml  \
+      --kube-version "1.22" \
+      --set 'server.persistentVolumeClaimRetentionPolicy.whenDeleted=Delete' \
+      . | tee /dev/stderr |
+      yq -r '.spec.persistentVolumeClaimRetentionPolicy.whenDeleted' | tee /dev/stderr)
+  [ "${actual}" = "null" ]
+}
+
+@test "server/standalone-StatefulSet: unset persistentVolumeClaimRetentionPolicy.whenScaled when kubernetes < 1.23" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/server-statefulset.yaml  \
+      --kube-version "1.22" \
+      --set 'server.persistentVolumeClaimRetentionPolicy.whenScaled=Delete' \
+      . | tee /dev/stderr |
+      yq -r '.spec.persistentVolumeClaimRetentionPolicy.whenScaled' | tee /dev/stderr)
+  [ "${actual}" = "null" ]
+}
+
+@test "server/standalone-StatefulSet: persistentVolumeClaimRetentionPolicy not set by default when kubernetes >= 1.23" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/server-statefulset.yaml  \
+      --kube-version "1.23" \
+      . | tee /dev/stderr |
+      yq -r '.spec.persistentVolumeClaimRetentionPolicy' | tee /dev/stderr)
+  [ "${actual}" = "null" ]
+}
+
+@test "server/standalone-StatefulSet: can set persistentVolumeClaimRetentionPolicy.whenDeleted when kubernetes >= 1.23" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/server-statefulset.yaml  \
+      --kube-version "1.23" \
+      --set 'server.persistentVolumeClaimRetentionPolicy.whenDeleted=Delete' \
+      . | tee /dev/stderr |
+      yq -r '.spec.persistentVolumeClaimRetentionPolicy.whenDeleted' | tee /dev/stderr)
+  [ "${actual}" = "Delete" ]
+}
+
+@test "server/standalone-StatefulSet: can set persistentVolumeClaimRetentionPolicy.whenScaled when kubernetes >= 1.23" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      -s templates/server-statefulset.yaml  \
+      --kube-version "1.23" \
+      --set 'server.persistentVolumeClaimRetentionPolicy.whenScaled=Delete' \
+      . | tee /dev/stderr |
+      yq -r '.spec.persistentVolumeClaimRetentionPolicy.whenScaled' | tee /dev/stderr)
+  [ "${actual}" = "Delete" ]
+}
+
+#--------------------------------------------------------------------
 # replicas
 
 @test "server/standalone-StatefulSet: default replicas" {

--- a/values.schema.json
+++ b/values.schema.json
@@ -619,6 +619,17 @@
                         }
                     }
                 },
+                "persistentVolumeClaimRetentionPolicy": {
+                    "type": "object",
+                    "properties": {
+                        "whenDeleted": {
+                            "type": "string"
+                        },
+                        "whenScaled": {
+                            "type": "string"
+                        }
+                    }
+                },
                 "dev": {
                     "type": "object",
                     "properties": {

--- a/values.yaml
+++ b/values.yaml
@@ -756,6 +756,14 @@ server:
     # Annotations to apply to the PVC
     annotations: {}
 
+  # Persistent Volume Claim (PVC) retention policy
+  # ref: https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#persistentvolumeclaim-retention
+  # Example:
+  # persistentVolumeClaimRetentionPolicy:
+  #   whenDeleted: Retain
+  #   whenScaled: Retain
+  persistentVolumeClaimRetentionPolicy: {}
+
   # This configures the Vault Statefulset to create a PVC for audit
   # logs.  Once Vault is deployed, initialized, and unsealed, Vault must
   # be configured to use this for audit logs.  This will be mounted to


### PR DESCRIPTION
Add new variable on the Helm chart to define the [PVC retention policy](https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#persistentvolumeclaim-retention) for the StatefulSet, as requested in #3101 

Changes proposed in this PR:
- Add new `persistentVolumeClaimRetentionPolicy` to control the PVC retention policy when the statefulset is deleted or the number of replicas is decreased.
- Only supported since [kubernetes 1.23](https://sysdig.com/blog/kubernetes-1-23-whats-new/#:~:text=%231847%20Auto%20remove%20PVCs%20created%20by%20StatefulSet)

How I've tested this PR:

```shell
$  bats ./test/unit/server-statefulset.bats 

server-statefulset.bats
 ✓ server/StatefulSet: disabled server.enabled
 ✓ server/StatefulSet: disabled server.enabled random string
 ✓ server/StatefulSet: enabled server.enabled explicit true
 ✓ server/standalone-StatefulSet: default server.standalone.enabled
 ✓ server/standalone-StatefulSet: enable with server.standalone.enabled true
 ✓ server/standalone-StatefulSet: disable with global.enabled
 ✓ server/standalone-StatefulSet: disable with injector.externalVaultAddr
 ✓ server/standalone-StatefulSet: namespace
 ✓ server/standalone-StatefulSet: image defaults to server.image.repository:tag
 ✓ server/standalone-StatefulSet: image tag defaults to latest
 ✓ server/standalone-StatefulSet: default imagePullPolicy
 ✓ server/standalone-StatefulSet: Custom imagePullPolicy
 ✓ server/standalone-StatefulSet: Custom imagePullSecrets
 ✓ server/standalone-StatefulSet: Custom imagePullSecrets - string array
 ✓ server/standalone-StatefulSet: default imagePullSecrets
 ✓ server/standalone-StatefulSet: OnDelete updateStrategy
 ✓ server/standalone-StatefulSet: persistentVolumeClaimRetentionPolicy not set by default when kubernetes < 1.23
 ✓ server/standalone-StatefulSet: unset persistentVolumeClaimRetentionPolicy.whenDeleted when kubernetes < 1.23
 ✓ server/standalone-StatefulSet: unset persistentVolumeClaimRetentionPolicy.whenScaled when kubernetes < 1.23
 ✓ server/standalone-StatefulSet: persistentVolumeClaimRetentionPolicy not set by default when kubernetes >= 1.23
 ✓ server/standalone-StatefulSet: can set persistentVolumeClaimRetentionPolicy.whenDeleted when kubernetes >= 1.23
 ✓ server/standalone-StatefulSet: can set persistentVolumeClaimRetentionPolicy.whenScaled when kubernetes >= 1.23
 ✓ server/standalone-StatefulSet: default replicas
 ✓ server/standalone-StatefulSet: custom replicas
 ✓ server/standalone-StatefulSet: default resources
 ✓ server/standalone-StatefulSet: custom resources
 ✓ server/standalone-StatefulSet: server.extraVolumes adds extra volume
 ✓ server/standalone-StatefulSet: server.extraVolumes adds extra secret volume
 ✓ server/standalone-StatefulSet: can mount audit
 ✓ server/standalone-StatefulSet: server.volumes adds volume
 ✓ server/standalone-StatefulSet: server.volumeMounts adds volumeMount
 ✓ server/standalone-StatefulSet: default log level to empty
 ✓ server/standalone-StatefulSet: log level can be changed
 ✓ server/standalone-StatefulSet: default log format to empty
 ✓ server/standalone-StatefulSet: can set log format
 ✓ server/standalone-StatefulSet: set extraEnvironmentVars
 ✓ server/standalone-StatefulSet: storageClass on claim by default
 ✓ server/standalone-StatefulSet: can set storageClass
 ✓ server/standalone-StatefulSet: can disable storage
 ✓ server/standalone-StatefulSet: default audit storage mount path
 ✓ server/standalone-StatefulSet: can configure audit storage mount path
 ✓ server/standalone-StatefulSet: default data storage mount path
 ✓ server/standalone-StatefulSet: can configure data storage mount path
 ✓ server/standalone-StatefulSet: affinity is set by default
 ✓ server/standalone-StatefulSet: affinity can be set as string
 ✓ server/standalone-StatefulSet: affinity can be set as YAML
 ✓ server/standalone-StatefulSet: topologySpreadConstraints is null by default
 ✓ server/standalone-StatefulSet: topologySpreadConstraints can be set as YAML
 ✓ server/standalone-StatefulSet: tolerations not set by default
 ✓ server/standalone-StatefulSet: tolerations can be set as string
 ✓ server/standalone-StatefulSet: tolerations can be set as YAML
 ✓ server/standalone-StatefulSet: nodeSelector is not set by default
 ✓ server/standalone-StatefulSet: specified nodeSelector as string
 ✓ server/standalone-StatefulSet: nodeSelector can be set as YAML
 ✓ server/standalone-StatefulSet: adds extra init containers
 ✓ server/standalone-StatefulSet: add two extra init containers
 ✓ server/standalone-StatefulSet: adds extra containers
 ✓ server/standalone-StatefulSet: add two extra containers
 ✓ server/standalone-StatefulSet: no extra containers added
 ✓ server/standalone-StatefulSet: shareProcessNamespace disabled by default
 ✓ server/standalone-StatefulSet: shareProcessNamespace enabled
 ✓ server/standalone-StatefulSet: specify extraLabels
 ✓ server/standalone-StatefulSet: default statefulSet.annotations
 ✓ server/standalone-StatefulSet: specify statefulSet.annotations yaml
 ✓ server/standalone-StatefulSet: specify statefulSet.annotations yaml string
 ✓ server/standalone-StatefulSet: uid default
 ✓ server/standalone-StatefulSet: uid configurable
 ✓ server/standalone-StatefulSet: gid default
 ✓ server/standalone-StatefulSet: gid configurable
 ✓ server/standalone-StatefulSet: fsgroup default
 ✓ server/standalone-StatefulSet: fsgroup configurable
 ✓ server/standalone-StatefulSet: readinessProbe default
 ✓ server/standalone-StatefulSet: readinessProbe configurable
 ✓ server/standalone-StatefulSet: readiness failureThreshold default
 ✓ server/standalone-StatefulSet: readiness failureThreshold configurable
 ✓ server/standalone-StatefulSet: readiness initialDelaySeconds default
 ✓ server/standalone-StatefulSet: readiness initialDelaySeconds configurable
 ✓ server/standalone-StatefulSet: readiness periodSeconds default
 ✓ server/standalone-StatefulSet: readiness periodSeconds configurable
 ✓ server/standalone-StatefulSet: readiness successThreshold default
 ✓ server/standalone-StatefulSet: readiness successThreshold configurable
 ✓ server/standalone-StatefulSet: readiness timeoutSeconds default
 ✓ server/standalone-StatefulSet: readiness timeoutSeconds configurable
 ✓ server/standalone-StatefulSet: livenessProbe default
 ✓ server/standalone-StatefulSet: livenessProbe configurable
 ✓ server/standalone-StatefulSet: liveness failureThreshold default
 ✓ server/standalone-StatefulSet: liveness failureThreshold configurable
 ✓ server/standalone-StatefulSet: liveness initialDelaySeconds default
 ✓ server/standalone-StatefulSet: liveness initialDelaySeconds configurable
 ✓ server/standalone-StatefulSet: liveness periodSeconds default
 ✓ server/standalone-StatefulSet: liveness periodSeconds configurable
 ✓ server/standalone-StatefulSet: liveness successThreshold default
 ✓ server/standalone-StatefulSet: liveness successThreshold configurable
 ✓ server/standalone-StatefulSet: liveness timeoutSeconds default
 ✓ server/standalone-StatefulSet: liveness timeoutSeconds configurable
 ✓ server/standalone-StatefulSet: add extraArgs
 ✓ server/standalone-StatefulSet: terminationGracePeriodSeconds default
 ✓ server/standalone-StatefulSet: terminationGracePeriodSeconds 30
 ✓ server/standalone-StatefulSet: preStop sleep duration default
 ✓ server/standalone-StatefulSet: preStop sleep duration 10
 ✓ server/standalone-StatefulSet: vault port name is http, when tlsDisable is true
 ✓ server/standalone-StatefulSet: vault replication port name is http-rep, when tlsDisable is true
 ✓ server/standalone-StatefulSet: vault port name is https, when tlsDisable is false
 ✓ server/standalone-StatefulSet: vault replication port name is https-rep, when tlsDisable is false
 ✓ server/standalone-StatefulSet: generic annotations string
 ✓ server/standalone-StatefulSet: auditStorage volumeClaim annotations string
 ✓ server/standalone-StatefulSet: dataStorage volumeClaim annotations string
 ✓ server/standalone-StatefulSet: auditStorage volumeClaim annotations yaml
 ✓ server/standalone-StatefulSet: dataStorage volumeClaim annotations yaml
 ✓ server/ha-standby-Service: generic annotations yaml
 ✓ server/standalone-StatefulSet: priorityClassName not set by default
 ✓ server/standalone-StatefulSet: priorityClassName can be set
 ✓ server/standalone-StatefulSet: postStart disabled by default
 ✓ server/standalone-StatefulSet: postStart can be set
 ✓ server/standalone-StatefulSet: OpenShift - runAsUser disabled
 ✓ server/standalone-StatefulSet: OpenShift - runAsGroup disabled
 ✓ server/standalone-StatefulSet: serviceAccount.name is set
 ✓ server/standalone-StatefulSet: serviceAccount.name is not set
 ✓ server/StatefulSet: adds volume for license secret when enterprise license secret name and key are provided
 ✓ server/StatefulSet: adds volume mount for license secret when enterprise license secret name and key are provided
 ✓ server/StatefulSet: adds env var for license path when enterprise license secret name and key are provided
 ✓ server/StatefulSet: blank secretName does not set env var
 ✓ server/standalone-StatefulSet: default statefulSet.securityContext.pod
 ✓ server/standalone-StatefulSet: default statefulSet.securityContext.container
 ✓ server/standalone-StatefulSet: specify statefulSet.securityContext.pod yaml
 ✓ server/standalone-StatefulSet: specify statefulSet.securityContext.container yaml
 ✓ server/standalone-StatefulSet: specify statefulSet.securityContext.pod yaml string
 ✓ server/standalone-StatefulSet: specify statefulSet.securityContext.container yaml string
 ✓ server/StatefulSet: server.hostNetwork not set
 ✓ server/StatefulSet: server.hostNetwork is set
 ✓ server/StatefulSet: server.hostAliases not set
 ✓ server/StatefulSet: server.hostAliases is set
 ✓ server/standalone-StatefulSet: adds extra ports
 ✓ server/StatefulSet: server.readinessProbe.port is set
 ✓ server/StatefulSet: server.livenessProbe.port is set

135 tests, 0 failures

```

closes #964 