### PR TITLE
Injector -  support revisionhistorylimit

### DIFF
--- a/templates/injector-deployment.yaml
+++ b/templates/injector-deployment.yaml
@@ -18,6 +18,7 @@ metadata:
     component: webhook
 spec:
   replicas: {{ .Values.injector.replicas }}
+  revisionHistoryLimit: {{ .Values.injector.revisionHistoryLimit }}
   selector:
     matchLabels:
       app.kubernetes.io/name: {{ template "vault.name" . }}-agent-injector

--- a/values.yaml
+++ b/values.yaml
@@ -50,6 +50,9 @@ injector:
 
   replicas: 1
 
+  # Number of old ReplicaSets to retain to allow rollback.
+  revisionHistoryLimit: 10
+
   # Configures the port the injector should listen on
   port: 8080
 


### PR DESCRIPTION
Support setting setting revisionhistorylimit  for injector to control Number of old ReplicaSets to retain to allow rollback.

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [x] I have documented a clear reason for, and description of, the change I am making.

- [x] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [x] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
