### PR TITLE
Preparing for v0.28.0 release

### DIFF
--- a/.github/actions/setup-test-tools/action.yaml
+++ b/.github/actions/setup-test-tools/action.yaml
@@ -9,10 +9,10 @@ runs:
     - uses: actions/setup-node@5e21ff4d9bc1a8cf6de233a3057d20ec6b3fb69d # v3.8.1
       with:
         node-version: '16'
-    - run: npm install -g bats@${BATS_VERSION}
+    - run: sudo npm install -g bats@${BATS_VERSION}
       shell: bash
       env:
-        BATS_VERSION: '1.8.2'
+        BATS_VERSION: '1.11.0'
     - run: bats -v
       shell: bash
     - uses: actions/setup-python@65d7f2d534ac1bc67fcd62888c5f4f3d2cb2b236 # v4.7.1

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -10,14 +10,14 @@ jobs:
   chart-verifier:
     runs-on: ubuntu-latest
     env:
-      CHART_VERIFIER_VERSION: '1.13.0'
+      CHART_VERIFIER_VERSION: '1.13.3'
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       - name: Setup test tools
         uses: ./.github/actions/setup-test-tools
       - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
         with:
-          go-version: '1.22.1'
+          go-version: '1.22.2'
       - run: go install "github.com/redhat-certification/chart-verifier@${CHART_VERIFIER_VERSION}"
       - run: bats --tap --timing ./test/chart
 permissions:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -17,7 +17,7 @@ jobs:
         uses: ./.github/actions/setup-test-tools
       - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
         with:
-          go-version: '1.21.3'
+          go-version: '1.22.1'
       - run: go install "github.com/redhat-certification/chart-verifier@${CHART_VERIFIER_VERSION}"
       - run: bats --tap --timing ./test/chart
 permissions:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,20 @@
 ## Unreleased
 
