### PR TITLE
Add podManagementPolicy values option to server StatefulSet

### DIFF
--- a/templates/server-statefulset.yaml
+++ b/templates/server-statefulset.yaml
@@ -20,7 +20,7 @@ metadata:
   {{- template "vault.statefulSet.annotations" . }}
 spec:
   serviceName: {{ template "vault.fullname" . }}-internal
-  podManagementPolicy: Parallel
+  podManagementPolicy: {{ .Values.server.podManagementPolicy }}
   replicas: {{ template "vault.replicas" . }}
   updateStrategy:
     type: {{ .Values.server.updateStrategyType }}

--- a/values.schema.json
+++ b/values.schema.json
@@ -962,6 +962,9 @@
                         }
                     }
                 },
+                "podManagementPolicy": {
+                    "type": "string"
+                },
                 "postStart": {
                     "type": "array"
                 },

--- a/values.yaml
+++ b/values.yaml
@@ -381,6 +381,10 @@ server:
     # Overrides the default Image Pull Policy
     pullPolicy: IfNotPresent
 
+  # Configure the Pod Management Policy for the StatefulSet
+  # See https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#pod-management-policies
+  podManagementPolicy: "Parallel"
+
   # Configure the Update Strategy Type for the StatefulSet
   # See https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#update-strategies
   updateStrategyType: "OnDelete"


### PR DESCRIPTION
As Vault usage has increased in our production environment, we've observed that during Vault rollouts, the Vault service and UI intermittently return "Service Unavailable" error. This disruption occurs because all Vault server pods are being recreated in parallel, leading to temporary unavailability.

By adding the podManagementPolicy configuration option, we can set it to OrderedReady. This policy ensures that pods are recreated in a controlled, sequential manner (one at a time), which should mitigate the service disruption during rollouts.