### PR TITLE
Add extraPorts to the server's Service resource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Unreleased
 
+Features:
+* server: New `extraPorts` option for adding ports to the Vault's server Service.
+
 ## 0.29.1 (November 20, 2024)
 
 Bugs:

--- a/templates/server-service.yaml
+++ b/templates/server-service.yaml
@@ -49,6 +49,9 @@ spec:
     - name: https-internal
       port: 8201
       targetPort: 8201
+  {{- if .Values.server.service.extraPorts -}}
+  {{ toYaml .Values.server.service.extraPorts | nindent 4}}
+  {{- end }}
   selector:
     app.kubernetes.io/name: {{ include "vault.name" . }}
     {{- if eq (.Values.server.service.instanceSelector.enabled | toString) "true" }}

--- a/test/unit/server-service.bats
+++ b/test/unit/server-service.bats
@@ -509,3 +509,28 @@ load _helpers
       yq -r '.spec.ipFamilies' | tee /dev/stderr)
   [ "${actual}" = "null" ]
 }
+
+@test "server/Service: adds extra ports" {
+  cd `chart_dir`
+
+  # Test that it defines it
+  local object=$(helm template \
+      --show-only templates/server-service.yaml  \
+      --set 'server.service.extraPorts[0].name=foo' \
+      --set 'server.service.extraPorts[0].port=1111' \
+      --set 'server.service.extraPorts[0].targetPort=2222' \
+      . | tee /dev/stderr |
+      yq -r '.spec.ports[2] | select(.name == "foo")' | tee /dev/stderr)
+
+  local actual=$(echo $object |
+      yq -r '.name' | tee /dev/stderr)
+  [ "${actual}" = "foo" ]
+
+  local actual=$(echo $object |
+      yq -r '.port' | tee /dev/stderr)
+  [ "${actual}" = "1111" ]
+
+  local actual=$(echo $object |
+      yq -r '.targetPort' | tee /dev/stderr)
+  [ "${actual}" = "2222" ]
+}

--- a/values.schema.json
+++ b/values.schema.json
@@ -1106,6 +1106,12 @@
                         },
                         "targetPort": {
                             "type": "integer"
+                        },
+                        "extraPorts": {
+                            "type": [
+                                "null",
+                                "array"
+                            ]
                         }
                     }
                 },

--- a/values.yaml
+++ b/values.yaml
@@ -760,6 +760,13 @@ server:
     # to the service.
     annotations: {}
 
+    # extraPorts is a list of extra ports. Specified as a YAML list.
+    # Useful if you host additional services inside your Vault pod(s).
+    extraPorts: null
+      # - name: extra
+      #   port: 9000
+      #   targetPort: 9000
+
   # This configures the Vault Statefulset to create a PVC for data
   # storage when using the file or raft backend storage engines.
   # See https://developer.hashicorp.com/vault/docs/configuration/storage to know more


### PR DESCRIPTION
## Overview

This change allows one to specify additional ports in the `Service` resource created for the Vault pod(s).

The rationale is that, in our use case, we inject pods into certain kinds of workloads that in turn alter their traffic routine. As a result, the initial assumptions about networking no longer hold, and extra ports are necessary.

Based on [a similar PR](https://github.com/hashicorp/vault-helm/pull/841) that added the same to the corresponding `StatefulSet`.

## Testing

I added a new test and verified that my change works correctly, both via `bats` as well as on my own deployments.