### PR TITLE
Update CSI log tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,6 @@ Bugs:
 
 * Properly handle JSON formatted server config [GH-1049](https://github.com/hashicorp/vault-helm/pull/1049)
 
-
 ## 0.28.1 (July 11, 2024)
 
 Changes:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Unreleased
 
+* Default `vault` version updated to 1.17.3
+* Default `vault-csi-provider` version updated to 1.5.0
+
 ## 0.28.1 (July 11, 2024)
 
 Changes:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+Changes:
+
 * Default `vault` version updated to 1.17.3
 * Default `vault-csi-provider` version updated to 1.5.0
 

--- a/templates/csi-daemonset.yaml
+++ b/templates/csi-daemonset.yaml
@@ -59,8 +59,6 @@ spec:
             - --log-level={{ .Values.csi.logLevel }}
             {{- else if .Values.csi.debug }}
             - --log-level=debug
-            {{- else }}
-            - --log-level=info
             {{- end }}
             {{- if .Values.csi.hmacSecretName }}
             - --hmac-secret-name={{ .Values.csi.hmacSecretName }}

--- a/templates/csi-daemonset.yaml
+++ b/templates/csi-daemonset.yaml
@@ -55,10 +55,12 @@ spec:
           imagePullPolicy: {{ .Values.csi.image.pullPolicy }}
           args:
             - --endpoint=/provider/vault.sock
-            {{- if .Values.csi.debug }}
+            {{- if .Values.csi.logLevel }}
+            - --log-level={{ .Values.csi.logLevel }}
+            {{- else if .Values.csi.debug }}
             - --log-level=debug
             {{- else }}
-            - --log-level={{ .Values.csi.logLevel }}
+            - --log-level=info
             {{- end }}
             {{- if .Values.csi.hmacSecretName }}
             - --hmac-secret-name={{ .Values.csi.hmacSecretName }}

--- a/templates/csi-daemonset.yaml
+++ b/templates/csi-daemonset.yaml
@@ -55,12 +55,10 @@ spec:
           imagePullPolicy: {{ .Values.csi.image.pullPolicy }}
           args:
             - --endpoint=/provider/vault.sock
-            {{- if .Values.csi.logLevel }}
-            - --log-level={{ .Values.csi.logLevel }}
-            {{- else if .Values.csi.debug }}
+            {{- if .Values.csi.debug }}
             - --log-level=debug
             {{- else }}
-            - --log-level=info
+            - --log-level={{ .Values.csi.logLevel }}
             {{- end }}
             {{- if .Values.csi.hmacSecretName }}
             - --hmac-secret-name={{ .Values.csi.hmacSecretName }}

--- a/templates/csi-daemonset.yaml
+++ b/templates/csi-daemonset.yaml
@@ -55,7 +55,11 @@ spec:
           imagePullPolicy: {{ .Values.csi.image.pullPolicy }}
           args:
             - --endpoint=/provider/vault.sock
-            - --debug={{ .Values.csi.debug }}
+            {{- if .Values.csi.debug }}
+            - --log-level=debug
+            {{- else }}
+            - --log-level={{ .Values.csi.logLevel }}
+            {{- end }}
             {{- if .Values.csi.hmacSecretName }}
             - --hmac-secret-name={{ .Values.csi.hmacSecretName }}
             {{- else }}

--- a/templates/csi-daemonset.yaml
+++ b/templates/csi-daemonset.yaml
@@ -59,6 +59,8 @@ spec:
             - --log-level={{ .Values.csi.logLevel }}
             {{- else if .Values.csi.debug }}
             - --log-level=debug
+            {{- else }}
+            - --log-level=info
             {{- end }}
             {{- if .Values.csi.hmacSecretName }}
             - --hmac-secret-name={{ .Values.csi.hmacSecretName }}

--- a/test/acceptance/csi.bats
+++ b/test/acceptance/csi.bats
@@ -11,7 +11,7 @@ load _helpers
   # Install Secrets Store CSI driver
   # Configure it to pass in a JWT for the provider to use, and rotate secrets rapidly
   # so we can see Agent's cache working.
-  CSI_DRIVER_VERSION=1.5.0
+  CSI_DRIVER_VERSION=1.4.2
   helm install secrets-store-csi-driver secrets-store-csi-driver \
     --repo https://kubernetes-sigs.github.io/secrets-store-csi-driver/charts \
     --version=$CSI_DRIVER_VERSION \

--- a/test/acceptance/csi.bats
+++ b/test/acceptance/csi.bats
@@ -11,7 +11,7 @@ load _helpers
   # Install Secrets Store CSI driver
   # Configure it to pass in a JWT for the provider to use, and rotate secrets rapidly
   # so we can see Agent's cache working.
-  CSI_DRIVER_VERSION=1.4.2
+  CSI_DRIVER_VERSION=1.5.0
   helm install secrets-store-csi-driver secrets-store-csi-driver \
     --repo https://kubernetes-sigs.github.io/secrets-store-csi-driver/charts \
     --version=$CSI_DRIVER_VERSION \

--- a/test/acceptance/csi.bats
+++ b/test/acceptance/csi.bats
@@ -27,7 +27,7 @@ load _helpers
     --namespace=acceptance \
     --set="server.dev.enabled=true" \
     --set="csi.enabled=true" \
-    --set="csi.debug=true" \
+    --set="csi.logLevel=debug" \
     --set="csi.agent.logLevel=debug" \
     --set="injector.enabled=false" \
     .

--- a/test/unit/csi-daemonset.bats
+++ b/test/unit/csi-daemonset.bats
@@ -177,16 +177,39 @@ load _helpers
       --set "csi.enabled=true" \
       . | tee /dev/stderr |
       yq -r '.spec.template.spec.containers[0].args[1]' | tee /dev/stderr)
