### PR TITLE
Add ability to disable k8s service links

### DIFF
--- a/templates/server-statefulset.yaml
+++ b/templates/server-statefulset.yaml
@@ -59,6 +59,7 @@ spec:
       {{- template "server.statefulSet.securityContext.pod" . }}
       {{- if not .Values.global.openshift }}
       hostNetwork: {{ .Values.server.hostNetwork }}
+      enableServiceLinks: {{ .Values.server.enableServiceLinks }}
       {{- end }}
       volumes:
         {{ template "vault.volumes" . }}

--- a/test/unit/server-statefulset.bats
+++ b/test/unit/server-statefulset.bats
@@ -1957,6 +1957,28 @@ load _helpers
 }
 
 #--------------------------------------------------------------------
+# enableServiceLinks
+
+@test "server/StatefulSet: server.enableServiceLinks not set" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/server-statefulset.yaml \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.enableServiceLinks' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}
+
+@test "server/StatefulSet: server.enableServiceLinks is set" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/server-statefulset.yaml \
+      --set 'server.enableServiceLinks=false' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.enableServiceLinks' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+}
+
+#--------------------------------------------------------------------
 # hostAliases
 
 @test "server/StatefulSet: server.hostAliases not set" {

--- a/values.yaml
+++ b/values.yaml
@@ -1026,6 +1026,10 @@ server:
   # Should the server pods run on the host network
   hostNetwork: false
 
+  # Should the server pods export all k8s services via
+  # environment variables
+  enableServiceLinks: true
+
 # Vault UI
 ui:
   # True if you want to create a Service entry for the Vault UI.


### PR DESCRIPTION
Hey everyone, we'd love to add this feature to the Helm chart. By default Kubernetes will inject all services via environment variables to a pod. While this normally is no big issue, Vault prints all environment names of variables on startup, causing a huge block in the logs that makes it hard to read.

By setting `enableServiceLinks` to false, this behavior can be stopped.