### PR TITLE
server: fix config templating

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 ## Unreleased
 
+Bugs:
+* server: restore support for templated config [GH-1073](https://github.com/hashicorp/vault-helm/pull/1073)
+
 ## 0.29.0 (November 7, 2024)
+
+KNOWN ISSUES:
+* Template support in server config stopped working [GH-1072](https://github.com/hashicorp/vault-helm/issues/1072)
 
 Changes:
 

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -1091,7 +1091,7 @@ config file from values
 {{- $type := typeOf $config -}}
 {{- if eq $type "string" -}}
 {{/* Vault supports both HCL and JSON as its configuration format */}}
-{{- $json := $config | fromJson -}}
+{{- $json := tpl $config . | fromJson -}}
 {{/*
 Helm's fromJson does not behave according to the corresponding sprig function nor Helm docs,
 which claim that it should return empty string on invalid JSON, it actually returns
@@ -1109,6 +1109,6 @@ https://github.com/helm/helm/blob/50c22ed7f953fadb32755e5881ba95a92da852b2/pkg/e
 {{- else }}
 {{- fail "structured server config is not supported, value must be a string"}}
 {{- end }}
-{{- $config | nindent 4 | trim }}
+{{- tpl $config . | nindent 4 | trim }}
 {{- end -}}
 {{- end -}}

--- a/test/unit/server-configmap.bats
+++ b/test/unit/server-configmap.bats
@@ -136,10 +136,11 @@ load _helpers
       --set 'server.standalone.config=\{\"hello\": \"world\"\}' \
       . | tee /dev/stderr |
       yq '.data')
-  [ "$(echo "${data}" | \
-    yq '(. | length) == 1')" = "true" ]
-  [ "$(echo "${data}" | \
-    yq '."extraconfig-from-values.hcl" == "{\"disable_mlock\":true,\"hello\":\"world\"}"')" = 'true' ]
+  local checkLength=$(echo "${data}" | yq '(. | length) == 1')
+  [ "${checkLength}" = "true" ]
+  local checkExtraConfig=$(echo "${data}" | \
+    yq '."extraconfig-from-values.hcl" == "{\"disable_mlock\":true,\"hello\":\"world\"}"')
+  [ "${checkExtraConfig}" = 'true' ]
 
   data=$(helm template \
       --show-only templates/server-config-configmap.yaml  \
@@ -147,10 +148,11 @@ load _helpers
       --set 'server.standalone.config=\{\"foo\": \"bar\"\}' \
       . | tee /dev/stderr |
       yq '.data' | tee /dev/stderr)
-  [ "$(echo "${data}" | \
-    yq '(. | length) == 1')" = "true" ]
-  [ "$(echo "${data}" | \
-    yq '."extraconfig-from-values.hcl" == "{\"disable_mlock\":true,\"foo\":\"bar\"}"')" = 'true' ]
+  checkLength=$(echo "${data}" | yq '(. | length) == 1')
+  [ "${checkLength}" = "true" ]
+  checkExtraConfig=$(echo "${data}" | \
+    yq '."extraconfig-from-values.hcl" == "{\"disable_mlock\":true,\"foo\":\"bar\"}"')
+  [ "${checkExtraConfig}" = 'true' ]
 
   data=$(helm template \
       --show-only templates/server-config-configmap.yaml  \
@@ -158,10 +160,11 @@ load _helpers
       --set 'server.standalone.config=\{\"disable_mlock\": false\,\"foo\":\"bar\"\}' \
       . | tee /dev/stderr |
       yq '.data' | tee /dev/stderr)
-  [ "$(echo "${data}" | \
-    yq '(. | length) == 1')" = "true" ]
-  [ "$(echo "${data}" | \
-    yq '."extraconfig-from-values.hcl" == "{\"disable_mlock\":false,\"foo\":\"bar\"}"')" = 'true' ]
+  checkLength=$(echo "${data}" | yq '(. | length) == 1')
+  [ "${checkLength}" = "true" ]
+  checkExtraConfig=$(echo "${data}" | \
+    yq '."extraconfig-from-values.hcl" == "{\"disable_mlock\":false,\"foo\":\"bar\"}"')
+  [ "${checkExtraConfig}" = 'true' ]
 }
 
 @test "server/ConfigMap: standalone extraConfig is set as not JSON" {
@@ -202,10 +205,11 @@ load _helpers
       --set 'server.ha.config=\{\"hello\": \"ha-world\"\}' \
       . | tee /dev/stderr |
       yq '.data' | tee /dev/stderr)
-  [ "$(echo "${data}" | \
-    yq '(. | length) == 1')" = "true" ]
-  [ "$(echo "${data}" | \
-    yq '."extraconfig-from-values.hcl" == "{\"disable_mlock\":true,\"hello\":\"ha-world\"}"')" = 'true' ]
+  local checkLength=$(echo "${data}" | yq '(. | length) == 1')
+  [ "${checkLength}" = "true" ]
+  local checkExtraConfig=$(echo "${data}" | \
+    yq '."extraconfig-from-values.hcl" == "{\"disable_mlock\":true,\"hello\":\"ha-world\"}"')
+  [ "$checkExtraConfig" = 'true' ]
 
  data=$(helm template \
       --show-only templates/server-config-configmap.yaml  \
@@ -213,10 +217,11 @@ load _helpers
       --set 'server.ha.config=\{\"foo\": \"bar\"\,\"disable_mlock\":false\}' \
       . | tee /dev/stderr |
       yq '.data' | tee /dev/stderr)
-  [ "$(echo "${data}" | \
-    yq '(. | length) == 1')" = "true" ]
-  [ "$(echo "${data}" | \
-    yq '."extraconfig-from-values.hcl" == "{\"disable_mlock\":false,\"foo\":\"bar\"}"')" = 'true' ]
+  checkLength=$(echo "${data}" | yq '(. | length) == 1')
+  [ "$checkLength" = "true" ]
+  checkExtraConfig=$(echo "${data}" | \
+    yq '."extraconfig-from-values.hcl" == "{\"disable_mlock\":false,\"foo\":\"bar\"}"')
+  [ "${checkExtraConfig}" = 'true' ]
 }
 
 @test "server/ConfigMap: disabled by injector.externalVaultAddr" {


### PR DESCRIPTION
Adds support back for templating the server config (inadvertently removed in #1049).

Fixes #1072 