### PR TITLE
Add delete rights to configmaps for agent-injector

### DIFF
--- a/templates/injector-role.yaml
+++ b/templates/injector-role.yaml
@@ -25,6 +25,10 @@ rules:
       - "list"
       - "update"
   - apiGroups: [""]
+    resources: ["configmaps"]
+    verbs:
+      - "delete"
+  - apiGroups: [""]
     resources: ["pods"]
     verbs:
       - "get"


### PR DESCRIPTION
The agent-injector service account needs delete permissions on configmaps in order to become leader when the leader becomes unresponsive, due to the machine going offline for example:

**Test**
Determine which vault-agent pod is leader and in which datacenter it is running
```
kubectl get pods -n vault -o wide
kubectl logs <vault-agent-injector-pod> -n vault | grep -i "currently the leader"
```
Poweroff the VMs in that datacenter
Result, other vault-agent pod cannot take over leadership, while leader pod is still terminating.
```
[300234@ontw.alfa.local@VDL000010 dev-werner-34]$ k get nodes 
NAME                                            STATUS     ROLES                       AGE    VERSION 
dev-werner-34-dca-default-masters-895bm-2xmrv   NotReady   control-plane,etcd,master   6d3h   v1.30.7+rke2r1 
dev-werner-34-dca-default-workers-jlgtv-m4zgq   NotReady   worker                      6d2h   v1.30.7+rke2r1 
dev-werner-34-dca-default-workers-jlgtv-pwzd8   NotReady   worker                      6d2h   v1.30.7+rke2r1 
dev-werner-34-dcb-default-masters-hshsn-v4jn2   Ready      control-plane,etcd,master   6d2h   v1.30.7+rke2r1 
dev-werner-34-dcb-default-workers-gg77f-tfgqs   Ready      worker                      6d2h   v1.30.7+rke2r1 
dev-werner-34-dcb-default-workers-gg77f-z7ctv   Ready      worker                      6d2h   v1.30.7+rke2r1 
dev-werner-34-dcg-default-masters-52gwd-56xnk   Ready      control-plane,etcd,master   6d2h   v1.30.7+rke2r1 
dev-werner-34-dcg-default-workers-5ft7k-8ljbc   Ready      worker                      6d2h   v1.30.7+rke2r1 

```
```

[300234@ontw.alfa.local@VDL000010 dev-werner-34]$ k get pods -n vault -o wide
NAME                                    READY   STATUS             RESTARTS       AGE    IP              NODE                                            NOMINATED NODE   READINESS GATES
vault-agent-injector-7578459b9d-4n4sj   1/1     Terminating        0              26h    172.21.54.142   dev-werner-34-dca-default-workers-jlgtv-pwzd8   <none>           <none>
vault-agent-injector-7578459b9d-9xchz   0/1     Pending            0              163m   <none>          <none>                                          <none>           <none>
vault-agent-injector-7578459b9d-vw74k   0/1     CrashLoopBackOff   32 (46s ago)   21h    172.21.2.74     dev-werner-34-dcb-default-workers-gg77f-z7ctv   <none>           <none>


```
```
[300234@ontw.alfa.local@VDL000010 dev-werner-34]$ k logs pod/vault-agent-injector-7578459b9d-vw74k
Using internal leader elector logic for webhook certificate management
Listening on ":8080"...
2025-03-04T12:50:49.620Z [INFO]  handler: Starting handler..
2025-03-04T12:50:49.666Z [ERROR] handler: Trouble becoming leader: error="configmaps \"vault-k8s-leader\" is forbidden: User \"system:serviceaccount:vault:vault-agent-injector\" cannot delete resource \"configmaps\" in API group \"\" in the namespace \"vault\""
2025-03-04T12:50:49.720Z [INFO]  handler.certwatcher: Updated certificate bundle received. Updating certs...
2025-03-04T12:50:49.721Z [INFO]  handler.certwatcher: Webhooks changed. Updating certs...
2025-03-04T12:50:49.721Z [INFO]  handler.certwatcher: Webhooks changed. Updating certs...
2025-03-04T12:50:49.721Z [INFO]  handler.certwatcher: Webhooks changed. Updating certs...
2025-03-04T12:50:49.721Z [INFO]  handler.certwatcher: Webhooks changed. Updating certs...
2025-03-04T12:50:49.721Z [INFO]  handler.certwatcher: Webhooks changed. Updating certs...
2025-03-04T12:50:49.721Z [INFO]  handler.certwatcher: Webhooks changed. Updating certs...
2025-03-04T12:50:49.721Z [INFO]  handler.certwatcher: Webhooks changed. Updating certs...
2025-03-04T12:50:49.721Z [INFO]  handler.certwatcher: Webhooks changed. Updating certs...
2025-03-04T12:50:50.164Z [ERROR] handler: Trouble becoming leader: error="configmaps \"vault-k8s-leader\" is forbidden: User \"system:serviceaccount:vault:vault-agent-injector\" cannot delete resource \"configmaps\" in API group \"\" in the namespace \"vault\""
2025-03-04T12:50:51.181Z [ERROR] handler: Trouble becoming leader: error="configmaps \"vault-k8s-leader\" is forbidden: User \"system:serviceaccount:vault:vault-agent-injector\" cannot delete resource \"configmaps\" in API group \"\" in the namespace \"vault\""
2025-03-04T12:50:52.365Z [ERROR] handler: Trouble becoming leader: error="configmaps \"vault-k8s-leader\" is forbidden: User \"system:serviceaccount:vault:vault-agent-injector\" cannot delete resource \"configmaps\" in API group \"\" in the namespace \"vault\""
2025-03-04T12:50:54.814Z [ERROR] handler: Trouble becoming leader: error="configmaps \"vault-k8s-leader\" is forbidden: User \"system:serviceaccount:vault:vault-agent-injector\" cannot delete resource \"configmaps\" in API group \"\" in the namespace \"vault\""
2025-03-04T12:50:56.653Z [ERROR] handler: Trouble becoming leader: error="configmaps \"vault-k8s-leader\" is forbidden: User \"system:serviceaccount:vault:vault-agent-injector\" cannot delete resource \"configmaps\" in API group \"\" in the namespace \"vault\""
2025-03-04T12:51:00.337Z [ERROR] handler: Trouble becoming leader: error="configmaps \"vault-k8s-leader\" is forbidden: User \"system:serviceaccount:vault:vault-agent-injector\" cannot delete resource \"configmaps\" in API group \"\" in the namespace \"vault\""
2025-03-04T12:51:07.031Z [ERROR] handler: Trouble becoming leader: error="configmaps \"vault-k8s-leader\" is forbidden: User \"system:serviceaccount:vault:vault-agent-injector\" cannot delete resource \"configmaps\" in API group \"\" in the namespace \"vault\""
2025-03-04T12:51:14.626Z [ERROR] handler: Trouble becoming leader: error="configmaps \"vault-k8s-leader\" is forbidden: User \"system:serviceaccount:vault:vault-agent-injector\" cannot delete resource \"configmaps\" in API group \"\" in the namespace \"vault\""
2025-03-04T12:51:26.730Z [ERROR] handler: Trouble becoming leader: error="configmaps \"vault-k8s-leader\" is forbidden: User \"system:serviceaccount:vault:vault-agent-injector\" cannot delete resource \"configmaps\" in API group \"\" in the namespace \"vault\""
2025-03-04T12:51:40.794Z [ERROR] handler: Trouble becoming leader: error="configmaps \"vault-k8s-leader\" is forbidden: User \"system:serviceaccount:vault:vault-agent-injector\" cannot delete resource \"configmaps\" in API group \"\" in the namespace \"vault\""
2025-03-04T12:51:40.794Z [ERROR] handler: Shutting down due to error: error="configmaps \"vault-k8s-leader\" is forbidden: User \"system:serviceaccount:vault:vault-agent-injector\" cannot delete resource \"configmaps\" in API group \"\" in the namespace \"vault\""
Error listening: http: Server closed
```
This pull request fixes the issue by explicitly allowing vault-injector to delete the configmap.