### PR TITLE
server: support setting custom preStop commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ Changes:
 * Default `vault-k8s` version updated to 1.6.2
 * Tested with Kubernetes versions 1.28-1.32
 
+Features:
+
+* server: Support setting custom preStop commands [GH-1099](https://github.com/hashicorp/vault-helm/pull/1099)
+
 ## 0.29.1 (November 20, 2024)
 
 Bugs:

--- a/templates/server-statefulset.yaml
+++ b/templates/server-statefulset.yaml
@@ -206,14 +206,22 @@ spec:
             # causes issues with graceful shutdowns such as deregistering itself
             # from Consul (zombie services).
             preStop:
+            {{- if .Values.server.preStop }}
               exec:
-                command: [
-                  "/bin/sh", "-c",
-                  # Adding a sleep here to give the pod eviction a
-                  # chance to propagate, so requests will not be made
-                  # to this pod while it's terminating
-                  "sleep {{ .Values.server.preStopSleepSeconds }} && kill -SIGTERM $(pidof vault)",
-                ]
+                command:
+                {{- range (.Values.server.preStop) }}
+                - {{ . | quote }}
+                {{- end }}
+            {{- else }}
+              exec:
+                command:
+                - "/bin/sh"
+                - "-c"
+                # Adding a sleep here to give the pod eviction a
+                # chance to propagate, so requests will not be made
+                # to this pod while it's terminating
+                - "sleep {{ .Values.server.preStopSleepSeconds }} && kill -SIGTERM $(pidof vault)"
+            {{- end}}
             {{- if .Values.server.postStart }}
             postStart:
               exec:

--- a/values.yaml
+++ b/values.yaml
@@ -554,8 +554,17 @@ server:
   # See: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/
   terminationGracePeriodSeconds: 10
 
-  # Used to set the sleep time during the preStop step
+  # Used to set the sleep time during the preStop step, if custom preStop
+  # commands are not set.
   preStopSleepSeconds: 5
+
+  # Used to define custom preStop exec commands to run before the pod is
+  # terminated. If not set, this will default to:
+  # preStop:
+  #   - "/bin/sh"
+  #   - "-c"
+  #   - "sleep {{ .Values.server.preStopSleepSeconds }} && kill -SIGTERM $(pidof vault)"
+  preStop: []
 
   # Used to define commands to run after the pod is ready.
   # This can be used to automate processes such as initialization


### PR DESCRIPTION
Adds a `server.preStop` option to set custom preStop commands for the Vault server pods.

Fixes #1089 