### PR TITLE
fix: add pod labels to the server-test.yaml

### DIFF
--- a/templates/tests/server-test.yaml
+++ b/templates/tests/server-test.yaml
@@ -13,10 +13,10 @@ metadata:
   namespace: {{ include "vault.namespace" . }}
   annotations:
     "helm.sh/hook": test
+  {{- with .Values.server.extraLabels }}
   labels: 
-    {{- if  .Values.server.extraLabels -}}
-      {{- toYaml .Values.server.extraLabels | nindent 8 -}}
-    {{- end -}}   
+    {{- toYaml . | nindent 4 }}
+  {{- end }}    
 spec:
   {{- include "imagePullSecrets" . | nindent 2 }}
   containers:

--- a/templates/tests/server-test.yaml
+++ b/templates/tests/server-test.yaml
@@ -14,9 +14,9 @@ metadata:
   annotations:
     "helm.sh/hook": test
   {{- with .Values.server.extraLabels }}
-  labels: 
+  labels:
     {{- toYaml . | nindent 4 }}
-  {{- end }}    
+  {{- end }}
 spec:
   {{- include "imagePullSecrets" . | nindent 2 }}
   containers:

--- a/templates/tests/server-test.yaml
+++ b/templates/tests/server-test.yaml
@@ -13,6 +13,10 @@ metadata:
   namespace: {{ include "vault.namespace" . }}
   annotations:
     "helm.sh/hook": test
+  labels: 
+    {{- if  .Values.server.extraLabels -}}
+      {{- toYaml .Values.server.extraLabels | nindent 8 -}}
+    {{- end -}}   
 spec:
   {{- include "imagePullSecrets" . | nindent 2 }}
   containers:

--- a/test/unit/server-test.bats
+++ b/test/unit/server-test.bats
@@ -277,3 +277,27 @@ load _helpers
       yq -r 'map(select(.name=="FOOBAR")) | .[] .value' | tee /dev/stderr)
   [ "${name}" = "foobar" ]
 }
+# ----------------------------------------------------------------------
+# extraLabels
+
+@test "server/standalone=server-test-Pod: specify extraLabels" {
+  cd `chart_dir`
+
+  local actual=$(helm template \
+      --show-only templates/tests/server-test.yaml  \
+      --set 'server.extraLabels.foo=bar' \
+      . | tee /dev/stderr |
+      yq -r '.metadata.labels.foo' | tee /dev/stderr)
+  [ "${actual}" = "bar" ]
+}
+
+@test "server/standalone=server-test-Pod: no extraLabels set" {
+  cd `chart_dir`
+
+  local actual=$(helm template \
+      --show-only templates/tests/server-test.yaml  \
+      . | tee /dev/stderr |
+      yq -r '.metadata.labels // "null"' | tee /dev/stderr)
+
+  [ "${actual}" = "null" ]
+}

--- a/test/unit/server-test.bats
+++ b/test/unit/server-test.bats
@@ -277,6 +277,7 @@ load _helpers
       yq -r 'map(select(.name=="FOOBAR")) | .[] .value' | tee /dev/stderr)
   [ "${name}" = "foobar" ]
 }
+
 # ----------------------------------------------------------------------
 # extraLabels
 

--- a/test/unit/server-test.bats
+++ b/test/unit/server-test.bats
@@ -288,6 +288,7 @@ load _helpers
       --set 'server.extraLabels.foo=bar' \
       . | tee /dev/stderr |
       yq -r '.metadata.labels.foo' | tee /dev/stderr)
+
   [ "${actual}" = "bar" ]
 }
 


### PR DESCRIPTION
Overview
This change allows one to add labels to the server-test.yaml.

The rationale is that, in our CI pipeline we have a kyverno policy that validates if the required labels are added to the pod manifests. Currently, there is no way to pass extra labels to this template and my change allows to use an existing template to insert pod labels to the server-test pod.

I added unit test to verify the changes 
<img width="1247" alt="image" src="https://github.com/user-attachments/assets/9416bfd4-a6e7-4bcb-82f9-a3ca36aef854" />
