### PR TITLE
Update values.yaml - Move resource documentation to correct section in values.yaml

### DIFF
--- a/values.yaml
+++ b/values.yaml
@@ -371,10 +371,6 @@ server:
     # The key within the Kubernetes secret that holds the enterprise license.
     secretKey: "license"
 
-  # Resource requests, limits, etc. for the server cluster placement. This
-  # should map directly to the value of the resources field for a PodSpec.
-  # By default no direct resource request is made.
-
   image:
     repository: "hashicorp/vault"
     tag: "1.18.1"
@@ -392,7 +388,10 @@ server:
   # Configure the logging format for the Vault server.
   # Supported log formats include: standard, json
   logFormat: ""
-
+  
+  # Resource requests, limits, etc. for the server cluster placement. This
+  # should map directly to the value of the resources field for a PodSpec.
+  # By default no direct resource request is made.
   resources: {}
   # resources:
   #   requests:


### PR DESCRIPTION
This PR moves the comment about resource requests and limits to the correct section in `values.yaml` . Previously, the documentation was misplaced under the `image` section, but it should be next to the `resources`  key to improve clarity. No functional changes were made—only the comment position was adjusted.