### PR TITLE
Ability to deploy without cluster-admin permissions

### DIFF
--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -102,6 +102,7 @@ Compute if the server auth delegator serviceaccount is enabled.
     (eq (.Values.server.authDelegator.enabled | toString) "true" )
     (or (eq (.Values.server.serviceAccount.create | toString) "true")
         (not (eq .Values.server.serviceAccount.name "")))
+    (eq (.Values.server.serviceAccount.createClusterRoleBinding | toString) "true")
     (or
       (eq (.Values.server.enabled | toString) "true")
       (eq (.Values.global.enabled | toString) "true"))) -}}

--- a/templates/csi-clusterrole.yaml
+++ b/templates/csi-clusterrole.yaml
@@ -5,6 +5,7 @@ SPDX-License-Identifier: MPL-2.0
 
 {{- template "vault.csiEnabled" . -}}
 {{- if .csiEnabled -}}
+{{- if eq (.Values.csi.serviceAccount.createClusterRoleAndBinding | toString) "true" }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -20,4 +21,5 @@ rules:
   - serviceaccounts/token
   verbs:
   - create
+{{- end }}
 {{- end }}

--- a/templates/csi-clusterrolebinding.yaml
+++ b/templates/csi-clusterrolebinding.yaml
@@ -5,6 +5,7 @@ SPDX-License-Identifier: MPL-2.0
 
 {{- template "vault.csiEnabled" . -}}
 {{- if .csiEnabled -}}
+{{- if eq (.Values.csi.serviceAccount.createClusterRoleAndBinding | toString) "true" }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
@@ -21,4 +22,5 @@ subjects:
 - kind: ServiceAccount
   name: {{ template "vault.fullname" . }}-csi-provider
   namespace: {{ include "vault.namespace" . }}
+{{- end }}
 {{- end }}

--- a/templates/csi-serviceaccount.yaml
+++ b/templates/csi-serviceaccount.yaml
@@ -5,6 +5,7 @@ SPDX-License-Identifier: MPL-2.0
 
 {{- template "vault.csiEnabled" . -}}
 {{- if .csiEnabled -}}
+{{- if eq (.Values.csi.serviceAccount.create | toString) "true" }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -18,4 +19,5 @@ metadata:
       {{- toYaml .Values.csi.serviceAccount.extraLabels | nindent 4 -}}
     {{- end -}}
   {{ template "csi.serviceAccount.annotations" . }}
+{{- end }}
 {{- end }}

--- a/templates/injector-clusterrole.yaml
+++ b/templates/injector-clusterrole.yaml
@@ -5,6 +5,7 @@ SPDX-License-Identifier: MPL-2.0
 
 {{- template "vault.injectorEnabled" . -}}
 {{- if .injectorEnabled -}}
+{{- if eq (.Values.injector.serviceAccount.createClusterRoleAndBinding | toString) "true" }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -26,5 +27,6 @@ rules:
   resources: ["nodes"]
   verbs:
     - "get"
+{{ end }}
 {{ end }}
 {{ end }}

--- a/templates/injector-clusterrolebinding.yaml
+++ b/templates/injector-clusterrolebinding.yaml
@@ -5,6 +5,7 @@ SPDX-License-Identifier: MPL-2.0
 
 {{- template "vault.injectorEnabled" . -}}
 {{- if .injectorEnabled -}}
+{{- if eq (.Values.injector.serviceAccount.createClusterRoleAndBinding | toString) "true" }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
@@ -21,4 +22,5 @@ subjects:
 - kind: ServiceAccount
   name: {{ template "vault.fullname" . }}-agent-injector
   namespace: {{ include "vault.namespace" . }}
+{{ end }}
 {{ end }}

--- a/templates/injector-serviceaccount.yaml
+++ b/templates/injector-serviceaccount.yaml
@@ -5,6 +5,7 @@ SPDX-License-Identifier: MPL-2.0
 
 {{- template "vault.injectorEnabled" . -}}
 {{- if .injectorEnabled -}}
+{{- if eq (.Values.injector.serviceAccount.create | toString) "true" }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -15,4 +16,5 @@ metadata:
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
   {{ template "injector.serviceAccount.annotations" . }}
+{{ end }}
 {{ end }}

--- a/values.yaml
+++ b/values.yaml
@@ -336,6 +336,10 @@ injector:
 
   # Injector serviceAccount specific config
   serviceAccount:
+    # Specifies whether a service account should be created
+    create: true
+    # Specifies whether a ClusterRole and ClusterRoleBinding should be created (if not, cluster administrator is responsible to create them)
+    createClusterRoleAndBinding: true  
     # Extra annotations to attach to the injector serviceAccount
     annotations: {}
 
@@ -988,6 +992,8 @@ server:
     # The name of the service account to use.
     # If not set and create is true, a name is generated using the fullname template
     name: ""
+    # Specifies whether a ClusterRoleBinding should be created (if not, cluster administrator is responsible to create them)
+    createClusterRoleBinding: true    
     # Create a Secret API object to store a non-expiring token for the service account.
     # Prior to v1.24.0, Kubernetes used to generate this secret for each service account by default.
     # Kubernetes now recommends using short-lived tokens from the TokenRequest API or projected volumes instead if possible.
@@ -1218,6 +1224,10 @@ csi:
   priorityClassName: ""
 
   serviceAccount:
+    # Specifies whether a service account should be created
+    create: true
+    # Specifies whether a ClusterRole and ClusterRoleBinding should be created (if not, cluster administrator is responsible to create them)
+    createClusterRoleAndBinding: true  
     # Extra annotations for the serviceAccount definition. This can either be
     # YAML or a YAML-formatted multi-line templated string map of the
     # annotations to apply to the serviceAccount.


### PR DESCRIPTION
This PR allows to deploy Vault without cluster-admin permissions using dedicated ServiceAccounts prepared by cluster admin.

Fixes: #1147

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [X] I have documented a clear reason for, and description of, the change I am making.

- [X] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [X] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
