### PR TITLE
support exec in server liveness probe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Unreleased
 
-IMPROVEMENTS:
+Improvements:
 
 * Support exec in the server liveness probe [GH-971](https://github.com/hashicorp/vault-helm/pull/971)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Unreleased
 
+IMPROVEMENTS:
+
+* Support exec in the server liveness probe [GH-971](https://github.com/hashicorp/vault-helm/pull/971)
+
 ## 0.26.1 (October 30, 2023)
 
 Bugs:

--- a/templates/server-statefulset.yaml
+++ b/templates/server-statefulset.yaml
@@ -179,10 +179,18 @@ spec:
           {{- end }}
           {{- if .Values.server.livenessProbe.enabled }}
           livenessProbe:
+            {{- if .Values.server.livenessProbe.execCommand }}
+            exec:
+              command:
+                {{- range (.Values.server.livenessProbe.execCommand) }}
+                - {{ . | quote }}
+                {{- end }}
+            {{- else }}
             httpGet:
               path: {{ .Values.server.livenessProbe.path | quote }}
               port: {{ .Values.server.livenessProbe.port }}
               scheme: {{ include "vault.scheme" . | upper }}
+            {{- end }}
             failureThreshold: {{ .Values.server.livenessProbe.failureThreshold }}
             initialDelaySeconds: {{ .Values.server.livenessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.server.livenessProbe.periodSeconds }}

--- a/values.schema.json
+++ b/values.schema.json
@@ -818,6 +818,12 @@
                         "path": {
                             "type": "string"
                         },
+                        "port": {
+                            "type": "integer"
+                        },
+                        "execCommand": {
+                            "type": "array"
+                        },
                         "periodSeconds": {
                             "type": "integer"
                         },

--- a/values.yaml
+++ b/values.yaml
@@ -531,7 +531,7 @@ server:
   # Used to enable a livenessProbe for the pods
   livenessProbe:
     enabled: false
-    # Used to define a liveness exec command. If provided, exec is preferred to httpGet as the livenessProbe handler.
+    # Used to define a liveness exec command. If provided, exec is preferred to httpGet (path) as the livenessProbe handler.
     execCommand: []
     # - /bin/sh
     # - -c

--- a/values.yaml
+++ b/values.yaml
@@ -531,14 +531,15 @@ server:
   # Used to enable a livenessProbe for the pods
   livenessProbe:
     enabled: false
-    path: "/v1/sys/health?standbyok=true"
-    # Port number on which livenessProbe will be checked.
-    port: 8200
     # Used to define a liveness exec command. If provided, exec is preferred to httpGet as the livenessProbe handler.
     execCommand: []
     # - /bin/sh
     # - -c
     # - /vault/userconfig/mylivenessscript/run.sh
+    # Path on which livenessProbe will be checked if httpGet is used as the livenessProbe handler
+    path: "/v1/sys/health?standbyok=true"
+    # Port number on which livenessProbe will be checked if httpGet is used as the livenessProbe handler
+    port: 8200
     # When a probe fails, Kubernetes will try failureThreshold times before giving up
     failureThreshold: 2
     # Number of seconds after the container has started before probe initiates

--- a/values.yaml
+++ b/values.yaml
@@ -536,7 +536,7 @@ server:
     # - /bin/sh
     # - -c
     # - /vault/userconfig/mylivenessscript/run.sh
-    # Path on which livenessProbe will be checked if httpGet is used as the livenessProbe handler
+    # Path for the livenessProbe to use httpGet as the livenessProbe handler
     path: "/v1/sys/health?standbyok=true"
     # Port number on which livenessProbe will be checked if httpGet is used as the livenessProbe handler
     port: 8200

--- a/values.yaml
+++ b/values.yaml
@@ -534,6 +534,11 @@ server:
     path: "/v1/sys/health?standbyok=true"
     # Port number on which livenessProbe will be checked.
     port: 8200
+    # Used to define a liveness exec command. If provided, exec is preferred to httpGet as the livenessProbe handler.
+    execCommand: []
+    # - /bin/sh
+    # - -c
+    # - /vault/userconfig/mylivenessscript/run.sh
     # When a probe fails, Kubernetes will try failureThreshold times before giving up
     failureThreshold: 2
     # Number of seconds after the container has started before probe initiates
@@ -544,11 +549,6 @@ server:
     successThreshold: 1
     # Number of seconds after which the probe times out.
     timeoutSeconds: 3
-    # Used to define a liveness command
-    execCommand: []
-    # - /bin/sh
-    # - -c
-    # - /vault/userconfig/mylivenessscript/run.sh
 
   # Optional duration in seconds the pod needs to terminate gracefully.
   # See: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/

--- a/values.yaml
+++ b/values.yaml
@@ -544,6 +544,11 @@ server:
     successThreshold: 1
     # Number of seconds after which the probe times out.
     timeoutSeconds: 3
+    # Used to define a liveness command
+    execCommand: []
+    # - /bin/sh
+    # - -c
+    # - /vault/userconfig/mylivenessscript/run.sh
 
   # Optional duration in seconds the pod needs to terminate gracefully.
   # See: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/
@@ -695,7 +700,7 @@ server:
     # should be.
     # These are only supported for kubernetes versions >=1.23.0
     #
-    # Configures the service's supported IP family policy, can be either:
+     # Configures the service's supported IP family policy, can be either:
     #     SingleStack: Single-stack service. The control plane allocates a cluster IP for the Service, using the first configured service cluster IP range.
     #     PreferDualStack: Allocates IPv4 and IPv6 cluster IPs for the Service.
     #     RequireDualStack: Allocates Service .spec.ClusterIPs from both IPv4 and IPv6 address ranges.

--- a/values.yaml
+++ b/values.yaml
@@ -700,7 +700,7 @@ server:
     # should be.
     # These are only supported for kubernetes versions >=1.23.0
     #
-     # Configures the service's supported IP family policy, can be either:
+    # Configures the service's supported IP family policy, can be either:
     #     SingleStack: Single-stack service. The control plane allocates a cluster IP for the Service, using the first configured service cluster IP range.
     #     PreferDualStack: Allocates IPv4 and IPv6 cluster IPs for the Service.
     #     RequireDualStack: Allocates Service .spec.ClusterIPs from both IPv4 and IPv6 address ranges.


### PR DESCRIPTION
This PR supports exec in the server liveness probe. If provided, exec is preferred to httpGet as the server liveness probe handler.