### PR TITLE
feat: Add extraObjects for deploying additional Kubernetes objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Unreleased
+
+Features:
+
+* Add `extraObjects` for deploying additional Kubernetes objects as part of the chart's release. Accepts a list or a map, whose entries are either YAML maps or templated strings, and renders each entry with `tpl` against the chart's context [#1143](https://github.com/hashicorp/vault-helm/pull/1143)
+
 ## 0.34.1 (August 13, 2026)
 
 Changes:

--- a/templates/extra-objects.yaml
+++ b/templates/extra-objects.yaml
@@ -1,0 +1,38 @@
+{{/*
+Copyright IBM Corp. 2018, 2026
+SPDX-License-Identifier: MPL-2.0
+*/}}
+
+{{- /*
+extraObjects is accepted as a list or as a map. Both are normalized to a list
+of entries keeping the list index or the map key, so that an entry of an
+unsupported type can be named in the error. An entry that renders to nothing is
+skipped rather than emitting an empty document, so that an entry may be wrapped
+in a conditional tying it to a component being enabled.
+*/ -}}
+{{- $entries := list -}}
+{{- $extraObjects := .Values.extraObjects | default list -}}
+{{- if kindIs "map" $extraObjects -}}
+{{- range $key, $object := $extraObjects -}}
+{{- $entries = append $entries (dict "id" $key "object" $object) -}}
+{{- end -}}
+{{- else -}}
+{{- range $index, $object := $extraObjects -}}
+{{- $entries = append $entries (dict "id" $index "object" $object) -}}
+{{- end -}}
+{{- end -}}
+{{- range $entry := $entries }}
+{{- $object := $entry.object }}
+{{- $rendered := "" }}
+{{- if kindIs "string" $object }}
+{{- $rendered = tpl $object $ }}
+{{- else if kindIs "map" $object }}
+{{- $rendered = tpl (toYaml $object) $ }}
+{{- else }}
+{{- fail (printf "extraObjects[%v]: expected a map or a string, got %s" $entry.id (kindOf $object)) }}
+{{- end }}
+{{- if trim $rendered }}
+---
+{{- $rendered | nindent 0 }}
+{{- end }}
+{{- end }}

--- a/templates/extra.yaml
+++ b/templates/extra.yaml
@@ -1,0 +1,4 @@
+{{ range .Values.extraObjects }}
+---
+{{ tpl . $ }}
+{{ end }}

--- a/templates/extra.yaml
+++ b/templates/extra.yaml
@@ -1,4 +1,0 @@
-{{ range .Values.extraObjects }}
----
-{{ tpl . $ }}
-{{ end }}

--- a/test/unit/extra-objects.bats
+++ b/test/unit/extra-objects.bats
@@ -1,0 +1,239 @@
+#!/usr/bin/env bats
+
+load _helpers
+
+#--------------------------------------------------------------------
+# extraObjects
+
+@test "extraObjects: not rendered by default" {
+  cd `chart_dir`
+  local actual=$( (helm template \
+      --show-only templates/extra-objects.yaml \
+      . || echo "---") | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+}
+
+@test "extraObjects: renders an object given as a map" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/extra-objects.yaml \
+      . \
+      -f - <<EOF \
+      | tee /dev/stderr \
+      | yq -r '.metadata.name' | tee /dev/stderr
+extraObjects:
+  - apiVersion: v1
+    kind: ConfigMap
+    metadata:
+      name: from-a-map
+    data:
+      key: value
+EOF
+)
+  [ "${actual}" = "from-a-map" ]
+}
+
+@test "extraObjects: renders an object given as a string" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/extra-objects.yaml \
+      . \
+      -f - <<EOF \
+      | tee /dev/stderr \
+      | yq -r '.data.key' | tee /dev/stderr
+extraObjects:
+  - |
+    apiVersion: v1
+    kind: ConfigMap
+    metadata:
+      name: from-a-string
+    data:
+      key: value
+EOF
+)
+  [ "${actual}" = "value" ]
+}
+
+@test "extraObjects: renders every object in the list" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/extra-objects.yaml \
+      . \
+      -f - <<EOF \
+      | tee /dev/stderr \
+      | yq -s -r 'map(.metadata.name) | join(",")' | tee /dev/stderr
+extraObjects:
+  - apiVersion: v1
+    kind: ConfigMap
+    metadata:
+      name: first
+  - |
+    apiVersion: v1
+    kind: ConfigMap
+    metadata:
+      name: second
+EOF
+)
+  [ "${actual}" = "first,second" ]
+}
+
+@test "extraObjects: accepts a map of objects" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/extra-objects.yaml \
+      . \
+      -f - <<EOF \
+      | tee /dev/stderr \
+      | yq -s -r 'map(.metadata.name) | sort | join(",")' | tee /dev/stderr
+extraObjects:
+  alpha:
+    apiVersion: v1
+    kind: ConfigMap
+    metadata:
+      name: first
+  beta: |
+    apiVersion: v1
+    kind: ConfigMap
+    metadata:
+      name: second
+EOF
+)
+  [ "${actual}" = "first,second" ]
+}
+
+@test "extraObjects: objects are templated against the chart context" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/extra-objects.yaml \
+      --namespace vault-namespace \
+      . \
+      -f - <<EOF \
+      | tee /dev/stderr \
+      | yq -r '[.metadata.name, .metadata.namespace, .metadata.labels["app.kubernetes.io/name"]] | join(",")' | tee /dev/stderr
+extraObjects:
+  - |
+    apiVersion: v1
+    kind: ConfigMap
+    metadata:
+      name: {{ include "vault.fullname" . }}-extra
+      namespace: {{ include "vault.namespace" . }}
+      labels:
+        app.kubernetes.io/name: {{ include "vault.name" . }}
+    data:
+      chart: {{ .Chart.Name }}
+EOF
+)
+  [ "${actual}" = "release-name-vault-extra,vault-namespace,vault" ]
+}
+
+@test "extraObjects: templated values are resolved in the map form too" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/extra-objects.yaml \
+      . \
+      -f - <<EOF \
+      | tee /dev/stderr \
+      | yq -r '.metadata.name' | tee /dev/stderr
+extraObjects:
+  - apiVersion: v1
+    kind: ConfigMap
+    metadata:
+      name: '{{ include "vault.fullname" . }}-extra'
+EOF
+)
+  [ "${actual}" = "release-name-vault-extra" ]
+}
+
+@test "extraObjects: rendered when global.enabled is false" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/extra-objects.yaml \
+      --set 'global.enabled=false' \
+      . \
+      -f - <<EOF \
+      | tee /dev/stderr \
+      | yq -r '.metadata.name' | tee /dev/stderr
+extraObjects:
+  - apiVersion: v1
+    kind: ConfigMap
+    metadata:
+      name: still-here
+EOF
+)
+  [ "${actual}" = "still-here" ]
+}
+
+@test "extraObjects: an entry that renders to nothing is skipped" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/extra-objects.yaml \
+      --set 'csi.enabled=false' \
+      . \
+      -f - <<EOF \
+      | tee /dev/stderr \
+      | yq -s -r 'map(.metadata.name) | join(",")' | tee /dev/stderr
+extraObjects:
+  server: |
+    apiVersion: v1
+    kind: ConfigMap
+    metadata:
+      name: always-here
+  csi: |
+    {{- if .Values.csi.enabled }}
+    apiVersion: v1
+    kind: ConfigMap
+    metadata:
+      name: only-with-csi
+    {{- end }}
+EOF
+)
+  [ "${actual}" = "always-here" ]
+}
+
+@test "extraObjects: objects for the server and the CSI provider can be deployed together" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/extra-objects.yaml \
+      --set 'csi.enabled=true' \
+      . \
+      -f - <<EOF \
+      | tee /dev/stderr \
+      | yq -s -r 'map(.metadata.name) | sort | join(",")' | tee /dev/stderr
+extraObjects:
+  server: |
+    apiVersion: v1
+    kind: ConfigMap
+    metadata:
+      name: {{ include "vault.fullname" . }}-server-tls
+  csi: |
+    {{- if .Values.csi.enabled }}
+    apiVersion: v1
+    kind: ConfigMap
+    metadata:
+      name: {{ include "vault.fullname" . }}-csi-tls
+    {{- end }}
+EOF
+)
+  [ "${actual}" = "release-name-vault-csi-tls,release-name-vault-server-tls" ]
+}
+
+@test "extraObjects: an entry that is neither a map nor a string fails" {
+  cd `chart_dir`
+  run helm template \
+      --show-only templates/extra-objects.yaml \
+      --set 'extraObjects[0]=42' \
+      .
+  [ "$status" -eq 1 ]
+  [[ "$output" =~ "extraObjects[0]: expected a map or a string" ]]
+}
+
+@test "extraObjects: a failing entry in the map form is named by its key" {
+  cd `chart_dir`
+  run helm template \
+      --show-only templates/extra-objects.yaml \
+      --set 'extraObjects.serverCert=42' \
+      .
+  [ "$status" -eq 1 ]
+  [[ "$output" =~ "extraObjects[serverCert]: expected a map or a string" ]]
+}

