### PR TITLE
Prepare v0.30.1 release

### DIFF
--- a/.github/workflows/acceptance.yaml
+++ b/.github/workflows/acceptance.yaml
@@ -5,12 +5,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        kind-k8s-version:
-          - 1.32.3
-          - 1.31.6
-          - 1.30.10
-          - 1.29.14
-          - 1.28.15
+        kind-k8s-version: ["1.33.1", "1.32.5", "1.31.9", "1.30.13", "1.29.14"]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -21,7 +16,7 @@ jobs:
         with:
           config: test/kind/config.yaml
           node_image: kindest/node:v${{ matrix.kind-k8s-version }}
-          version: v0.27.0
+          version: v0.29.0
       - run: bats --tap --timing ./test/acceptance
         env:
           VAULT_LICENSE_CI: ${{ secrets.VAULT_LICENSE_CI }}

--- a/.github/workflows/acceptance.yaml
+++ b/.github/workflows/acceptance.yaml
@@ -5,7 +5,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        kind-k8s-version: ["1.33.1", "1.32.5", "1.31.9", "1.30.13", "1.29.14"]
+        kind-k8s-version: ["1.33.2", "1.32.5", "1.31.9", "1.30.13", "1.29.14"]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.github/workflows/jira.yaml
+++ b/.github/workflows/jira.yaml
@@ -14,4 +14,4 @@ jobs:
       JIRA_SYNC_USER_EMAIL: ${{ secrets.JIRA_SYNC_USER_EMAIL }}
       JIRA_SYNC_API_TOKEN: ${{ secrets.JIRA_SYNC_API_TOKEN }}
     with:
-      teams-array: '["vault-eco"]'
+      teams-array: '["vault-eco-infra"]'

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -10,14 +10,14 @@ jobs:
   chart-verifier:
     runs-on: ubuntu-latest
     env:
-      CHART_VERIFIER_VERSION: '1.13.10'
+      CHART_VERIFIER_VERSION: '1.13.12'
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Setup test tools
         uses: ./.github/actions/setup-test-tools
       - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
         with:
-          go-version: '1.23.7'
+          go-version: '1.24.5'
       - run: go install "github.com/redhat-certification/chart-verifier@${CHART_VERIFIER_VERSION}"
       - run: bats --tap --timing ./test/chart
 permissions:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 Changes:
 
-* Default `vault` version updated to 1.20.0
+* Default `vault` version updated to 1.20.1
 * Default `vault-k8s` version updated to 1.7.0
 * Default `vault-csi-provider` version updated to 1.5.1
 * Tested with Kubernetes versions 1.29-1.33

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+## 0.30.1 (July 28, 2025)
+
 Changes:
 
 * Default `vault` version updated to 1.20.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 ## Unreleased
 
