### PR TITLE
injector: add get for nodes in clusterrole

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Unreleased
 
+Bugs:
+* injector: add missing `get` `nodes` permission to ClusterRole [GH-1005](https://github.com/hashicorp/vault-helm/pull/1005)
+
 ## 0.27.0 (November 16, 2023)
 
 Changes:

--- a/templates/injector-clusterrole.yaml
+++ b/templates/injector-clusterrole.yaml
@@ -21,4 +21,10 @@ rules:
     - "list"
     - "watch"
     - "patch"
+{{- if and (eq (.Values.injector.leaderElector.enabled | toString) "true") (gt (.Values.injector.replicas | int) 1) }}
+- apiGroups: [""]
+  resources: ["nodes"]
+  verbs:
+    - "get"
+{{ end }}
 {{ end }}

--- a/test/unit/injector-clusterrole.bats
+++ b/test/unit/injector-clusterrole.bats
@@ -20,3 +20,33 @@ load _helpers
       yq 'length > 0' | tee /dev/stderr)
   [ "${actual}" = "false" ]
 }
+
+@test "injector/ClusterRole: no nodes permissions when replicas=1" {
+  cd `chart_dir`
+  local rules=$(helm template \
+      --show-only templates/injector-clusterrole.yaml  \
+      --set 'injector.replicas=1' \
+      . | tee /dev/stderr |
+      yq '.rules' | tee /dev/stderr)
+  rules_length=$(echo "${rules}" | yq 'length')
+  [ "${rules_length}" = "1" ]
+  resources_length=$(echo "${rules}" | yq '.[0].resources | length')
+  [ "${resources_length}" = "1" ]
+  resource=$(echo "${rules}" | yq -r '.[0].resources[0]')
+  [ "${resource}" = "mutatingwebhookconfigurations" ]
+}
+
+@test "injector/ClusterRole: nodes permissions when replicas=2" {
+  cd `chart_dir`
+  local rules=$(helm template \
+      --show-only templates/injector-clusterrole.yaml  \
+      --set 'injector.replicas=2' \
+      . | tee /dev/stderr |
+      yq '.rules' | tee /dev/stderr)
+  rules_length=$(echo "${rules}" | yq 'length')
+  [ "${rules_length}" = "2" ]
+  resources_length=$(echo "${rules}" | yq '.[1].resources | length')
+  [ "${resources_length}" = "1" ]
+  resource=$(echo "${rules}" | yq -r '.[1].resources[0]')
+  [ "${resource}" = "nodes" ]
+}


### PR DESCRIPTION
Required for operator-lib leader logic, as described in https://github.com/hashicorp/vault-k8s/issues/605

Fixes #980, #725 