+## 0.28.0 (TBD)
+
+Changes:
+
+* Default `vault` version updated to 1.16.1
+* Default `vault-k8s` version updated to 1.4.1
+* Default `vault-csi-provider` version updated to 1.4.2
+* Tested with Kubernetes versions 1.25-1.29
+
+Features:
+
+* server: Add annotation on config change [GH-1001](https://github.com/hashicorp/vault-helm/pull/1001)
+
 Bugs:
+
 * injector: add missing `get` `nodes` permission to ClusterRole [GH-1005](https://github.com/hashicorp/vault-helm/pull/1005)
 
 ## 0.27.0 (November 16, 2023)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Unreleased
 
-## 0.28.0 (TBD)
+## 0.28.0 (April 8, 2024)
 
 Changes:
 

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -3,8 +3,8 @@
 
 apiVersion: v2
 name: vault
-version: 0.27.0
-appVersion: 1.15.2
+version: 0.28.0
+appVersion: 1.16.1
 kubeVersion: ">= 1.20.0-0"
 description: Official HashiCorp Vault Chart
 home: https://www.vaultproject.io

--- a/test/README.md
+++ b/test/README.md
@@ -45,7 +45,7 @@ There is a make target for generating values.schema.json:
 It relies on the helm [schema-gen plugin][schema-gen]. Note that some manual
 editing will be required, since several properties accept multiple data types.
 
-[schema-gen]: https://github.com/KnechtionsCoding/helm-schema-gen.git
+[schema-gen]: https://github.com/KnechtionsCoding/helm-schema-gen
 
 ## Helm test
 

--- a/test/README.md
+++ b/test/README.md
@@ -45,7 +45,7 @@ There is a make target for generating values.schema.json:
 It relies on the helm [schema-gen plugin][schema-gen]. Note that some manual
 editing will be required, since several properties accept multiple data types.
 
-[schema-gen]: https://github.com/karuppiah7890/helm-schema-gen
+[schema-gen]: https://github.com/KnechtionsCoding/helm-schema-gen.git
 
 ## Helm test
 

--- a/test/acceptance/csi.bats
+++ b/test/acceptance/csi.bats
@@ -11,7 +11,7 @@ load _helpers
   # Install Secrets Store CSI driver
   # Configure it to pass in a JWT for the provider to use, and rotate secrets rapidly
   # so we can see Agent's cache working.
-  CSI_DRIVER_VERSION=1.3.2
+  CSI_DRIVER_VERSION=1.4.2
   helm install secrets-store-csi-driver secrets-store-csi-driver \
     --repo https://kubernetes-sigs.github.io/secrets-store-csi-driver/charts \
     --version=$CSI_DRIVER_VERSION \

--- a/test/chart/_helpers.bash
+++ b/test/chart/_helpers.bash
@@ -3,7 +3,7 @@
 
 # chart_dir returns the directory for the chart
 chart_dir() {
-    echo ${BATS_TEST_DIRNAME}/../..
+    echo "${BATS_TEST_DIRNAME}"/../..
 }
 
 # check_result checks if the specified test passed
@@ -16,6 +16,12 @@ chart_dir() {
 # }
 check_result() {
   local -r var="$1"
-  local check=$(cat $VERIFY_OUTPUT | jq -r ".results[] | select(.check==\"${var}\").outcome")
-  [ "$check" = "PASS" ]
+  local -r check=$(jq -r ".results[] | select(.check==\"${var}\")" < "$VERIFY_OUTPUT")
+  local -r outcome=$(jq -r .outcome <<< "$check")
+  local -r reason=$(jq -r .reason <<< "$check")
+
+  # print the reason if this fails
+  echo "reason: ${reason}"
+
+  [ "$outcome" = "PASS" ]
 }

--- a/test/chart/verifier.bats
+++ b/test/chart/verifier.bats
@@ -30,7 +30,7 @@ setup_file() {
       --output json \
       --openshift-version $OPENSHIFT_VERSION \
       --disable $DISABLED_TESTS \
-      --chart-values values.openshift.yaml 2>&1 | tee $VERIFY_OUTPUT
+      --chart-values values.openshift.yaml | tee $VERIFY_OUTPUT
 }
 
 teardown_file() {

--- a/values.openshift.yaml
+++ b/values.openshift.yaml
@@ -9,16 +9,16 @@ global:
 injector:
   image:
     repository: "registry.connect.redhat.com/hashicorp/vault-k8s"
-    tag: "1.3.1-ubi"
+    tag: "1.4.1-ubi"
 
   agentImage:
     repository: "registry.connect.redhat.com/hashicorp/vault"
-    tag: "1.15.2-ubi"
+    tag: "1.16.1-ubi"
 
 server:
   image:
     repository: "registry.connect.redhat.com/hashicorp/vault"
-    tag: "1.15.2-ubi"
+    tag: "1.16.1-ubi"
 
   readinessProbe:
     path: "/v1/sys/health?uninitcode=204"

--- a/values.schema.json
+++ b/values.schema.json
@@ -99,6 +99,9 @@
                 "extraArgs": {
                     "type": "array"
                 },
+                "hmacSecretName": {
+                    "type": "string"
+                },
                 "image": {
                     "type": "object",
                     "properties": {
@@ -228,14 +231,14 @@
                 "enabled": {
                     "type": "boolean"
                 },
-                "namespace": {
-                    "type": "string"
-                },        
                 "externalVaultAddr": {
                     "type": "string"
                 },
                 "imagePullSecrets": {
                     "type": "array"
+                },
+                "namespace": {
+                    "type": "string"
                 },
                 "openshift": {
                     "type": "boolean"
@@ -250,6 +253,14 @@
                             ]
                         },
                         "enable": {
+                            "type": "boolean"
+                        }
+                    }
+                },
+                "serverTelemetry": {
+                    "type": "object",
+                    "properties": {
+                        "prometheusOperator": {
                             "type": "boolean"
                         }
                     }
@@ -388,6 +399,26 @@
                         }
                     }
                 },
+                "livenessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "failureThreshold": {
+                            "type": "integer"
+                        },
+                        "initialDelaySeconds": {
+                            "type": "integer"
+                        },
+                        "periodSeconds": {
+                            "type": "integer"
+                        },
+                        "successThreshold": {
+                            "type": "integer"
+                        },
+                        "timeoutSeconds": {
+                            "type": "integer"
+                        }
+                    }
+                },
                 "logFormat": {
                     "type": "string"
                 },
@@ -426,6 +457,26 @@
                 },
                 "priorityClassName": {
                     "type": "string"
+                },
+                "readinessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "failureThreshold": {
+                            "type": "integer"
+                        },
+                        "initialDelaySeconds": {
+                            "type": "integer"
+                        },
+                        "periodSeconds": {
+                            "type": "integer"
+                        },
+                        "successThreshold": {
+                            "type": "integer"
+                        },
+                        "timeoutSeconds": {
+                            "type": "integer"
+                        }
+                    }
                 },
                 "replicas": {
                     "type": "integer"
@@ -472,6 +523,26 @@
                                 "object",
                                 "string"
                             ]
+                        }
+                    }
+                },
+                "startupProbe": {
+                    "type": "object",
+                    "properties": {
+                        "failureThreshold": {
+                            "type": "integer"
+                        },
+                        "initialDelaySeconds": {
+                            "type": "integer"
+                        },
+                        "periodSeconds": {
+                            "type": "integer"
+                        },
+                        "successThreshold": {
+                            "type": "integer"
+                        },
+                        "timeoutSeconds": {
+                            "type": "integer"
                         }
                     }
                 },
