### PR TITLE
prepare for 0.26.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Unreleased
 
-## 0.26.0 (October 26, 2023)
+## 0.26.0 (October 27, 2023)
 
 Changes:
 * Default `vault` version updated to 1.15.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 Changes:
 * Default `vault` version updated to 1.15.1
 * Default `vault-k8s` version updated to 1.3.1
+* Default `vault-csi-provider` version updated to 1.4.1
 * Tested with Kubernetes versions 1.24-1.28
 * server: OpenShift default readiness probe returns 204 when uninitialized [GH-966](https://github.com/hashicorp/vault-helm/pull/966)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,10 @@
 ## Unreleased
 
+## 0.26.0 (October 26, 2023)
+
 Changes:
-* Default `vault` version updated to 1.15.0
-* Default `vault-k8s` version updated to 1.3.0
+* Default `vault` version updated to 1.15.1
+* Default `vault-k8s` version updated to 1.3.1
 * Tested with Kubernetes versions 1.24-1.28
 * server: OpenShift default readiness probe returns 204 when uninitialized [GH-966](https://github.com/hashicorp/vault-helm/pull/966)
 

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -3,8 +3,8 @@
 
 apiVersion: v2
 name: vault
-version: 0.25.0
-appVersion: 1.14.0
+version: 0.26.0
+appVersion: 1.15.1
 kubeVersion: ">= 1.20.0-0"
 description: Official HashiCorp Vault Chart
 home: https://www.vaultproject.io

--- a/values.openshift.yaml
+++ b/values.openshift.yaml
@@ -9,16 +9,16 @@ global:
 injector:
   image:
     repository: "registry.connect.redhat.com/hashicorp/vault-k8s"
-    tag: "1.3.0-ubi"
+    tag: "1.3.1-ubi"
 
   agentImage:
     repository: "registry.connect.redhat.com/hashicorp/vault"
-    tag: "1.15.0-ubi"
+    tag: "1.15.1-ubi"
 
 server:
   image:
     repository: "registry.connect.redhat.com/hashicorp/vault"
-    tag: "1.15.0-ubi"
+    tag: "1.15.1-ubi"
 
   readinessProbe:
     path: "/v1/sys/health?uninitcode=204"

--- a/values.yaml
+++ b/values.yaml
@@ -68,7 +68,7 @@ injector:
   # image sets the repo and tag of the vault-k8s image to use for the injector.
   image:
     repository: "hashicorp/vault-k8s"
-    tag: "1.3.0"
+    tag: "1.3.1"
     pullPolicy: IfNotPresent
 
   # agentImage sets the repo and tag of the Vault image to use for the Vault Agent
@@ -76,7 +76,7 @@ injector:
   # required.
   agentImage:
     repository: "hashicorp/vault"
-    tag: "1.15.0"
+    tag: "1.15.1"
 
   # The default values for the injected Vault Agent containers.
   agentDefaults:
@@ -377,7 +377,7 @@ server:
 
   image:
     repository: "hashicorp/vault"
-    tag: "1.14.0"
+    tag: "1.15.1"
     # Overrides the default Image Pull Policy
     pullPolicy: IfNotPresent
 
@@ -1054,7 +1054,7 @@ csi:
 
   image:
     repository: "hashicorp/vault-csi-provider"
-    tag: "1.4.0"
+    tag: "1.4.1"
     pullPolicy: IfNotPresent
 
   # volumes is a list of volumes made available to all containers. These are rendered
@@ -1139,7 +1139,7 @@ csi:
 
     image:
       repository: "hashicorp/vault"
-      tag: "1.15.0"
+      tag: "1.15.1"
       pullPolicy: IfNotPresent
 
     logFormat: standard


### PR DESCRIPTION
```
## 0.26.0 (October 26, 2023)

Changes:
* Default `vault` version updated to 1.15.1
* Default `vault-k8s` version updated to 1.3.1
* Tested with Kubernetes versions 1.24-1.28
* server: OpenShift default readiness probe returns 204 when uninitialized [GH-966](https://github.com/hashicorp/vault-helm/pull/966)

Features:
* server: Add support for dual stack clusters [GH-833](https://github.com/hashicorp/vault-helm/pull/833)
* server: Support `hostAliases` for the StatefulSet pods [GH-955](https://github.com/hashicorp/vault-helm/pull/955)
* server: Add `server.service.active.annotations` and `server.service.standby.annotations` [GH-896](https://github.com/hashicorp/vault-helm/pull/896)
* server: Add long-lived service account token option [GH-923](https://github.com/hashicorp/vault-helm/pull/923)

Bugs:
* csi: Add namespace field to `csi-role` and `csi-rolebindings`. [GH-909](https://github.com/hashicorp/vault-helm/pull/909)

Improvements:
* global: Add `global.namespace` to override the helm installation namespace. [GH-909](https://github.com/hashicorp/vault-helm/pull/909)
* server: use vault.fullname in Helm test [GH-912](https://github.com/hashicorp/vault-helm/pull/912)
* server: Allow scaling HA replicas to zero [GH-943](https://github.com/hashicorp/vault-helm/pull/943)
```