### PR TITLE
Install with pip regardless of PEPpy warnings.

### DIFF
--- a/test/docker/Test.dockerfile
+++ b/test/docker/Test.dockerfile
@@ -28,7 +28,7 @@ RUN apk update && apk add --no-cache --virtual .build-deps \
     jq
 
 # yq
-RUN pip install yq
+RUN pip install yq --break-system-packages
 
 # gcloud
 RUN curl -OL https://dl.google.com/dl/cloudsdk/channels/rapid/install_google_cloud_sdk.bash && \


### PR DESCRIPTION
This adds a flag so that newly built test images can install a python library with pip on the host, regardless of the PEP 668.

After running this, I verified that all of the unit tests still pass (on my machine).