@@ -559,15 +630,15 @@
                                 "string"
                             ]
                         },
-                        "labels": {
-                            "type": [
-                                "object",
-                                "string"
-                            ]
-                        },
                         "enabled": {
                             "type": [
                                 "boolean",
+                                "string"
+                            ]
+                        },
+                        "labels": {
+                            "type": [
+                                "object",
                                 "string"
                             ]
                         },
@@ -593,6 +664,9 @@
                         }
                     }
                 },
+                "configAnnotation": {
+                    "type": "boolean"
+                },
                 "dataStorage": {
                     "type": "object",
                     "properties": {
@@ -605,15 +679,15 @@
                                 "string"
                             ]
                         },
-                        "labels": {
-                            "type": [
-                                "object",
-                                "string"
-                            ]
-                        },
                         "enabled": {
                             "type": [
                                 "boolean",
+                                "string"
+                            ]
+                        },
+                        "labels": {
+                            "type": [
+                                "object",
                                 "string"
                             ]
                         },
@@ -628,17 +702,6 @@
                                 "null",
                                 "string"
                             ]
-                        }
-                    }
-                },
-                "persistentVolumeClaimRetentionPolicy": {
-                    "type": "object",
-                    "properties": {
-                        "whenDeleted": {
-                            "type": "string"
-                        },
-                        "whenScaled": {
-                            "type": "string"
                         }
                     }
                 },
@@ -673,12 +736,6 @@
                 "extraArgs": {
                     "type": "string"
                 },
-                "extraPorts": {
-                    "type": [
-                        "null",
-                        "array"
-                    ]
-                },
                 "extraContainers": {
                     "type": [
                         "null",
@@ -696,6 +753,12 @@
                 },
                 "extraLabels": {
                     "type": "object"
+                },
+                "extraPorts": {
+                    "type": [
+                        "null",
+                        "array"
+                    ]
                 },
                 "extraSecretEnvironmentVars": {
                     "type": "array"
@@ -766,6 +829,9 @@
                 "hostAliases": {
                     "type": "array"
                 },
+                "hostNetwork": {
+                    "type": "boolean"
+                },
                 "image": {
                     "type": "object",
                     "properties": {
@@ -832,6 +898,9 @@
                         "enabled": {
                             "type": "boolean"
                         },
+                        "execCommand": {
+                            "type": "array"
+                        },
                         "failureThreshold": {
                             "type": "integer"
                         },
@@ -841,13 +910,10 @@
                         "path": {
                             "type": "string"
                         },
-                        "port": {
+                        "periodSeconds": {
                             "type": "integer"
                         },
-                        "execCommand": {
-                            "type": "array"
-                        },
-                        "periodSeconds": {
+                        "port": {
                             "type": "integer"
                         },
                         "successThreshold": {
@@ -885,6 +951,17 @@
                         "string"
                     ]
                 },
+                "persistentVolumeClaimRetentionPolicy": {
+                    "type": "object",
+                    "properties": {
+                        "whenDeleted": {
+                            "type": "string"
+                        },
+                        "whenScaled": {
+                            "type": "string"
+                        }
+                    }
+                },
                 "postStart": {
                     "type": "array"
                 },
@@ -907,6 +984,9 @@
                             "type": "integer"
                         },
                         "periodSeconds": {
+                            "type": "integer"
+                        },
+                        "port": {
                             "type": "integer"
                         },
                         "successThreshold": {
@@ -952,16 +1032,19 @@
                         "active": {
                             "type": "object",
                             "properties": {
-                                "enabled": {
-                                    "type": "boolean"
-                                },
                                 "annotations": {
                                     "type": [
                                         "object",
                                         "string"
                                     ]
+                                },
+                                "enabled": {
+                                    "type": "boolean"
                                 }
                             }
+                        },
+                        "activeNodePort": {
+                            "type": "integer"
                         },
                         "annotations": {
                             "type": [
@@ -983,6 +1066,15 @@
                                 }
                             }
                         },
+                        "ipFamilies": {
+                            "type": "array"
+                        },
+                        "ipFamilyPolicy": {
+                            "type": "string"
+                        },
+                        "nodePort": {
+                            "type": "integer"
+                        },
                         "port": {
                             "type": "integer"
                         },
@@ -992,36 +1084,22 @@
                         "standby": {
                             "type": "object",
                             "properties": {
-                                "enabled": {
-                                    "type": "boolean"
-                                },
                                 "annotations": {
                                     "type": [
                                         "object",
                                         "string"
                                     ]
+                                },
+                                "enabled": {
+                                    "type": "boolean"
                                 }
                             }
-                        },
-                        "targetPort": {
-                            "type": "integer"
-                        },
-                        "nodePort": {
-                            "type": "integer"
-                        },
-                        "activeNodePort": {
-                            "type": "integer"
                         },
                         "standbyNodePort": {
                             "type": "integer"
                         },
-                        "ipFamilyPolicy": {
-                            "type": "string"
-                        },
-                        "ipFamilies": {
-                            "type": [
-                                "array"
-                            ]
+                        "targetPort": {
+                            "type": "integer"
                         }
                     }
                 },
@@ -1037,11 +1115,11 @@
                         "create": {
                             "type": "boolean"
                         },
-                        "extraLabels": {
-                            "type": "object"
-                        },
                         "createSecret": {
                             "type": "boolean"
+                        },
+                        "extraLabels": {
+                            "type": "object"
                         },
                         "name": {
                             "type": "string"
@@ -1135,9 +1213,6 @@
                         "null",
                         "array"
                     ]
-                },
-                "hostNetwork": {
-                    "type": "boolean"
                 }
             }
         },
