### PR TITLE
Preparing release v0.29.0

### DIFF
--- a/.github/workflows/acceptance.yaml
+++ b/.github/workflows/acceptance.yaml
@@ -6,11 +6,10 @@ jobs:
       fail-fast: false
       matrix:
         kind-k8s-version:
-          - 1.30.0
-          - 1.29.4
-          - 1.28.9
-          - 1.27.13
-          - 1.26.15
+          - 1.31.1
+          - 1.30.4
+          - 1.29.8
+          - 1.28.13
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -21,7 +20,7 @@ jobs:
         with:
           config: test/kind/config.yaml
           node_image: kindest/node:v${{ matrix.kind-k8s-version }}
-          version: v0.23.0
+          version: v0.24.0
       - run: bats --tap --timing ./test/acceptance
         env:
           VAULT_LICENSE_CI: ${{ secrets.VAULT_LICENSE_CI }}

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -17,7 +17,7 @@ jobs:
         uses: ./.github/actions/setup-test-tools
       - uses: actions/setup-go@41dfa10bad2bb2ae585af6ee5bb4d7d973ad74ed # v5.1.0
         with:
-          go-version: '1.22.5'
+          go-version: '1.22.8'
       - run: go install "github.com/redhat-certification/chart-verifier@${CHART_VERIFIER_VERSION}"
       - run: bats --tap --timing ./test/chart
 permissions:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -10,7 +10,7 @@ jobs:
   chart-verifier:
     runs-on: ubuntu-latest
     env:
-      CHART_VERIFIER_VERSION: '1.13.4'
+      CHART_VERIFIER_VERSION: '1.13.8'
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Setup test tools

--- a/.helmignore
+++ b/.helmignore
@@ -26,3 +26,4 @@
 .github/
 .gitlab-ci.yml
 test/
+scratch/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Unreleased
 
-## 0.29.0 (November 6, 2024)
+## 0.29.0 (November 7, 2024)
 
 Changes:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,13 @@
 ## Unreleased
 
+## 0.29.0 (November 6, 2024)
+
 Changes:
 
-* Default `vault` version updated to 1.17.3
+* Default `vault` version updated to 1.18.1
+* Default `vault-k8s` version updated to 1.5.0
 * Default `vault-csi-provider` version updated to 1.5.0
+* Tested with Kubernetes versions 1.28-1.31
 
 Features:
 

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -3,8 +3,8 @@
 
 apiVersion: v2
 name: vault
-version: 0.28.1
-appVersion: 1.17.2
+version: 0.29.0
+appVersion: 1.18.1
 kubeVersion: ">= 1.20.0-0"
 description: Official HashiCorp Vault Chart
 home: https://www.vaultproject.io

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ LOCAL_ACCEPTANCE_TESTS?=false
 KIND_CLUSTER_NAME?=vault-helm
 
 # kind k8s version
-KIND_K8S_VERSION?=v1.30.0
+KIND_K8S_VERSION?=v1.31.1
 
 # Generate json schema for chart values. See test/README.md for more details.
 values-schema:

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ this README. Please refer to the Kubernetes and Helm documentation.
 The versions required are:
 
   * **Helm 3.6+**
-  * **Kubernetes 1.26+** - This is the earliest version of Kubernetes tested.
+  * **Kubernetes 1.28+** - This is the earliest version of Kubernetes tested.
     It is possible that this chart works with earlier versions but it is
     untested.
 

--- a/test/chart/verifier.bats
+++ b/test/chart/verifier.bats
@@ -6,9 +6,9 @@ setup_file() {
     cd `chart_dir`
     export VERIFY_OUTPUT="/$BATS_RUN_TMPDIR/verify.json"
     export CHART_VOLUME=vault-helm-chart-src
-    local IMAGE="quay.io/redhat-certification/chart-verifier:1.10.1"
+    local IMAGE="quay.io/redhat-certification/chart-verifier:1.13.8"
     # chart-verifier requires an openshift version if a cluster isn't available
-    local OPENSHIFT_VERSION="4.12"
+    local OPENSHIFT_VERSION="4.17"
     local DISABLED_TESTS="chart-testing"
 
     local run_cmd="chart-verifier"

--- a/values.openshift.yaml
+++ b/values.openshift.yaml
@@ -9,16 +9,16 @@ global:
 injector:
   image:
     repository: "registry.connect.redhat.com/hashicorp/vault-k8s"
-    tag: "1.4.2-ubi"
+    tag: "1.5.0-ubi"
 
   agentImage:
     repository: "registry.connect.redhat.com/hashicorp/vault"
-    tag: "1.17.2-ubi"
+    tag: "1.18.1-ubi"
 
 server:
   image:
     repository: "registry.connect.redhat.com/hashicorp/vault"
-    tag: "1.17.2-ubi"
+    tag: "1.18.1-ubi"
 
   readinessProbe:
     path: "/v1/sys/health?uninitcode=204"

--- a/values.schema.json
+++ b/values.schema.json
@@ -139,6 +139,9 @@
                         }
                     }
                 },
+                "logLevel": {
+                    "type": "string"
+                },
                 "pod": {
                     "type": "object",
                     "properties": {
@@ -667,9 +670,6 @@
                         }
                     }
                 },
-                "includeConfigAnnotation": {
-                    "type": "boolean"
-                },
                 "dataStorage": {
                     "type": "object",
                     "properties": {
@@ -848,6 +848,9 @@
                             "type": "string"
                         }
                     }
+                },
+                "includeConfigAnnotation": {
+                    "type": "boolean"
                 },
                 "ingress": {
                     "type": "object",

--- a/values.yaml
+++ b/values.yaml
@@ -68,7 +68,7 @@ injector:
   # image sets the repo and tag of the vault-k8s image to use for the injector.
   image:
     repository: "hashicorp/vault-k8s"
-    tag: "1.4.2"
+    tag: "1.5.0"
     pullPolicy: IfNotPresent
 
   # agentImage sets the repo and tag of the Vault image to use for the Vault Agent
@@ -76,7 +76,7 @@ injector:
   # required.
   agentImage:
     repository: "hashicorp/vault"
-    tag: "1.17.3"
+    tag: "1.18.1"
 
   # The default values for the injected Vault Agent containers.
   agentDefaults:
@@ -377,7 +377,7 @@ server:
 
   image:
     repository: "hashicorp/vault"
-    tag: "1.17.2"
+    tag: "1.18.1"
     # Overrides the default Image Pull Policy
     pullPolicy: IfNotPresent
 
@@ -1177,7 +1177,7 @@ csi:
 
     image:
       repository: "hashicorp/vault"
-      tag: "1.17.2"
+      tag: "1.18.1"
       pullPolicy: IfNotPresent
 
     logFormat: standard


### PR DESCRIPTION
Update image defaults, k8s versions, and changelog

---

## 0.29.0 (November 7, 2024)

Changes:

* Default `vault` version updated to 1.18.1
* Default `vault-k8s` version updated to 1.5.0
* Default `vault-csi-provider` version updated to 1.5.0
* Tested with Kubernetes versions 1.28-1.31

Features:

* csi: Allow modification of the hostNetwork parameter on the DaemonSet [GH-1046](https://github.com/hashicorp/vault-helm/pull/1046)

Bugs:

* Properly handle JSON formatted server config [GH-1049](https://github.com/hashicorp/vault-helm/pull/1049)

---
(Previous release PR for comparison: https://github.com/hashicorp/vault-helm/pull/1036)

Associated docs update: https://github.com/hashicorp/vault/pull/28851

<!-- VAULT-31629 since this updates k8s CI versions -->