### PR TITLE
support custom exec command in server readiness probe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Features:
 
 * server: Add Vault Enterprise redundancy zones support (requires Kubernetes 1.35+)
 
+Improvements:
+
+* Support custom exec command in the server readiness probe [GH-1106](https://github.com/hashicorp/vault-helm/pull/1106)
+
 ## 0.32.0 (January 14, 2026)
 
 Changes:

--- a/templates/server-statefulset.yaml
+++ b/templates/server-statefulset.yaml
@@ -179,7 +179,11 @@ spec:
             #   1 - error
             #   2 - sealed
             exec:
+              {{- if .Values.server.readinessProbe.execCommand }}
+              command: {{- toYaml .Values.server.readinessProbe.execCommand | nindent 14 }}
+              {{- else }}
               command: ["/bin/sh", "-ec", "vault status -tls-skip-verify"]
+              {{- end }}
             {{- end }}
             failureThreshold: {{ .Values.server.readinessProbe.failureThreshold }}
             initialDelaySeconds: {{ .Values.server.readinessProbe.initialDelaySeconds }}

--- a/test/unit/server-statefulset.bats
+++ b/test/unit/server-statefulset.bats
@@ -1253,6 +1253,26 @@ load _helpers
   [ "${actual}" = "null" ]
 }
 
+@test "server/standalone-StatefulSet: readiness execCommand configurable" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/server-statefulset.yaml \
+      --set 'server.readinessProbe.execCommand={/bin/sh,-c,sleep}' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.containers[0].readinessProbe.exec.command[2]' | tee /dev/stderr)
+  [ "${actual}" = "sleep" ]
+}
+
+@test "server/standalone-StatefulSet: readiness httpGet path configurable" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/server-statefulset.yaml \
+      --set 'server.readinessProbe.path=/v1/sys/health?standbyok=true' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.containers[0].readinessProbe.httpGet.path' | tee /dev/stderr)
+  [ "${actual}" = "/v1/sys/health?standbyok=true" ]
+}
+
 @test "server/standalone-StatefulSet: readiness failureThreshold default" {
   cd `chart_dir`
   local actual=$(helm template \

--- a/values.schema.json
+++ b/values.schema.json
@@ -1005,11 +1005,17 @@
                         "enabled": {
                             "type": "boolean"
                         },
+                        "execCommand": {
+                            "type": "array"
+                        },
                         "failureThreshold": {
                             "type": "integer"
                         },
                         "initialDelaySeconds": {
                             "type": "integer"
+                        },
+                        "path": {
+                            "type": "string"
                         },
                         "periodSeconds": {
                             "type": "integer"

--- a/values.yaml
+++ b/values.yaml
@@ -556,11 +556,17 @@ server:
   # Used to define custom readinessProbe settings
   readinessProbe:
     enabled: true
-    # If you need to use a http path instead of the default exec
+    # Set this, if you want to use a httpGet (path) instead of the default exec as the readinessProbe handler.
     # path: /v1/sys/health?standbyok=true
-
-    # Port number on which readinessProbe will be checked.
+    # Port number on which readinessProbe will be checked if httpGet is used as the readinessProbe handler.
     port: 8200
+
+    # If you need to overwrite default exec command, you can set it here.
+    # execCommand:
+    # - "/bin/sh"
+    # - "-ec"
+    # - "vault status -tls-skip-verify"
+
     # When a probe fails, Kubernetes will try failureThreshold times before giving up
     failureThreshold: 2
     # Number of seconds after the container has started before probe initiates


### PR DESCRIPTION
This PR supports custom exec command in server readiness probe. If `server.readinessProbe.execCommand` is set, then it overwrites the default exec command in server readiness probe.

We need to be able to do this since we enforce mTLS by setting `tls_require_and_verify_client_cert = "true"` and so have to provide client certificates in readiness and liveness probes.

Note: I executed tests with `docker run -it --rm -v "${PWD}:/test" hashicorpdev/vault-helm-test:latest bats /test/test/unit/server-statefulset.bats -f "server/standalone-StatefulSet: readiness"`.