### PR TITLE
Add values option to override name of the pods in stateful set

### DIFF
--- a/templates/server-statefulset.yaml
+++ b/templates/server-statefulset.yaml
@@ -11,7 +11,11 @@ SPDX-License-Identifier: MPL-2.0
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
+{{- if .Values.server.nameOverride }}
+  name: {{ .Values.nameOverride }}
+{{- else }}
   name: {{ template "vault.fullname" . }}
+{{- end }}
   namespace: {{ include "vault.namespace" . }}
   labels:
     app.kubernetes.io/name: {{ include "vault.name" . }}


### PR DESCRIPTION
Add a values option (.Values.server.nameOverride) that allows to change just the name of the vault pods

The fullnameOverride does not fit the bill as that changes the name for all vault related k8s resources