### PR TITLE
Preparing for v0.28.1 release

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,3 +5,16 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    labels: ["dependencies"]
+    groups:
+      github-actions-breaking:
+        update-types:
+          - major
+      github-actions-backward-compatible:
+        update-types:
+          - minor
+          - patch
+    # only update internal github actions, external github actions are handled
+    # by https://github.com/hashicorp/security-tsccr/tree/main/automation
+    allow:
+      - dependency-name: "hashicorp/*"

--- a/.github/workflows/jira.yaml
+++ b/.github/workflows/jira.yaml
@@ -14,4 +14,4 @@ jobs:
       JIRA_SYNC_USER_EMAIL: ${{ secrets.JIRA_SYNC_USER_EMAIL }}
       JIRA_SYNC_API_TOKEN: ${{ secrets.JIRA_SYNC_API_TOKEN }}
     with:
-      teams-array: '["ecosystem", "foundations-eco"]'
+      teams-array: '["vault-eco"]'

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -10,14 +10,14 @@ jobs:
   chart-verifier:
     runs-on: ubuntu-latest
     env:
-      CHART_VERIFIER_VERSION: '1.13.3'
+      CHART_VERIFIER_VERSION: '1.13.4'
     steps:
       - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
       - name: Setup test tools
         uses: ./.github/actions/setup-test-tools
       - uses: actions/setup-go@cdcb36043654635271a94b9a6d1392de5bb323a7 # v5.0.1
         with:
