### PR TITLE
feat: add metricRelabelings to serviceMonitor

### DIFF
--- a/templates/prometheus-servicemonitor.yaml
+++ b/templates/prometheus-servicemonitor.yaml
@@ -52,6 +52,10 @@ spec:
     authorization:
     {{- toYaml . | nindent 6 }}
     {{- end }}
+    {{- with .Values.serverTelemetry.serviceMonitor.metricRelabelings }}
+    metricRelabelings:
+    {{- toYaml . | nindent 6 }}
+    {{- end }}
   namespaceSelector:
     matchNames:
       - {{ include "vault.namespace" . }}

--- a/test/acceptance/server-test/vault-telemetry.yaml
+++ b/test/acceptance/server-test/vault-telemetry.yaml
@@ -14,3 +14,6 @@ serverTelemetry:
       credentials:
         name: vault-metrics-client
         key: token
+    metricRelabelings:
+      - sourceLabels: [cluster]
+        targetLabel: vault_cluster

--- a/values.schema.json
+++ b/values.schema.json
@@ -1251,6 +1251,9 @@
                         "interval": {
                             "type": "string"
                         },
+                        "metricRelabelings": {
+                            "type": "array"
+                        },
                         "scrapeTimeout": {
                             "type": "string"
                         },

--- a/values.yaml
+++ b/values.yaml
@@ -1321,6 +1321,14 @@ serverTelemetry:
     #     key: token
     authorization: {}
 
+    # metricRelabelings configures the relabeling rules to apply to the samples before ingestion.
+    # See API reference: https://prometheus-operator.dev/docs/api-reference/api/#monitoring.coreos.com/v1.RelabelConfig
+    # example:
+    # metricRelabelings:
+    #   - sourceLabels: [cluster]
+    #     targetLabel: vault_cluster
+    metricRelabelings: []
+
   prometheusRules:
       # The Prometheus operator *must* be installed before enabling this feature,
       # if not the chart will fail to install due to missing CustomResourceDefinitions


### PR DESCRIPTION
Vault emits metrics with the `cluster` label set.
The `cluster` label is used in many environments for multi-cloud purposes (dashboards).
Therefore it would be nice, if this label could be relabeled before ingesting into prometheus.