### PR TITLE
Added toggle to exclude the internal service from receiving annotations.

### DIFF
--- a/templates/server-headless-service.yaml
+++ b/templates/server-headless-service.yaml
@@ -20,7 +20,7 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     vault-internal: "true"
   annotations:
-{{- if not .Values.server.service.excludeInternalService }}
+{{- if not .Values.server.service.excludeAnnotationsFromInternalService }}
 {{ template "vault.service.annotations" .}}
 {{- end }}
 spec:

--- a/templates/server-headless-service.yaml
+++ b/templates/server-headless-service.yaml
@@ -20,7 +20,9 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     vault-internal: "true"
   annotations:
+{{- if not .Values.server.service.excludeInternalService }}
 {{ template "vault.service.annotations" .}}
+{{- end }}
 spec:
   {{- if (semverCompare ">= 1.23-0" .Capabilities.KubeVersion.Version) }}
   {{- if .Values.server.service.ipFamilyPolicy }}

--- a/values.yaml
+++ b/values.yaml
@@ -768,6 +768,12 @@ server:
     # to the service.
     annotations: {}
 
+    # If enabled, the above annotations will not be applied to the internal service
+    # that is used for inter-pod communication within the Vault cluster.
+    # Use this when you're running single node vaults in combination with the OpenShift service CA
+    # which will apply this to all services in the namespace and cause issues.
+    excludeAnnotationsFromInternalService: false
+
   # This configures the Vault Statefulset to create a PVC for data
   # storage when using the file or raft backend storage engines.
   # See https://developer.hashicorp.com/vault/docs/configuration/storage to know more


### PR DESCRIPTION
We are running single node Vault servers in OpenShift with the following config:

```
vault:
  global:
    tlsDisable: false
    openshift: true
  injector:
    enabled: false
    metrics:
      enabled: true
  ui:
    enabled: true
  serverTelemetry:
    serviceMonitor:
      enabled: true
    prometheusRules:
      enabled: true
  server:
    image:
      tag: "1.19.5"
    updateStrategyType: RollingUpdate
    authDelegator:
      enabled: false
    logLevel: info
    service:
      annotations:
        service.beta.openshift.io/serving-cert-secret-name: vault-tls
        service.beta.openshift.io/inject-cabundle: "true"
    configAnnotation: true
[snip]
    volumes:
      - name: vault-tls
        secret:
          secretName: vault-tls
      - name: vault-init-script
        configMap:
          name: vault-init-script
          defaultMode: 493
    volumeMounts:
      - name: vault-tls
        mountPath: "/vault/userconfig/vault-tls"
      - name: vault-init-script
        mountPath: "/vault/userconfig/vault-init-script"
  [snip]
    route:
      enabled: true
      host: "vaultl.cluster.tld"
      tls:
        termination: passthrough 
    standalone:
      enabled: "-"
      config: |
        ui = true
        log_level = "info"
        listener "tcp" {
          tls_cert_file = "/vault/userconfig/vault-tls/tls.crt"
          tls_key_file = "/vault/userconfig/vault-tls/tls.key"
          tls_client_ca_file = "/run/secrets/kubernetes.io/serviceaccount/service-ca.crt"
          address = "[::]:8200"
          cluster_address = "[::]:8201"
          telemetry {
            unauthenticated_metrics_access = "true"
          }
        }
        telemetry {
          prometheus_retention_time = "30s",
          disable_hostname = true
        }
        service_registration "kubernetes" {}
        storage "raft" {
          path = "/vault/data"
        }
  
```

Setting 
```
    service:
      annotations:
        service.beta.openshift.io/serving-cert-secret-name: vault-tls
        service.beta.openshift.io/inject-cabundle: "true"
```
causes BOTH deployed services (vault-internal and vault) to receive those annotations, which causes the OpenShift CA to try and issue the certificates for both of them. For a headless service, openshift deploys a *.servicename wildcard which does not bode well with routes that choose to use the reencrypt tls option. 

I propose a change so that the user can toggle whether the annotations get applied to both of the services or just one (vault, in this case). 

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [X] I have documented a clear reason for, and description of, the change I am making.

- [x] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [x] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
