### PR TITLE
Preparing release v0.29.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+## 0.29.1 (November 20, 2024)
+
 Bugs:
 * server: restore support for templated config [GH-1073](https://github.com/hashicorp/vault-helm/pull/1073)
 


### PR DESCRIPTION
## 0.29.1 (November 20, 2024)

Bugs:
* server: restore support for templated config [GH-1073](https://github.com/hashicorp/vault-helm/pull/1073)

---

(Previous release PR for comparison: https://github.com/hashicorp/vault-helm/pull/1071)

<!-- VAULT-32492 -->