### PR TITLE
Bump vault image to v1.15.2

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -3,8 +3,8 @@
 
 apiVersion: v2
 name: vault
-version: 0.26.1
-appVersion: 1.15.1
+version: 0.26.2
+appVersion: 1.15.2
 kubeVersion: ">= 1.20.0-0"
 description: Official HashiCorp Vault Chart
 home: https://www.vaultproject.io

--- a/values.yaml
+++ b/values.yaml
@@ -76,7 +76,7 @@ injector:
   # required.
   agentImage:
     repository: "hashicorp/vault"
-    tag: "1.15.1"
+    tag: "1.15.2"
 
   # The default values for the injected Vault Agent containers.
   agentDefaults:
@@ -377,7 +377,7 @@ server:
 
   image:
     repository: "hashicorp/vault"
-    tag: "1.15.1"
+    tag: "1.15.2"
     # Overrides the default Image Pull Policy
     pullPolicy: IfNotPresent
 
@@ -1153,7 +1153,7 @@ csi:
 
     image:
       repository: "hashicorp/vault"
-      tag: "1.15.1"
+      tag: "1.15.2"
       pullPolicy: IfNotPresent
 
     logFormat: standard


### PR DESCRIPTION
I would also change the default values of image.tag to the value of appversion like common in other common charts

for example: 

https://github.com/prometheus-community/helm-charts/pull/3847/files

I can do this as part of this PR or in a different one, whatever maintainers perfer