### PR TITLE
server: add IPC_LOCK capability to prevent page faults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Unreleased
 
+Bugs:
+
+* server: add IPC_LOCK container capability to prevent unecessary major page faults [GH-1139](https://github.com/hashicorp/vault-helm/pull/1139)
+
 ## 0.30.1 (July 28, 2025)
 
 Changes:

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -541,6 +541,8 @@ securityContext for the injector container level.
             capabilities:
               drop:
                 - ALL
+              add:
+                - IPC_LOCK
   {{- end }}
 {{- end -}}
 

--- a/values.yaml
+++ b/values.yaml
@@ -263,6 +263,8 @@ injector:
   #    capabilities:
   #      drop:
   #        - ALL
+  #      add:
+  #        - IPC_LOCK
   securityContext:
     pod: {}
     container: {}


### PR DESCRIPTION
Fixes: https://github.com/hashicorp/vault-helm/issues/1138

This basically just adds compliance with the documentation at https://developer.hashicorp.com/vault/tutorials/kubernetes/kubernetes-security-concerns#ensure-mlock-is-enabled

I have tested this in my deployment - works perfectly fine.