--- a/values.schema.json
+++ b/values.schema.json
@@ -242,6 +242,13 @@
                 }
             }
         },
+        "extraObjects": {
+            "type": [
+                "array",
+                "object",
+                "null"
+            ]
+        },
         "global": {
             "type": "object",
             "properties": {

--- a/values.yaml
+++ b/values.yaml
@@ -1479,3 +1479,14 @@ serverTelemetry:
       #    for: 5m
       #    labels:
       #      severity: critical
+
+
+# -- List of extra manifests to deploy
+extraObjects: []
+# - |
+#   apiVersion: v1
+#   kind: ConfigMap
+#   metadata:
+#     name: example-cm
+#   data:
+#     foo: bar

--- a/values.yaml
+++ b/values.yaml
@@ -1480,13 +1480,82 @@ serverTelemetry:
       #    labels:
       #      severity: critical
 
-
-# -- List of extra manifests to deploy
-extraObjects: []
-# - |
-#   apiVersion: v1
-#   kind: ConfigMap
-#   metadata:
-#     name: example-cm
-#   data:
-#     foo: bar
+# Additional Kubernetes objects to deploy alongside the chart's own resources.
+# Use this for objects the chart does not model, such as a cert-manager
+# Certificate issuing the Secret referenced by server.volumes, or a
+# NetworkPolicy for the CSI provider. Keeping them here puts them in the same
+# Helm release, so they share its lifecycle instead of being applied separately.
+#
+# Each entry is either a YAML map or a string. Both forms are rendered with
+# `tpl` against the chart's context, so they can call the chart's own templates
+# and values. Using helpers such as `vault.fullname`, `vault.name` and
+# `vault.namespace` keeps names, selectors and labels in step with the
+# resources the chart generates. An entry that is neither a map nor a string
+# fails rendering with an error naming its list index or its map key.
+#
+# extraObjects may also be given as a map of named entries instead of a list.
+# Helm replaces lists wholesale when merging values files but merges maps key
+# by key, so the map form lets a layered values file add or override a single
+# object without restating the others.
+#
+# These objects are not gated on global.enabled or on any component being
+# enabled. An entry that renders to nothing is skipped rather than emitting an
+# empty document, so an entry can be wrapped in a conditional to tie it to a
+# component: see the server and CSI provider example below. This matters when
+# one release enables more than one component, since each component needs its
+# own object under its own name.
+#
+# example, as a list of maps:
+# extraObjects:
+#   - apiVersion: cert-manager.io/v1
+#     kind: Certificate
+#     metadata:
+#       name: '{{ include "vault.fullname" . }}-tls'
+#       namespace: '{{ include "vault.namespace" . }}'
+#     spec:
+#       secretName: vault-tls
+#       issuerRef:
+#         name: internal-issuer
+#         kind: ClusterIssuer
+#       dnsNames:
+#         - vault.example.com
+#
+# example, as a map of templated strings, giving the server and the CSI
+# provider a certificate each. The CSI entry renders to nothing when the CSI
+# provider is disabled, so the same values file serves a release with either or
+# both:
+# extraObjects:
+#   serverCertificate: |
+#     apiVersion: cert-manager.io/v1
+#     kind: Certificate
+#     metadata:
+#       name: {{ include "vault.fullname" . }}-server-tls
+#       namespace: {{ include "vault.namespace" . }}
+#       labels:
+#         app.kubernetes.io/name: {{ include "vault.name" . }}
+#     spec:
+#       secretName: vault-server-tls
+#       issuerRef:
+#         name: internal-issuer
+#         kind: ClusterIssuer
+#       dnsNames:
+#         - vault.example.com
+#   csiCertificate: |
+#     {{- if .Values.csi.enabled }}
+#     apiVersion: cert-manager.io/v1
+#     kind: Certificate
+#     metadata:
+#       name: {{ include "vault.fullname" . }}-csi-tls
+#       namespace: {{ include "vault.namespace" . }}
+#     spec:
+#       secretName: vault-csi-tls
+#       issuerRef:
+#         name: internal-issuer
+#         kind: ClusterIssuer
+#       dnsNames:
+#         - vault-csi.example.com
+#     {{- end }}
+#
+# The default is null rather than an empty list so that neither the list nor
+# the map form conflicts with the default's type when values files are merged.
+extraObjects: null


### PR DESCRIPTION
## Summary

Adds `extraObjects` for deploying additional Kubernetes objects as part of the chart's release: objects the chart does not model, such as a cert-manager `Certificate` issuing the Secret referenced by `server.volumes`. Today these need a separate `kubectl apply`, which splits them from the release that depends on them.

Resolves #1146.

## Behaviour

- Accepts a list or a map. Entries are YAML maps or strings, each rendered with `tpl` against the chart's context, so they can use helpers such as `vault.fullname` and `vault.namespace`.
- The map form lets a per-environment values file add or override a single object, since Helm merges maps key by key but replaces lists wholesale.
- An entry that renders to nothing is skipped, so it can be wrapped in a conditional tied to a component being enabled.
- An entry that is neither a map nor a string fails rendering with an error naming its index or key.
- Defaults to `null`, so charts that do not set `extraObjects` render exactly as before.

## Example

```yaml
extraObjects:
  appConfig:
    apiVersion: v1
    kind: ConfigMap
    metadata:
      name: '{{ include "vault.fullname" . }}-app-config'
    data:
      key: value
  csiCertificate: |
    {{- if .Values.csi.enabled }}
    apiVersion: cert-manager.io/v1
    kind: Certificate
    metadata:
      name: {{ include "vault.fullname" . }}-csi-tls
    spec:
      secretName: vault-csi-tls
      issuerRef:
        name: internal-issuer
        kind: ClusterIssuer
      dnsNames:
        - vault-csi.example.com
    {{- end }}
```

## Changes

`templates/extra-objects.yaml`, docs in `values.yaml`, a `values.schema.json` entry, a CHANGELOG entry, and 12 unit tests in `test/unit/extra-objects.bats`. Full unit suite passes locally. Rebased onto `main` at v0.34.1.

The extensions over the original template in this PR came from @khateeb15 in #1206, credited as co-author on the commit.

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [x] I have documented a clear reason for, and description of, the change I am making.

- [x] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [x] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
