### PR TITLE
Updated the ConfigMap Annotation Hook

### DIFF
--- a/values.schema.json
+++ b/values.schema.json
@@ -664,7 +664,7 @@
                         }
                     }
                 },
-                "configAnnotation": {
+                "includeConfigAnnotation": {
                     "type": "boolean"
                 },
                 "dataStorage": {

--- a/values.yaml
+++ b/values.yaml
@@ -673,7 +673,7 @@ server:
   # This can be used together with an OnDelete deployment strategy to help
   # identify which pods still need to be deleted during a deployment to pick up
   # any configuration changes.
-  configAnnotation: false
+  includeConfigAnnotation: false
 
   # Enables a headless service to be used by the Vault Statefulset
   service:

--- a/values.yaml
+++ b/values.yaml
@@ -671,8 +671,8 @@ server:
   # Add an annotation to the server configmap and the statefulset pods,
   # vaultproject.io/config-checksum, that is a hash of the Vault configuration.
   # This can be used together with an OnDelete deployment strategy to help
-  # identify which pods still need to be deleted during a deployment to pick up
-  # any configuration changes.
+  # identify which pods still need to be deleted during a deployment or with
+  # RollingUpdate on an auto-unsealed vault to pick up any configuration changes.
   includeConfigAnnotation: false
 
   # Enables a headless service to be used by the Vault Statefulset


### PR DESCRIPTION
The ConfigMap Annotation has been incorrectly mentioned in the values.yaml file, as https://github.com/hashicorp/vault-helm/blob/main/templates/_helpers.tpl#L462 states that it is expecting the boolean value of `includeConfigAnnotation`
```
  {{- if .Values.server.includeConfigAnnotation }}
        vault.hashicorp.com/config-checksum: {{ include "vault.config" . | sha256sum }}
  {{- end }}
```
Instead in `values.yaml` the hook has been specified as `configAnnotation: false` which is not being used, For Reference: https://github.com/hashicorp/vault-helm/blob/main/values.yaml#L676

After updating this value to true, the checksum annotation could be created in the Stateful Set.
```
annotations:
  vault.hashicorp.com/config-checksum: 3961301403b088XXXXXXXXXXX
```