### PR TITLE
Update to v0.27.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,16 @@
 ## Unreleased
 
+## 0.27.0 (November 16, 2023)
+
+Changes:
+
+* Default `vault` version updated to 1.15.2
+
 Features:
 
 * server: Support setting `persistentVolumeClaimRetentionPolicy` on the StatefulSet [GH-965](https://github.com/hashicorp/vault-helm/pull/965)
 * server: Support setting labels on PVCs [GH-969](https://github.com/hashicorp/vault-helm/pull/969)
+* server: Support setting ingress rules for networkPolicy [GH-877](https://github.com/hashicorp/vault-helm/pull/877)
 
 Improvements:
 

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -3,8 +3,8 @@
 
 apiVersion: v2
 name: vault
-version: 0.26.1
-appVersion: 1.15.1
+version: 0.27.0
+appVersion: 1.15.2
 kubeVersion: ">= 1.20.0-0"
 description: Official HashiCorp Vault Chart
 home: https://www.vaultproject.io

--- a/values.openshift.yaml
+++ b/values.openshift.yaml
@@ -13,12 +13,12 @@ injector:
 
   agentImage:
     repository: "registry.connect.redhat.com/hashicorp/vault"
-    tag: "1.15.1-ubi"
+    tag: "1.15.2-ubi"
 
 server:
   image:
     repository: "registry.connect.redhat.com/hashicorp/vault"
-    tag: "1.15.1-ubi"
+    tag: "1.15.2-ubi"
 
   readinessProbe:
     path: "/v1/sys/health?uninitcode=204"

--- a/values.schema.json
+++ b/values.schema.json
@@ -872,6 +872,9 @@
                         },
                         "enabled": {
                             "type": "boolean"
+                        },
+                        "ingress": {
+                            "type": "array"
                         }
                     }
                 },

--- a/values.yaml
+++ b/values.yaml
@@ -76,7 +76,7 @@ injector:
   # required.
   agentImage:
     repository: "hashicorp/vault"
-    tag: "1.15.1"
+    tag: "1.15.2"
 
   # The default values for the injected Vault Agent containers.
   agentDefaults:
@@ -377,7 +377,7 @@ server:
 
   image:
     repository: "hashicorp/vault"
-    tag: "1.15.1"
+    tag: "1.15.2"
     # Overrides the default Image Pull Policy
     pullPolicy: IfNotPresent
 
@@ -649,7 +649,7 @@ server:
     #     port: 443
     ingress:
       - from:
-          - namespaceSelector: {}
+        - namespaceSelector: {}
         ports:
         - port: 8200
           protocol: TCP
@@ -1165,7 +1165,7 @@ csi:
 
     image:
       repository: "hashicorp/vault"
-      tag: "1.15.1"
+      tag: "1.15.2"
       pullPolicy: IfNotPresent
 
     logFormat: standard


### PR DESCRIPTION
Changes:

* Default `vault` version updated to 1.15.2

Features:

* server: Support setting `persistentVolumeClaimRetentionPolicy` on the StatefulSet [GH-965](https://github.com/hashicorp/vault-helm/pull/965)
* server: Support setting labels on PVCs [GH-969](https://github.com/hashicorp/vault-helm/pull/969)
* server: Support setting ingress rules for networkPolicy [GH-877](https://github.com/hashicorp/vault-helm/pull/877)

Improvements:

* Support exec in the server liveness probe [GH-971](https://github.com/hashicorp/vault-helm/pull/971)

(Also adds some followup to #877 in the values schema)