### PR TITLE
server: fix service annotations precendence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Unreleased
 
+Bugs:
+
+* server: Allow `server.service.active.annotations` and `server.service.standby.annotation` to override `server.service.annotations` [GH-1121](https://github.com/hashicorp/vault-helm/pull/1121)
+
 ## 0.30.0 (March 27, 2025)
 
 Changes:

--- a/templates/server-ha-active-service.yaml
+++ b/templates/server-ha-active-service.yaml
@@ -22,8 +22,8 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     vault-active: "true"
   annotations:
-{{- template "vault.service.active.annotations" . }}
 {{- template "vault.service.annotations" . }}
+{{- template "vault.service.active.annotations" . }}
 spec:
   {{- if .Values.server.service.type}}
   type: {{ .Values.server.service.type }}

--- a/templates/server-ha-standby-service.yaml
+++ b/templates/server-ha-standby-service.yaml
@@ -21,8 +21,8 @@ metadata:
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
   annotations:
-{{- template "vault.service.standby.annotations" . }}
 {{- template "vault.service.annotations" . }}
+{{- template "vault.service.standby.annotations" . }}
 spec:
   {{- if .Values.server.service.type}}
   type: {{ .Values.server.service.type }}

--- a/test/unit/server-ha-active-service.bats
+++ b/test/unit/server-ha-active-service.bats
@@ -23,6 +23,7 @@ load _helpers
       yq -r '.metadata.annotations["vaultIsAwesome"]' | tee /dev/stderr)
   [ "${actual}" = "true" ]
 }
+
 @test "server/ha-active-Service: with both annotations set" {
   cd `chart_dir`
   local object=$(helm template \
@@ -38,6 +39,23 @@ load _helpers
   actual=$(echo "$object" | yq '.annotations["vaultIsNotAwesome"]' | tee /dev/stderr)
   [ "${actual}" = "false" ]
 }
+
+@test "server/ha-active-Service: with both annotations set active overrides general" {
+  cd "$(chart_dir)"
+  local metadata
+  metadata=$(helm template \
+      --show-only templates/server-ha-active-service.yaml \
+      --set 'server.ha.enabled=true' \
+      --set 'server.service.active.annotations=myAnnotation: active' \
+      --set 'server.service.annotations=myAnnotation: general' \
+      . | tee /dev/stderr |
+      yq -r '.metadata' | tee /dev/stderr)
+
+  local actual
+  actual=$(echo "$metadata" | yq -r '.annotations["myAnnotation"]' | tee /dev/stderr)
+  [ "${actual}" = "active" ]
+}
+
 @test "server/ha-active-Service: disable with ha.enabled false" {
   cd `chart_dir`
   local actual=$( (helm template \

--- a/test/unit/server-ha-standby-service.bats
+++ b/test/unit/server-ha-standby-service.bats
@@ -45,6 +45,7 @@ load _helpers
       yq -r '.metadata.annotations["vaultIsAwesome"]' | tee /dev/stderr)
   [ "${actual}" = "true" ]
 }
+
 @test "server/ha-standby-Service: with both annotations set" {
   cd `chart_dir`
   local object=$(helm template \
@@ -60,6 +61,23 @@ load _helpers
   actual=$(echo "$object" | yq '.annotations["vaultIsNotAwesome"]' | tee /dev/stderr)
   [ "${actual}" = "false" ]
 }
+
+@test "server/ha-standby-Service: with both annotations set standby overrides general" {
+  cd "$(chart_dir)"
+  local metadata
+  metadata=$(helm template \
+      --show-only templates/server-ha-standby-service.yaml \
+      --set 'server.ha.enabled=true' \
+      --set 'server.service.standby.annotations=myAnnotation: standby' \
+      --set 'server.service.annotations=myAnnotation: general' \
+      . | tee /dev/stderr |
+      yq -r '.metadata' | tee /dev/stderr)
+
+  local actual
+  actual=$(echo "$metadata" | yq -r '.annotations["myAnnotation"]' | tee /dev/stderr)
+  [ "${actual}" = "standby" ]
+}
+
 @test "server/ha-standby-Service: disable with ha.enabled false" {
   cd `chart_dir`
   local actual=$( (helm template \


### PR DESCRIPTION
Allows `server.service.active.annotations` and `server.service.standby.annotation` to override `server.service.annotations`.

So with a values file such as:

```yaml
server:
  ha:
    enabled: true
  service:
    annotations:
      "custom-annotation": "general"
    active:
      annotations:
        "custom-annotation": "active"
    standby:
      annotations:
        "custom-annotation": "standby"
```

The `vault-active` and `vault-standby` services will have `custom-annotation` set to "active" and "standby" respectively, while the `vault` and `vault-internal` services would have `custom-annotation` set to "general".