### PR TITLE
set default vault-k8s to v1.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Unreleased
 
+Changes:
+
+* Default `vault-k8s` version updated to 1.6.1
+
 ## 0.29.1 (November 20, 2024)
 
 Bugs:

--- a/values.openshift.yaml
+++ b/values.openshift.yaml
@@ -9,7 +9,7 @@ global:
 injector:
   image:
     repository: "registry.connect.redhat.com/hashicorp/vault-k8s"
-    tag: "1.5.0-ubi"
+    tag: "1.6.1-ubi"
 
   agentImage:
     repository: "registry.connect.redhat.com/hashicorp/vault"

--- a/values.yaml
+++ b/values.yaml
@@ -68,7 +68,7 @@ injector:
   # image sets the repo and tag of the vault-k8s image to use for the injector.
   image:
     repository: "hashicorp/vault-k8s"
-    tag: "1.5.0"
+    tag: "1.6.1"
     pullPolicy: IfNotPresent
 
   # agentImage sets the repo and tag of the Vault image to use for the Vault Agent


### PR DESCRIPTION
Default `vault-k8s` version updated to [1.6.1](https://github.com/hashicorp/vault-k8s/releases/tag/v1.6.1)