### PR TITLE
fix: server-side apply drift in StatefulSet when using GitOps

### DIFF
--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -286,7 +286,9 @@ storage might be desired by the user.
   {{- if and (ne .mode "dev") (or .Values.server.dataStorage.enabled .Values.server.auditStorage.enabled) }}
   volumeClaimTemplates:
       {{- if and (eq (.Values.server.dataStorage.enabled | toString) "true") (or (eq .mode "standalone") (eq (.Values.server.ha.raft.enabled | toString ) "true" )) }}
-    - metadata:
+    - apiVersion: v1
+      kind: PersistentVolumeClaim
+      metadata:
         name: data
         {{- include "vault.dataVolumeClaim.annotations" . | nindent 6 }}
         {{- include "vault.dataVolumeClaim.labels" . | nindent 6 }}


### PR DESCRIPTION
## Summary

Add explicit `apiVersion` and `kind` fields to `volumeClaimTemplates` in StatefulSet configuration to ensure compatibility with Kubernetes server-side apply.

## Context

This PR fixes issue #981, where Vault Helm deployments fail to reconcile properly when using server-side apply (SSA) with ArgoCD or other GitOps tools that leverage Kubernetes' server-side apply mechanism.

**The Problem:**

When deploying Vault with datastorage enabled (either standalone or raft mode), the generated StatefulSet includes a `volumeClaimTemplates` section. However, the current Helm template generates PersistentVolumeClaim specifications without explicit `apiVersion` and `kind` fields:

```yaml
# Current (Broken) Output
volumeClaimTemplates:
  - metadata:
      name: data
    spec:
      accessModes:
        - ReadWriteOnce
      resources:
        requests:
          storage: 10Gi
```

When Kubernetes applies this configuration using server-side apply, it automatically populates the missing fields with defaults:

```yaml
# What Kubernetes Creates in the Cluster
volumeClaimTemplates:
  - apiVersion: v1
    kind: PersistentVolumeClaim
    metadata:
      name: data
    spec:
      accessModes:
        - ReadWriteOnce
      resources:
        requests:
          storage: 10Gi
```

This discrepancy causes ArgoCD and other GitOps tools to detect perpetual drift between the desired state (from Helm) and the live state (in the cluster), marking applications as "OutOfSync" despite no actual changes being needed.

**Root Cause:**

