### PR TITLE
Properly handle JSON server config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Unreleased
 
+Bugs:
+
+* Properly handle JSON formatted server config [GH-1049](https://github.com/hashicorp/vault-helm/pull/1049)
+
 ## 0.28.1 (July 11, 2024)
 
 Changes:

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -1090,11 +1090,11 @@ config file from values
 {{- end -}}
 {{- $type := typeOf $config -}}
 {{- if eq $type "string" -}}
-{{/* Vault supports both HCL and JSON as its conifugration format */}}
+{{/* Vault supports both HCL and JSON as its configuration format */}}
 {{- $json := $config | fromJson -}}
 {{/*
 Helm's fromJson does not behave according to the corresponding sprig function nor Helm docs,
-which claim that it should return empty string on invalid JSON, it atually returns
+which claim that it should return empty string on invalid JSON, it actually returns
 a map containing a single 'Error' element.
 https://github.com/helm/helm/blob/50c22ed7f953fadb32755e5881ba95a92da852b2/pkg/engine/funcs.go#L158
  */}}

--- a/values.schema.json
+++ b/values.schema.json
@@ -664,7 +664,7 @@
                         }
                     }
                 },
-                "configAnnotation": {
+                "includeConfigAnnotation": {
                     "type": "boolean"
                 },
                 "dataStorage": {

--- a/values.yaml
+++ b/values.yaml
@@ -673,7 +673,7 @@ server:
   # This can be used together with an OnDelete deployment strategy to help
   # identify which pods still need to be deleted during a deployment to pick up
   # any configuration changes.
-  configAnnotation: false
+  includeConfigAnnotation: false
 
   # Enables a headless service to be used by the Vault Statefulset
   service:
@@ -829,13 +829,13 @@ server:
     # config is a raw string of default configuration when using a Stateful
     # deployment. Default is to use a PersistentVolumeClaim mounted at /vault/data
     # and store data there. This is only used when using a Replica count of 1, and
-    # using a stateful set. This should be HCL.
+    # using a stateful set. Supported formats are HCL and JSON.
 
     # Note: Configuration files are stored in ConfigMaps so sensitive data
     # such as passwords should be either mounted through extraSecretEnvironmentVars
-    # or through a Kube secret.  For more information see:
+    # or through a Kube secret. For more information see:
     # https://developer.hashicorp.com/vault/docs/platform/k8s/helm/run#protecting-sensitive-vault-configurations
-    config: |
+    config: |-
       ui = true
 
       listener "tcp" {
@@ -901,6 +901,7 @@ server:
       # such as passwords should be either mounted through extraSecretEnvironmentVars
       # or through a Kube secret.  For more information see:
       # https://developer.hashicorp.com/vault/docs/platform/k8s/helm/run#protecting-sensitive-vault-configurations
+      # Supported formats are HCL and JSON.
       config: |
         ui = true
 
@@ -922,11 +923,11 @@ server:
 
     # config is a raw string of default configuration when using a Stateful
     # deployment. Default is to use a Consul for its HA storage backend.
-    # This should be HCL.
+    # Supported formats are HCL and JSON.
 
     # Note: Configuration files are stored in ConfigMaps so sensitive data
     # such as passwords should be either mounted through extraSecretEnvironmentVars
-    # or through a Kube secret.  For more information see:
+    # or through a Kube secret. For more information see:
     # https://developer.hashicorp.com/vault/docs/platform/k8s/helm/run#protecting-sensitive-vault-configurations
     config: |
       ui = true


### PR DESCRIPTION
The changes made to generate the server configuration in d186b6ff broke the user's ability to provide extra server configuration as JSON. This PR adds checks to ensure that the extra server configuration can be specified as JSON.

The same change mentioned above introduced support for setting the extra server configuration from a YAML structure, unfortunately Helm is not able to properly render the value given the defaults found in `values.yaml`. This PR enforces that config value must be a string.