@@ -1152,6 +1227,23 @@
                         },
                         "rules": {
                             "type": "array"
+                        },
+                        "selectors": {
+                            "type": "object"
+                        }
+                    }
+                },
+                "serviceMonitor": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean"
+                        },
+                        "interval": {
+                            "type": "string"
+                        },
+                        "scrapeTimeout": {
+                            "type": "string"
                         },
                         "selectors": {
                             "type": "object"
@@ -1187,6 +1279,12 @@
                 "publishNotReadyAddresses": {
                     "type": "boolean"
                 },
+                "serviceIPFamilies": {
+                    "type": "array"
+                },
+                "serviceIPFamilyPolicy": {
+                    "type": "string"
+                },
                 "serviceNodePort": {
                     "type": [
                         "null",
@@ -1198,16 +1296,6 @@
                 },
                 "targetPort": {
                     "type": "integer"
-                },
-                "serviceIPFamilyPolicy": {
-                    "type": [
-                        "string"
-                    ]
-                },
-                "serviceIPFamilies": {
-                    "type": [
-                        "array"
-                    ]
                 }
             }
         }

--- a/values.yaml
+++ b/values.yaml
@@ -68,7 +68,7 @@ injector:
   # image sets the repo and tag of the vault-k8s image to use for the injector.
   image:
     repository: "hashicorp/vault-k8s"
-    tag: "1.3.1"
+    tag: "1.4.1"
     pullPolicy: IfNotPresent
 
   # agentImage sets the repo and tag of the Vault image to use for the Vault Agent

--- a/values.yaml
+++ b/values.yaml
@@ -76,7 +76,7 @@ injector:
   # required.
   agentImage:
     repository: "hashicorp/vault"
-    tag: "1.15.2"
+    tag: "1.16.1"
 
   # The default values for the injected Vault Agent containers.
   agentDefaults:
@@ -377,7 +377,7 @@ server:
 
   image:
     repository: "hashicorp/vault"
-    tag: "1.15.2"
+    tag: "1.16.1"
     # Overrides the default Image Pull Policy
     pullPolicy: IfNotPresent
 
@@ -1087,7 +1087,7 @@ csi:
 
   image:
     repository: "hashicorp/vault-csi-provider"
-    tag: "1.4.1"
+    tag: "1.4.2"
     pullPolicy: IfNotPresent
 
   # volumes is a list of volumes made available to all containers. These are rendered
@@ -1172,7 +1172,7 @@ csi:
 
     image:
       repository: "hashicorp/vault"
-      tag: "1.15.2"
+      tag: "1.16.1"
       pullPolicy: IfNotPresent
 
     logFormat: standard


### PR DESCRIPTION
# 0.28.0 (April 8, 2024)

## Changes:

* Default `vault` version updated to [1.16.1](https://github.com/hashicorp/vault/releases/tag/v1.16.1)
* Default `vault-k8s` version updated to [1.4.1](https://github.com/hashicorp/vault-k8s/releases/tag/v1.4.1)
* Default `vault-csi-provider` version updated to [1.4.2](https://github.com/hashicorp/vault-csi-provider/releases/tag/v1.4.2)
* Tested with Kubernetes versions 1.25-1.29

## Features:

* server: Add annotation on config change [GH-1001](https://github.com/hashicorp/vault-helm/pull/1001)

## Bugs:

* injector: add missing `get` `nodes` permission to ClusterRole [GH-1005](https://github.com/hashicorp/vault-helm/pull/1005)