### PR TITLE
Preparing release v0.30.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,25 @@
 ## Unreleased
 
+## 0.30.0 (March 27, 2025)
+
 Changes:
 
 * Default `vault` version updated to 1.19.0
 * Default `vault-k8s` version updated to 1.6.2
 * Tested with Kubernetes versions 1.28-1.32
+
+Features:
+
+* server: Support setting custom preStop commands [GH-1099](https://github.com/hashicorp/vault-helm/pull/1099)
+
+Improvements:
+
+* server: Add pod labels to server-test.yaml [GH-1094](https://github.com/hashicorp/vault-helm/pull/1094)
+
+Bugs:
+
+* server: Fix invalid yaml in server test when volumeMounts or volumes are empty [GH-855](https://github.com/hashicorp/vault-helm/pull/855)
+* injector: Add RBAC for deleting configmaps [GH-1100](https://github.com/hashicorp/vault-helm/pull/1100)
 
 ## 0.29.1 (November 20, 2024)
 

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -3,8 +3,8 @@
 
 apiVersion: v2
 name: vault
-version: 0.29.1
-appVersion: 1.18.1
+version: 0.30.0
+appVersion: 1.19.0
 kubeVersion: ">= 1.20.0-0"
 description: Official HashiCorp Vault Chart
 home: https://www.vaultproject.io

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ this README. Please refer to the Kubernetes and Helm documentation.
 The versions required are:
 
   * **Helm 3.6+**
-  * **Kubernetes 1.27+** - This is the earliest version of Kubernetes tested.
+  * **Kubernetes 1.28+** - This is the earliest version of Kubernetes tested.
     It is possible that this chart works with earlier versions but it is
     untested.
 

--- a/test/chart/verifier.bats
+++ b/test/chart/verifier.bats
@@ -6,9 +6,9 @@ setup_file() {
     cd `chart_dir`
     export VERIFY_OUTPUT="/$BATS_RUN_TMPDIR/verify.json"
     export CHART_VOLUME=vault-helm-chart-src
-    local IMAGE="quay.io/redhat-certification/chart-verifier:1.13.8"
+    local IMAGE="quay.io/redhat-certification/chart-verifier:1.13.10"
     # chart-verifier requires an openshift version if a cluster isn't available
-    local OPENSHIFT_VERSION="4.17"
+    local OPENSHIFT_VERSION="4.18"
     local DISABLED_TESTS="chart-testing"
 
     local run_cmd="chart-verifier"

--- a/test/unit/server-test.bats
+++ b/test/unit/server-test.bats
@@ -220,7 +220,7 @@ load _helpers
 @test "server/standalone-server-test-Pod: no server.volumes adds no volumes" {
   cd `chart_dir`
 
-  # Test that it defines it
+  # Test that it is not defined
   local actual=$(helm template \
       --show-only templates/tests/server-test.yaml  \
       . | tee /dev/stderr |
@@ -256,7 +256,7 @@ load _helpers
 @test "server/standalone-server-test-Pod: no server.volumeMounts adds no volumeMounts" {
   cd `chart_dir`
 
-  # Test that it defines it
+  # Test that it is not defined
   local actual=$(helm template \
       --show-only templates/tests/server-test.yaml  \
       . | tee /dev/stderr |


### PR DESCRIPTION
### Changes

* Default `vault` version updated to 1.19.0
* Default `vault-k8s` version updated to 1.6.2
* Tested with Kubernetes versions 1.28-1.32

### Features

* server: Support setting custom preStop commands [GH-1099](https://github.com/hashicorp/vault-helm/pull/1099)

### Improvements

* server: Add pod labels to server-test.yaml [GH-1094](https://github.com/hashicorp/vault-helm/pull/1094)

### Bugs

* server: Fix invalid yaml in server test when volumeMounts or volumes are empty [GH-855](https://github.com/hashicorp/vault-helm/pull/855)
* injector: Add RBAC for deleting configmaps [GH-1100](https://github.com/hashicorp/vault-helm/pull/1100)