Kubernetes PR [#87706](https://github.com/kubernetes/kubernetes/pull/87706) changed how nested `PersistentVolumeClaim` objects within `volumeClaimTemplates` are handled during storage encoding. The proto storage format requires explicit handling for TypeMeta fields (`apiVersion` and `kind`) in nested objects, unlike JSON which is self-identifying. Without these fields explicitly declared in the template, server-side apply cannot correctly determine that no changes have occurred, resulting in spurious diffs.

This affects Vault Helm users deploying with:
- ArgoCD with server-side apply enabled (see [argoproj/argo-cd#11143](https://github.com/argoproj/argo-cd/issues/11143))
- Any GitOps workflow relying on server-side apply for state reconciliation

## Changes

Modified `templates/_helpers.tpl` to include complete Kubernetes resource metadata in the `vault.volumeclaims` template helper:

```yaml
# New (Correct) Output
volumeClaimTemplates:
  - apiVersion: v1
    kind: PersistentVolumeClaim
    metadata:
      name: data
    spec:
      accessModes:
        - ReadWriteOnce
      resources:
        requests:
          storage: 10Gi
```

**Files Changed:**
- `templates/_helpers.tpl` (+3 lines, -1 line)

**Specific Modification:**

The `vault.volumeclaims` template helper now emits full Kubernetes resource definitions rather than partial specifications. This ensures that when the template is rendered at line 237 of `templates/server-statefulset.yaml`, it produces manifests compatible with server-side apply semantics.

## Technical Details

**Why These Fields Matter:**

In Kubernetes, `volumeClaimTemplates` is a special field within StatefulSet specifications that contains an array of PersistentVolumeClaim templates. When using server-side apply, Kubernetes needs to track field ownership and determine which fields have changed. The algorithm relies on complete type information (`apiVersion` + `kind`) to properly:

1. **Identify the object type** for conversion and validation
2. **Apply defaulting logic** consistently
3. **Track field managers** for conflict resolution
4. **Compute accurate diffs** between desired and actual state

Without explicit `apiVersion: v1` and `kind: PersistentVolumeClaim`, the server-side apply mechanism defaults these fields at apply time. However, because they're not present in the original manifest, the diff algorithm considers them as "new" fields on every reconciliation attempt, creating false positives.

**Server-Side Apply vs. Client-Side Apply:**

- **Client-side apply** (kubectl apply with `--server-side=false`): The client calculates diffs and sends a PATCH. Missing fields are ignored in diff calculations.
- **Server-side apply** (kubectl apply with `--server-side=true`, ArgoCD default): The server calculates diffs and manages field ownership. All fields must be explicitly declared for accurate change detection.

This is not a bug in Kubernetes or ArgoCD—it's the expected behavior of server-side apply's strongly-typed field management.

## Trade-offs and Alternatives

**Why This Approach:**

1. **Minimal change:** Only adds two fields to the existing template
2. **Zero functional impact:** These fields are required by the Kubernetes API schema and would be defaulted anyway
3. **Proven solution:** Successfully implemented in [VerneMQ](https://github.com/vernemq/docker-vernemq/pull/347) and other Helm charts facing the same issue
4. **Forward compatible:** Works with all Kubernetes versions and apply methods

**Alternatives Considered:**

1. **Disable server-side apply in ArgoCD:** This is a workaround, not a fix. It forces users to use deprecated client-side apply and loses benefits like better conflict resolution and field ownership tracking.

2. **Configure ArgoCD to ignore these fields:** ArgoCD supports diff customizations, but this requires every user to add chart-specific configuration. The root cause should be fixed in the chart.

3. **Wait for Kubernetes/ArgoCD to fix it:** This is not a bug in those projects—Helm charts must emit complete resource definitions for server-side apply to work correctly.

## Testing

**Manual Verification Required:**

1. Deploy Vault with server datastorage enabled:
   ```yaml
   server:
     dataStorage:
       enabled: true
       size: 10Gi
   ```

2. Enable server-side apply in ArgoCD or use kubectl with `--server-side=true`

3. Verify the StatefulSet applies successfully without sync drift

4. Confirm `kubectl get statefulset <vault-name> -o yaml` shows `volumeClaimTemplates` with `apiVersion` and `kind` fields

**Expected Behavior:**

- **Before:** ArgoCD continuously shows the application as "OutOfSync" with a diff on `volumeClaimTemplates`
- **After:** ArgoCD shows "Synced" status with no spurious diffs on `volumeClaimTemplates`

**Regression Risk:** Extremely low. These fields are required by the PersistentVolumeClaim schema and were always present in the live cluster—we're simply making them explicit in the template.

## Caveats / Known Issues

None. This change only affects the rendered YAML output and has no runtime impact on Vault behavior. It purely fixes a manifest rendering issue that prevents proper GitOps reconciliation.

## Review Focus

1. **Template syntax:** Verify the YAML indentation is correct in `_helpers.tpl`
2. **Rendered output:** Generate a test manifest with `helm template` and confirm `volumeClaimTemplates` includes both fields
3. **Conditional logic:** Ensure this works correctly when `server.dataStorage.enabled=true` (both standalone and raft modes)

## References

- Closes #981
- Kubernetes change: https://github.com/kubernetes/kubernetes/pull/87706
- Similar fix in VerneMQ: https://github.com/vernemq/docker-vernemq/pull/347  
- Related ArgoCD discussion: https://github.com/argoproj/argo-cd/issues/11143