### PR TITLE
openshift/server: readiness probe passes when server uninitialized

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -10,14 +10,14 @@ jobs:
   chart-verifier:
     runs-on: ubuntu-latest
     env:
-      CHART_VERIFIER_VERSION: '1.10.1'
+      CHART_VERIFIER_VERSION: '1.13.0'
     steps:
       - uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
       - name: Setup test tools
         uses: ./.github/actions/setup-test-tools
       - uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0
         with:
-          go-version: '1.19.2'
+          go-version: '1.21.3'
       - run: go install "github.com/redhat-certification/chart-verifier@${CHART_VERIFIER_VERSION}"
       - run: bats --tap --timing ./test/chart
 permissions:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Changes:
 * Default `vault` version updated to 1.15.0
 * Default `vault-k8s` version updated to 1.3.0
 * Tested with Kubernetes versions 1.24-1.28
+* server: OpenShift default readiness probe returns 204 when uninitialized
 
 Features:
 * server: Add support for dual stack clusters [GH-833](https://github.com/hashicorp/vault-helm/pull/833)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Changes:
 * Default `vault` version updated to 1.15.0
 * Default `vault-k8s` version updated to 1.3.0
 * Tested with Kubernetes versions 1.24-1.28
-* server: OpenShift default readiness probe returns 204 when uninitialized
+* server: OpenShift default readiness probe returns 204 when uninitialized [GH-966](https://github.com/hashicorp/vault-helm/pull/966)
 
 Features:
 * server: Add support for dual stack clusters [GH-833](https://github.com/hashicorp/vault-helm/pull/833)

--- a/values.openshift.yaml
+++ b/values.openshift.yaml
@@ -19,3 +19,6 @@ server:
   image:
     repository: "registry.connect.redhat.com/hashicorp/vault"
     tag: "1.15.0-ubi"
+
+  readinessProbe:
+    path: "/v1/sys/health?uninitcode=204"


### PR DESCRIPTION
Changes the default server readiness probe (just for openshift) to pass when the server is uninitialized, in order to pass the latest version of the chart-verifier test (see #954 for details).

Also updates the chart-verifier used in our tests to 1.13.0 (latest).

Testing against an OpenShift cluster:

```shell-session
$ go install github.com/redhat-certification/chart-verifier@1.13.0

$ chart-verifier verify ~/projects/vault-helm-review \
  --chart-values ~/projects/vault-helm-review/values.yaml \
  --chart-values ~/projects/vault-helm-review/values.openshift.yaml \
  --timeout 30s -e chart-testing
...
results:
    - check: v1.0/chart-testing
      type: Mandatory
      outcome: PASS
      reason: Chart tests have passed
```

Fixes #954 