### PR TITLE
Allow users to specify the target service for the ServiceMonitor

### DIFF
--- a/templates/prometheus-servicemonitor.yaml
+++ b/templates/prometheus-servicemonitor.yaml
@@ -27,10 +27,14 @@ spec:
     matchLabels:
       app.kubernetes.io/name: {{ template "vault.name" . }}
       app.kubernetes.io/instance: {{ .Release.Name }}
+      {{- if .Values.serverTelemetry.serviceMonitor.matchLabels }}
+      {{- toYaml .Values.serverTelemetry.serviceMonitor.matchLabels | nindent 6 }}
+      {{- else }}
       {{- if eq .mode "ha" }}
       vault-active: "true"
       {{- else }}
       vault-internal: "true"
+      {{- end }}
       {{- end }}
   endpoints:
   - port: {{ include "vault.scheme" . }}

--- a/values.yaml
+++ b/values.yaml
@@ -1343,6 +1343,21 @@ serverTelemetry:
     #     targetLabel: vault_cluster
     metricRelabelings: []
 
+    # matchLabels configures the service selector labels for the ServiceMonitor.
+    # By default, the ServiceMonitor targets services with:
+    #   - HA mode: vault-active: "true" (scrapes the raft leader only)
+    #   - Standalone mode: vault-internal: "true"
+    #
+    # To scrape metrics from all Vault pods including standbys (Enterprise only):
+    # 1. Enable unauthenticated_metrics_access in your Vault listener telemetry config
+    # 2. Set matchLabels to target the vault-internal headless service
+    # See: https://developer.hashicorp.com/vault/docs/configuration/telemetry#prometheus
+    #
+    # Example:
+    # matchLabels:
+    #   vault-internal: "true"
+    matchLabels: {}
+
   prometheusRules:
       # The Prometheus operator *must* be installed before enabling this feature,
       # if not the chart will fail to install due to missing CustomResourceDefinitions


### PR DESCRIPTION
Allow users to specify the target service for the ServiceMonitor. This will allow Vault Enterprise users with [unauthenticated_metrics_access](https://developer.hashicorp.com/vault/docs/configuration/listener/tcp#unauthenticated_metrics_access) enabled to scrape metrics from standby pods.

https://developer.hashicorp.com/vault/docs/configuration/telemetry#prometheus

Fixes: https://github.com/hashicorp/vault-helm/issues/1085

<!-- VAULT-40363 -->