### PR TITLE
Prepare for release 0.26.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,15 @@
 ## Unreleased
 
+## 0.26.1 (October 30, 2023)
+
+Bugs:
+* Fix templating of `server.ha.replicas` when set via override file. [GH-961](https://github.com/hashicorp/vault-helm/pull/961)
+
 ## 0.26.0 (October 27, 2023)
+
+KNOWN ISSUES:
+
+* The chart will ignore `server.ha.replicas` and always deploy 3 server replicas when `server.ha.enabled=true` unless overridden by command line when issuing the helm command: `--set server.ha.replicas=<some_number>`. Fixed in [GH-961](https://github.com/hashicorp/vault-helm/pull/961)
 
 Changes:
 * Default `vault` version updated to 1.15.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,13 +3,9 @@
 ## 0.26.1 (October 30, 2023)
 
 Bugs:
-* Fix templating of `server.ha.replicas` when set via override file. [GH-961](https://github.com/hashicorp/vault-helm/pull/961)
+* Fix templating of `server.ha.replicas` when set via override file. The `0.26.0` chart would ignore `server.ha.replicas` and always deploy 3 server replicas when `server.ha.enabled=true` unless overridden by command line when issuing the helm command: `--set server.ha.replicas=<some_number>`. Fixed in [GH-961](https://github.com/hashicorp/vault-helm/pull/961)
 
 ## 0.26.0 (October 27, 2023)
-
-KNOWN ISSUES:
-
-* The chart will ignore `server.ha.replicas` and always deploy 3 server replicas when `server.ha.enabled=true` unless overridden by command line when issuing the helm command: `--set server.ha.replicas=<some_number>`. Fixed in [GH-961](https://github.com/hashicorp/vault-helm/pull/961)
 
 Changes:
 * Default `vault` version updated to 1.15.1

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -3,7 +3,7 @@
 
 apiVersion: v2
 name: vault
-version: 0.26.0
+version: 0.26.1
 appVersion: 1.15.1
 kubeVersion: ">= 1.20.0-0"
 description: Official HashiCorp Vault Chart


### PR DESCRIPTION
Fixes a bug preventing templating of `server.ha.replicas`.

```
+## 0.26.1 (October 30, 2023)
+
+Bugs:
+* Fix templating of `server.ha.replicas` when set via override file. [GH-961](https://github.com/hashicorp/vault-helm/pull/961)
+
```