-          go-version: '1.22.2'
+          go-version: '1.22.5'
       - run: go install "github.com/redhat-certification/chart-verifier@${CHART_VERIFIER_VERSION}"
       - run: bats --tap --timing ./test/chart
 permissions:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Improvements:
 
 * Configurable `tlsConfig` and `authorization` for Prometheus ServiceMonitor [GH-1025](https://github.com/hashicorp/vault-helm/pull/1025)
 * Remove UPDATE from injector-mutating-webhook [GH-783](https://github.com/hashicorp/vault-helm/pull/783)
+* Add scope to mutating webhook [GH-1037](https://github.com/hashicorp/vault-helm/pull/1037)
 
 ## 0.28.0 (April 8, 2024)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 ## Unreleased
 
+## 0.28.1 (July 8, 2024)
+
+Changes:
+
+* Default `vault` version updated to 1.17.1
+* Default `vault-k8s` version updated to 1.4.2
+* Default `vault-csi-provider` version updated to 1.4.3
+* Tested with Kubernetes versions 1.26-1.30
+
+Improvements:
+
+* Configurable `tlsConfig` and `authorization` for Prometheus ServiceMonitor [GH-1025](https://github.com/hashicorp/vault-helm/pull/1025)
+* Remove UPDATE from injector-mutating-webhook [GH-783](https://github.com/hashicorp/vault-helm/pull/783)
+
 ## 0.28.0 (April 8, 2024)
 
 Changes:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 Changes:
 
-* Default `vault` version updated to 1.17.1
+* Default `vault` version updated to 1.17.2
 * Default `vault-k8s` version updated to 1.4.2
 * Default `vault-csi-provider` version updated to 1.4.3
 * Tested with Kubernetes versions 1.26-1.30

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Unreleased
 
-## 0.28.1 (July 8, 2024)
+## 0.28.1 (July 11, 2024)
 
 Changes:
 

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -3,8 +3,8 @@
 
 apiVersion: v2
 name: vault
-version: 0.28.0
-appVersion: 1.16.1
+version: 0.28.1
+appVersion: 1.17.1
 kubeVersion: ">= 1.20.0-0"
 description: Official HashiCorp Vault Chart
 home: https://www.vaultproject.io

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -4,7 +4,7 @@
 apiVersion: v2
 name: vault
 version: 0.28.1
-appVersion: 1.17.1
+appVersion: 1.17.2
 kubeVersion: ">= 1.20.0-0"
 description: Official HashiCorp Vault Chart
 home: https://www.vaultproject.io

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ this README. Please refer to the Kubernetes and Helm documentation.
 The versions required are:
 
   * **Helm 3.6+**
-  * **Kubernetes 1.22+** - This is the earliest version of Kubernetes tested.
+  * **Kubernetes 1.26+** - This is the earliest version of Kubernetes tested.
     It is possible that this chart works with earlier versions but it is
     untested.
 

--- a/values.openshift.yaml
+++ b/values.openshift.yaml
@@ -13,12 +13,12 @@ injector:
 
   agentImage:
     repository: "registry.connect.redhat.com/hashicorp/vault"
-    tag: "1.17.1-ubi"
+    tag: "1.17.2-ubi"
 
 server:
   image:
     repository: "registry.connect.redhat.com/hashicorp/vault"
-    tag: "1.17.1-ubi"
+    tag: "1.17.2-ubi"
 
   readinessProbe:
     path: "/v1/sys/health?uninitcode=204"

--- a/values.openshift.yaml
+++ b/values.openshift.yaml
@@ -9,16 +9,16 @@ global:
 injector:
   image:
     repository: "registry.connect.redhat.com/hashicorp/vault-k8s"
-    tag: "1.4.1-ubi"
+    tag: "1.4.2-ubi"
 
   agentImage:
     repository: "registry.connect.redhat.com/hashicorp/vault"
-    tag: "1.16.1-ubi"
+    tag: "1.17.1-ubi"
 
 server:
   image:
     repository: "registry.connect.redhat.com/hashicorp/vault"
-    tag: "1.16.1-ubi"
+    tag: "1.17.1-ubi"
 
   readinessProbe:
     path: "/v1/sys/health?uninitcode=204"

--- a/values.schema.json
+++ b/values.schema.json
@@ -1236,6 +1236,9 @@
                 "serviceMonitor": {
                     "type": "object",
                     "properties": {
+                        "authorization": {
+                            "type": "object"
+                        },
                         "enabled": {
                             "type": "boolean"
                         },
@@ -1246,6 +1249,9 @@
                             "type": "string"
                         },
                         "selectors": {
+                            "type": "object"
+                        },
+                        "tlsConfig": {
                             "type": "object"
                         }
                     }

--- a/values.yaml
+++ b/values.yaml
@@ -76,7 +76,7 @@ injector:
   # required.
   agentImage:
     repository: "hashicorp/vault"
-    tag: "1.17.1"
+    tag: "1.17.2"
 
   # The default values for the injected Vault Agent containers.
   agentDefaults:
@@ -377,7 +377,7 @@ server:
 
   image:
     repository: "hashicorp/vault"
-    tag: "1.17.1"
+    tag: "1.17.2"
     # Overrides the default Image Pull Policy
     pullPolicy: IfNotPresent
 
@@ -1172,7 +1172,7 @@ csi:
 
     image:
       repository: "hashicorp/vault"
-      tag: "1.17.1"
+      tag: "1.17.2"
       pullPolicy: IfNotPresent
 
     logFormat: standard

--- a/values.yaml
+++ b/values.yaml
@@ -68,7 +68,7 @@ injector:
   # image sets the repo and tag of the vault-k8s image to use for the injector.
   image:
     repository: "hashicorp/vault-k8s"
-    tag: "1.4.1"
+    tag: "1.4.2"
     pullPolicy: IfNotPresent
 
   # agentImage sets the repo and tag of the Vault image to use for the Vault Agent
@@ -76,7 +76,7 @@ injector:
   # required.
   agentImage:
     repository: "hashicorp/vault"
-    tag: "1.16.1"
+    tag: "1.17.1"
 
   # The default values for the injected Vault Agent containers.
   agentDefaults:
@@ -377,7 +377,7 @@ server:
 
   image:
     repository: "hashicorp/vault"
-    tag: "1.16.1"
+    tag: "1.17.1"
     # Overrides the default Image Pull Policy
     pullPolicy: IfNotPresent
 
@@ -1087,7 +1087,7 @@ csi:
 
   image:
     repository: "hashicorp/vault-csi-provider"
-    tag: "1.4.2"
+    tag: "1.4.3"
     pullPolicy: IfNotPresent
 
   # volumes is a list of volumes made available to all containers. These are rendered
@@ -1172,7 +1172,7 @@ csi:
 
     image:
       repository: "hashicorp/vault"
-      tag: "1.16.1"
+      tag: "1.17.1"
       pullPolicy: IfNotPresent
 
     logFormat: standard


### PR DESCRIPTION
Updating image defaults, dependabot config, and changelog.

## Changes:

* Default `vault` version updated to 1.17.2
* Default `vault-k8s` version updated to 1.4.2
* Default `vault-csi-provider` version updated to 1.4.3
* Tested with Kubernetes versions 1.26-1.30

## Improvements:

* Configurable `tlsConfig` and `authorization` for Prometheus ServiceMonitor [GH-1025](https://github.com/hashicorp/vault-helm/pull/1025)
* Remove UPDATE from injector-mutating-webhook [GH-783](https://github.com/hashicorp/vault-helm/pull/783)
* Add scope to mutating webhook [GH-1037](https://github.com/hashicorp/vault-helm/pull/1037)