### PR TITLE
ci: latest five k8s versions

### DIFF
--- a/.github/workflows/acceptance.yaml
+++ b/.github/workflows/acceptance.yaml
@@ -6,10 +6,11 @@ jobs:
       fail-fast: false
       matrix:
         kind-k8s-version:
-          - 1.31.1
-          - 1.30.4
-          - 1.29.8
-          - 1.28.13
+          - 1.31.2
+          - 1.30.6
+          - 1.29.10
+          - 1.28.15
+          - 1.27.16
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -20,7 +21,7 @@ jobs:
         with:
           config: test/kind/config.yaml
           node_image: kindest/node:v${{ matrix.kind-k8s-version }}
-          version: v0.24.0
+          version: v0.25.0
       - run: bats --tap --timing ./test/acceptance
         env:
           VAULT_LICENSE_CI: ${{ secrets.VAULT_LICENSE_CI }}

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -17,7 +17,7 @@ jobs:
         uses: ./.github/actions/setup-test-tools
       - uses: actions/setup-go@41dfa10bad2bb2ae585af6ee5bb4d7d973ad74ed # v5.1.0
         with:
-          go-version: '1.22.8'
+          go-version: '1.22.9'
       - run: go install "github.com/redhat-certification/chart-verifier@${CHART_VERIFIER_VERSION}"
       - run: bats --tap --timing ./test/chart
 permissions:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ Changes:
 * Default `vault` version updated to 1.18.1
 * Default `vault-k8s` version updated to 1.5.0
 * Default `vault-csi-provider` version updated to 1.5.0
-* Tested with Kubernetes versions 1.28-1.31
+* Tested with Kubernetes versions 1.27-1.31
 
 Features:
 


### PR DESCRIPTION
Use the latest five k8s versions to match the other k8s projects, and updating the kind version and go for tests.

<!-- VAULT-32492 -->