### PR TITLE
Add endpoint metricRelabelings in serviceMonitor

### DIFF
--- a/templates/prometheus-servicemonitor.yaml
+++ b/templates/prometheus-servicemonitor.yaml
@@ -43,6 +43,9 @@ spec:
       - prometheus
     tlsConfig:
       insecureSkipVerify: true
+    {{- with .Values.serverTelemetry.serviceMonitor.metricRelabelings }}
+    metricRelabelings: {{ toYaml . | nindent 6 }}
+    {{- end }}
   namespaceSelector:
     matchNames:
       - {{ include "vault.namespace" . }}

--- a/values.yaml
+++ b/values.yaml
@@ -1277,6 +1277,10 @@ serverTelemetry:
     # Timeout for Prometheus scrapes
     scrapeTimeout: 10s
 
+    # Configures the relabeling rules to apply to the samples before ingestion
+    # https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#monitoring.coreos.com/v1.RelabelConfig
+    metricRelabelings: []
+
   prometheusRules:
       # The Prometheus operator *must* be installed before enabling this feature,
       # if not the chart will fail to install due to missing CustomResourceDefinitions


### PR DESCRIPTION
Add `metricRelabelings` field for ServiceMonitor endpoint, to be able drop high cardinality metrics such as vault_expire_leases_by_expiration (https://github.com/hashicorp/vault/issues/24640) .

https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#monitoring.coreos.com/v1.RelabelConfig