+Changes:
+
+* Default `vault` version updated to 1.20.0
+* Default `vault-k8s` version updated to 1.7.0
+* Default `vault-csi-provider` version updated to 1.5.1
+* Tested with Kubernetes versions 1.29-1.33
+
 Bugs:
 
 * server: Allow `server.service.active.annotations` and `server.service.standby.annotation` to override `server.service.annotations` [GH-1121](https://github.com/hashicorp/vault-helm/pull/1121)

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -3,8 +3,8 @@
 
 apiVersion: v2
 name: vault
-version: 0.30.0
-appVersion: 1.19.0
+version: 0.30.1
+appVersion: 1.20.0
 kubeVersion: ">= 1.20.0-0"
 description: Official HashiCorp Vault Chart
 home: https://www.vaultproject.io

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -4,7 +4,7 @@
 apiVersion: v2
 name: vault
 version: 0.30.1
-appVersion: 1.20.0
+appVersion: 1.20.1
 kubeVersion: ">= 1.20.0-0"
 description: Official HashiCorp Vault Chart
 home: https://www.vaultproject.io

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ this README. Please refer to the Kubernetes and Helm documentation.
 The versions required are:
 
   * **Helm 3.6+**
-  * **Kubernetes 1.28+** - This is the earliest version of Kubernetes tested.
+  * **Kubernetes 1.29+** - This is the earliest version of Kubernetes tested.
     It is possible that this chart works with earlier versions but it is
     untested.
 

--- a/test/chart/verifier.bats
+++ b/test/chart/verifier.bats
@@ -6,9 +6,9 @@ setup_file() {
     cd `chart_dir`
     export VERIFY_OUTPUT="/$BATS_RUN_TMPDIR/verify.json"
     export CHART_VOLUME=vault-helm-chart-src
-    local IMAGE="quay.io/redhat-certification/chart-verifier:1.13.10"
+    local IMAGE="quay.io/redhat-certification/chart-verifier:1.13.12"
     # chart-verifier requires an openshift version if a cluster isn't available
-    local OPENSHIFT_VERSION="4.18"
+    local OPENSHIFT_VERSION="4.19"
     local DISABLED_TESTS="chart-testing"
 
     local run_cmd="chart-verifier"

--- a/values.openshift.yaml
+++ b/values.openshift.yaml
@@ -9,16 +9,16 @@ global:
 injector:
   image:
     repository: "registry.connect.redhat.com/hashicorp/vault-k8s"
-    tag: "1.6.2-ubi"
+    tag: "1.7.0-ubi"
 
   agentImage:
     repository: "registry.connect.redhat.com/hashicorp/vault"
-    tag: "1.19.0-ubi"
+    tag: "1.20.0-ubi"
 
 server:
   image:
     repository: "registry.connect.redhat.com/hashicorp/vault"
-    tag: "1.19.0-ubi"
+    tag: "1.20.0-ubi"
 
   readinessProbe:
     path: "/v1/sys/health?uninitcode=204"

--- a/values.openshift.yaml
+++ b/values.openshift.yaml
@@ -13,12 +13,12 @@ injector:
 
   agentImage:
     repository: "registry.connect.redhat.com/hashicorp/vault"
-    tag: "1.20.0-ubi"
+    tag: "1.20.1-ubi"
 
 server:
   image:
     repository: "registry.connect.redhat.com/hashicorp/vault"
-    tag: "1.20.0-ubi"
+    tag: "1.20.1-ubi"
 
   readinessProbe:
     path: "/v1/sys/health?uninitcode=204"

--- a/values.yaml
+++ b/values.yaml
@@ -76,7 +76,7 @@ injector:
   # required.
   agentImage:
     repository: "hashicorp/vault"
-    tag: "1.20.0"
+    tag: "1.20.1"
 
   # The default values for the injected Vault Agent containers.
   agentDefaults:
@@ -373,7 +373,7 @@ server:
 
   image:
     repository: "hashicorp/vault"
-    tag: "1.20.0"
+    tag: "1.20.1"
     # Overrides the default Image Pull Policy
     pullPolicy: IfNotPresent
 
@@ -1185,7 +1185,7 @@ csi:
 
     image:
       repository: "hashicorp/vault"
-      tag: "1.20.0"
+      tag: "1.20.1"
       pullPolicy: IfNotPresent
 
     logFormat: standard

--- a/values.yaml
+++ b/values.yaml
@@ -68,7 +68,7 @@ injector:
   # image sets the repo and tag of the vault-k8s image to use for the injector.
   image:
     repository: "hashicorp/vault-k8s"
-    tag: "1.6.2"
+    tag: "1.7.0"
     pullPolicy: IfNotPresent
 
   # agentImage sets the repo and tag of the Vault image to use for the Vault Agent
@@ -76,7 +76,7 @@ injector:
   # required.
   agentImage:
     repository: "hashicorp/vault"
-    tag: "1.19.0"
+    tag: "1.20.0"
 
   # The default values for the injected Vault Agent containers.
   agentDefaults:
@@ -373,7 +373,7 @@ server:
 
   image:
     repository: "hashicorp/vault"
-    tag: "1.19.0"
+    tag: "1.20.0"
     # Overrides the default Image Pull Policy
     pullPolicy: IfNotPresent
 
@@ -1096,7 +1096,7 @@ csi:
 
   image:
     repository: "hashicorp/vault-csi-provider"
-    tag: "1.5.0"
+    tag: "1.5.1"
     pullPolicy: IfNotPresent
 
   # volumes is a list of volumes made available to all containers. These are rendered
@@ -1185,7 +1185,7 @@ csi:
 
     image:
       repository: "hashicorp/vault"
-      tag: "1.19.0"
+      tag: "1.20.0"
       pullPolicy: IfNotPresent
 
     logFormat: standard


### PR DESCRIPTION
Changes:

* Default `vault` version updated to 1.20.1
* Default `vault-k8s` version updated to 1.7.0
* Default `vault-csi-provider` version updated to 1.5.1
* Tested with Kubernetes versions 1.29-1.33

Bugs:

* server: Allow `server.service.active.annotations` and `server.service.standby.annotation` to override `server.service.annotations` [GH-1121](https://github.com/hashicorp/vault-helm/pull/1121)

---

(Previous release PR for reference: https://github.com/hashicorp/vault-helm/pull/1102)