### PR TITLE
fix extraconfig-from-values.hcl condition mismatch

### DIFF
--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -183,7 +183,7 @@ defined a custom configuration.  Additionally iterates over any
 extra volumes the user may have specified (such as a secret with TLS).
 */}}
 {{- define "vault.volumes" -}}
-  {{- if and (ne .mode "dev") (or (.Values.server.standalone.config) (.Values.server.ha.config) (.Values.server.ha.raft.config)) }}
+  {{- if and (ne .mode "dev") (ne .mode "external") (.serverEnabled) (or (.Values.server.standalone.config) (.Values.server.ha.config) (.Values.server.ha.raft.config)) }}
         - name: config
           configMap:
             name: {{ template "vault.fullname" . }}-config
@@ -215,7 +215,7 @@ file with IP addresses to make the out of box experience easier
 for users looking to use this chart with Consul Helm.
 */}}
 {{- define "vault.args" -}}
-  {{ if or (eq .mode "standalone") (eq .mode "ha") }}
+  {{ if and (ne .mode "dev") (ne .mode "external") (.serverEnabled) (or (.Values.server.standalone.config) (.Values.server.ha.config) (.Values.server.ha.raft.config)) }}
           - |
             cp /vault/config/extraconfig-from-values.hcl /tmp/storageconfig.hcl;
             [ -n "${HOST_IP}" ] && sed -Ei "s|HOST_IP|${HOST_IP?}|g" /tmp/storageconfig.hcl;

--- a/templates/server-config-configmap.yaml
+++ b/templates/server-config-configmap.yaml
@@ -4,10 +4,7 @@ SPDX-License-Identifier: MPL-2.0
 */}}
 
 {{ template "vault.mode" . }}
-{{- if ne .mode "external" }}
-{{- if .serverEnabled -}}
-{{- if ne .mode "dev" -}}
-{{ if or (.Values.server.standalone.config) (.Values.server.ha.config) -}}
+{{- if and (ne .mode "dev") (ne .mode "external") (.serverEnabled) (or (.Values.server.standalone.config) (.Values.server.ha.config) (.Values.server.ha.raft.config)) }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -25,7 +22,4 @@ metadata:
 data:
   extraconfig-from-values.hcl: |-
     {{ template "vault.config" . }}
-{{- end }}
-{{- end }}
-{{- end }}
 {{- end }}


### PR DESCRIPTION
when setting the following values it's possible to disable the extraconfigs, which was my goal. But the conditions are mismatched and the cp command from `vault.args` fails on container start.

```
vault:
  server:
    standalone:
      config: ""
    ha:
      config: ""
      raft:
        config: ""
```