-  [ "${actual}" = "--debug=false" ]
+  [ "${actual}" = "--log-level=info" ]
 
   local actual=$(helm template \
       --show-only templates/csi-daemonset.yaml \
       --set "csi.enabled=true" \
+      --set "csi.logLevel=error" \
       --set "csi.debug=true" \
       . | tee /dev/stderr |
       yq -r '.spec.template.spec.containers[0].args[1]' | tee /dev/stderr)
-  [ "${actual}" = "--debug=true" ]
+  [ "${actual}" = "--log-level=debug" ]
 }
+
+@test "csi/daemonset: default log-level" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/csi-daemonset.yaml \
+      --set "csi.enabled=true" \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.containers[0].args[1]' | tee /dev/stderr)
+  [ "${actual}" = "--log-level=info" ]
+}
+
+@test "csi/daemonset: log-level is configurable" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/csi-daemonset.yaml \
+      --set "csi.enabled=true" \
+      --set "csi.logLevel=warn" \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.containers[0].args[1]' | tee /dev/stderr)
+  [ "${actual}" = "--log-level=warn" ]
+}
+
 
 # HMAC secret arg
 @test "csi/daemonset: HMAC secret arg is configurable" {

--- a/test/unit/csi-daemonset.bats
+++ b/test/unit/csi-daemonset.bats
@@ -183,7 +183,7 @@ load _helpers
   actual=$(helm template \
       --show-only templates/csi-daemonset.yaml \
       --set "csi.enabled=true" \
-      --set "csi.logLevel=error" \
+      --set "csi.logLevel=" \
       --set "csi.debug=true" \
       . | tee /dev/stderr |
       yq -r '.spec.template.spec.containers[0].args[1]' | tee /dev/stderr)

--- a/test/unit/csi-daemonset.bats
+++ b/test/unit/csi-daemonset.bats
@@ -172,7 +172,8 @@ load _helpers
 # Debug arg
 @test "csi/daemonset: debug arg is configurable" {
   cd `chart_dir`
-  local actual=$(helm template \
+  local actual
+  actual=$(helm template \
       --show-only templates/csi-daemonset.yaml \
       --set "csi.enabled=true" \
       . | tee /dev/stderr |

--- a/test/unit/csi-daemonset.bats
+++ b/test/unit/csi-daemonset.bats
@@ -183,7 +183,7 @@ load _helpers
   actual=$(helm template \
       --show-only templates/csi-daemonset.yaml \
       --set "csi.enabled=true" \
-      --set "csi.logLevel=" \
+      --set "csi.logLevel=error" \
       --set "csi.debug=true" \
       . | tee /dev/stderr |
       yq -r '.spec.template.spec.containers[0].args[1]' | tee /dev/stderr)

--- a/test/unit/csi-daemonset.bats
+++ b/test/unit/csi-daemonset.bats
@@ -202,7 +202,8 @@ load _helpers
 
 @test "csi/daemonset: log-level is configurable" {
   cd `chart_dir`
-  local actual=$(helm template \
+  local actual
+  actual=$(helm template \
       --show-only templates/csi-daemonset.yaml \
       --set "csi.enabled=true" \
       --set "csi.logLevel=warn" \

--- a/test/unit/csi-daemonset.bats
+++ b/test/unit/csi-daemonset.bats
@@ -179,7 +179,7 @@ load _helpers
       yq -r '.spec.template.spec.containers[0].args[1]' | tee /dev/stderr)
   [ "${actual}" = "--log-level=info" ]
 
-  local actual=$(helm template \
+  actual=$(helm template \
       --show-only templates/csi-daemonset.yaml \
       --set "csi.enabled=true" \
       --set "csi.logLevel=error" \

--- a/test/unit/csi-daemonset.bats
+++ b/test/unit/csi-daemonset.bats
@@ -191,7 +191,8 @@ load _helpers
 
 @test "csi/daemonset: default log-level" {
   cd `chart_dir`
-  local actual=$(helm template \
+  local actual
+  actual=$(helm template \
       --show-only templates/csi-daemonset.yaml \
       --set "csi.enabled=true" \
       . | tee /dev/stderr |

--- a/values.yaml
+++ b/values.yaml
@@ -1087,7 +1087,7 @@ csi:
 
   image:
     repository: "hashicorp/vault-csi-provider"
-    tag: "1.4.3"
+    tag: "1.5.0"
     pullPolicy: IfNotPresent
 
   # volumes is a list of volumes made available to all containers. These are rendered

--- a/values.yaml
+++ b/values.yaml
@@ -76,7 +76,7 @@ injector:
   # required.
   agentImage:
     repository: "hashicorp/vault"
-    tag: "1.17.2"
+    tag: "1.17.3"
 
   # The default values for the injected Vault Agent containers.
   agentDefaults:

--- a/values.yaml
+++ b/values.yaml
@@ -1225,7 +1225,7 @@ csi:
     # Number of seconds after which the probe times out.
     timeoutSeconds: 3
 
-  # Configures the log verbosity of the injector.
+  # Configures the log level for the Vault CSI provider.
   # Supported log levels include: trace, debug, info, warn, error, and off
   logLevel: "info"
 

--- a/values.yaml
+++ b/values.yaml
@@ -1225,7 +1225,12 @@ csi:
     # Number of seconds after which the probe times out.
     timeoutSeconds: 3
 
-  # Enables debug logging.
+  # Configures the log verbosity of the injector.
+  # Supported log levels include: trace, debug, info, warn, error, and off
+  logLevel: "info"
+
+  # Deprecated, set logLevel to debug instead.
+  # If set to true, the logLevel will be set to debug.
   debug: false
 
   # Pass arbitrary additional arguments to vault-csi-provider.


### PR DESCRIPTION
This PR involves updating the CSI log tests to use a new `-log-level` flag.

PR on the CSI provider side: https://github.com/hashicorp/vault-csi-provider/pull/295 