### PR TITLE
add the option to override the scope of the injector webhook

### DIFF
--- a/templates/injector-mutating-webhook.yaml
+++ b/templates/injector-mutating-webhook.yaml
@@ -36,7 +36,7 @@ webhooks:
         apiGroups: [""]
         apiVersions: ["v1"]
         resources: ["pods"]
-        scope: "Namespaced"
+        scope: {{ .Values.injector.webhook.scope }}
 {{- if or (.Values.injector.namespaceSelector) (((.Values.injector.webhook)).namespaceSelector) }}
     namespaceSelector:
 {{ toYaml (((.Values.injector.webhook)).namespaceSelector | default .Values.injector.namespaceSelector) | indent 6}}

--- a/values.yaml
+++ b/values.yaml
@@ -181,7 +181,7 @@ injector:
     #      sidecar-injector: enabled
     namespaceSelector: {}
 
-    # scope decied the scope of the webhook. It can be either "Cluster" or "Namespaced" or "*"
+    # scope decided the scope of the webhook. It can be either "Cluster" or "Namespaced" or "*"
     # by default it is set to "Namespaced"
     # See https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/#matching-requests-rules
     scope: "Namespaced"

--- a/values.yaml
+++ b/values.yaml
@@ -181,6 +181,11 @@ injector:
     #      sidecar-injector: enabled
     namespaceSelector: {}
 
+    # scope decied the scope of the webhook. It can be either "Cluster" or "Namespaced" or "*"
+    # by default it is set to "Namespaced"
+    # See https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/#matching-requests-rules
+    scope: "Namespaced"
+
     # objectSelector is the selector for restricting the webhook to only
     # specific labels.
     # See https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/#matching-requests-objectselector
@@ -388,7 +393,7 @@ server:
   # Configure the logging format for the Vault server.
   # Supported log formats include: standard, json
   logFormat: ""
-  
+
   # Resource requests, limits, etc. for the server cluster placement. This
   # should map directly to the value of the resources field for a PodSpec.
   # By default no direct resource request is made.


### PR DESCRIPTION
Signed-off-by: AvivGuiser <avivguiser@gmail.com>

fixes #1110