### PR TITLE
Update vault default image to 1.17.0 in values.yaml for vault-helm chart

### DIFF
--- a/values.yaml
+++ b/values.yaml
@@ -76,7 +76,7 @@ injector:
   # required.
   agentImage:
     repository: "hashicorp/vault"
-    tag: "1.16.1"
+    tag: "1.17.0"
 
   # The default values for the injected Vault Agent containers.
   agentDefaults:


### PR DESCRIPTION
This PR updates the default image version for `vault` to `1.17.0` in the values.yaml file of the vault-helm chart. This ensures that users will deploy the latest stable version of the vault-agent by default.