### PR TITLE
Added Kubernetes-Recommended Version Label to Workloads

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -3,7 +3,7 @@
 
 apiVersion: v2
 name: vault
-version: 0.28.1
+version: 0.28.2
 appVersion: 1.17.2
 kubeVersion: ">= 1.20.0-0"
 description: Official HashiCorp Vault Chart

--- a/templates/csi-daemonset.yaml
+++ b/templates/csi-daemonset.yaml
@@ -14,6 +14,7 @@ metadata:
     app.kubernetes.io/name: {{ include "vault.name" . }}-csi-provider
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion }}
     {{- if  .Values.csi.daemonSet.extraLabels -}}
       {{- toYaml .Values.csi.daemonSet.extraLabels | nindent 4 -}}
     {{- end -}}
@@ -34,6 +35,7 @@ spec:
       labels:
         app.kubernetes.io/name: {{ template "vault.name" . }}-csi-provider
         app.kubernetes.io/instance: {{ .Release.Name }}
+        app.kubernetes.io/version: {{ .Chart.AppVersion }}
         {{- if  .Values.csi.pod.extraLabels -}}
           {{- toYaml .Values.csi.pod.extraLabels | nindent 8 -}}
         {{- end -}}

--- a/templates/injector-deployment.yaml
+++ b/templates/injector-deployment.yaml
@@ -21,6 +21,7 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/name: {{ template "vault.name" . }}-agent-injector
+      app.kubernetes.io/version: {{ .Chart.AppVersion }}
       app.kubernetes.io/instance: {{ .Release.Name }}
       component: webhook
   {{ template "injector.strategy" . }}
@@ -29,6 +30,7 @@ spec:
       labels:
         app.kubernetes.io/name: {{ template "vault.name" . }}-agent-injector
         app.kubernetes.io/instance: {{ .Release.Name }}
+        app.kubernetes.io/version: {{ .Chart.AppVersion }}
         component: webhook
         {{- if  .Values.injector.extraLabels -}}
           {{- toYaml .Values.injector.extraLabels | nindent 8 -}}

--- a/templates/server-statefulset.yaml
+++ b/templates/server-statefulset.yaml
@@ -17,6 +17,7 @@ metadata:
     app.kubernetes.io/name: {{ include "vault.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion }}
   {{- template "vault.statefulSet.annotations" . }}
 spec:
   serviceName: {{ template "vault.fullname" . }}-internal
@@ -38,6 +39,7 @@ spec:
         helm.sh/chart: {{ template "vault.chart" . }}
         app.kubernetes.io/name: {{ template "vault.name" . }}
         app.kubernetes.io/instance: {{ .Release.Name }}
+        app.kubernetes.io/version: {{ .Chart.AppVersion }}
         component: server
         {{- if  .Values.server.extraLabels -}}
           {{- toYaml .Values.server.extraLabels | nindent 8 -}}


### PR DESCRIPTION
This PR adds the Kubernetes-recommended label "app.kubernetes.io/version" to the any workloads and their Pods.
https://kubernetes.io/docs/concepts/overview/working-with-objects/common-labels/#labels

The value of the version label:

> The current version of the application (e.g., a [SemVer 1.0](https://semver.org/spec/v1.0.0.html), revision hash, etc.)