### PR TITLE
feat: add reinvocationPolicy option for injector webhook

### DIFF
--- a/templates/injector-mutating-webhook.yaml
+++ b/templates/injector-mutating-webhook.yaml
@@ -22,6 +22,7 @@ webhooks:
   - name: vault.hashicorp.com
     failurePolicy: {{ ((.Values.injector.webhook)).failurePolicy | default .Values.injector.failurePolicy }}
     matchPolicy: {{ ((.Values.injector.webhook)).matchPolicy | default "Exact" }}
+    reinvocationPolicy: {{ ((.Values.injector.webhook)).reinvocationPolicy | default "Never" }}
     sideEffects: None
     timeoutSeconds: {{ ((.Values.injector.webhook)).timeoutSeconds | default "30" }}
     admissionReviewVersions: ["v1", "v1beta1"]

--- a/test/unit/injector-mutating-webhook.bats
+++ b/test/unit/injector-mutating-webhook.bats
@@ -158,6 +158,41 @@ load _helpers
   [ "${actual}" = "50" ]
 }
 
+@test "injector/MutatingWebhookConfiguration: reinvocationPolicy 'Never' by default" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/injector-mutating-webhook.yaml  \
+      --set 'injector.enabled=true' \
+      . | tee /dev/stderr |
+      yq '.webhooks[0].reinvocationPolicy' | tee /dev/stderr)
+
+  [ "${actual}" = "\"Never\"" ]
+}
+
+@test "injector/MutatingWebhookConfiguration: can set webhook.reinvocationPolicy to IfNeeded" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/injector-mutating-webhook.yaml  \
+      --set 'injector.enabled=true' \
+      --set 'injector.webhook.reinvocationPolicy=IfNeeded' \
+      . | tee /dev/stderr |
+      yq '.webhooks[0].reinvocationPolicy' | tee /dev/stderr)
+
+  [ "${actual}" = "\"IfNeeded\"" ]
+}
+
+@test "injector/MutatingWebhookConfiguration: can set webhook.reinvocationPolicy to Never" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/injector-mutating-webhook.yaml  \
+      --set 'injector.enabled=true' \
+      --set 'injector.webhook.reinvocationPolicy=Never' \
+      . | tee /dev/stderr |
+      yq '.webhooks[0].reinvocationPolicy' | tee /dev/stderr)
+
+  [ "${actual}" = "\"Never\"" ]
+}
+
 #--------------------------------------------------------------------
 # annotations
 

--- a/values.yaml
+++ b/values.yaml
@@ -171,6 +171,13 @@ injector:
     #
     timeoutSeconds: 30
 
+    # reinvocationPolicy specifies whether the webhook should be called again if other
+    # webhooks modify the object. Valid values are "Never" and "IfNeeded".
+    # See https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/#reinvocation-policy
+    # for more details.
+    #
+    reinvocationPolicy: Never
+
     # namespaceSelector is the selector for restricting the webhook to only
     # specific namespaces.
     # See https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/#matching-requests-namespaceselector


### PR DESCRIPTION
# Add reinvocationPolicy option for injector webhook 

This option on the webhoook configuration should be exposed to the user. An example case being where they may use other mutating webhooks to add, or adjust, vault annotations required by the injector.

Webhook ordering is not guaranteed, therefore it should be made possible for the vault injector to be reinvoked in case of webhooks adding relevant vault annotations. 

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [x] I have documented a clear reason for, and description of, the change I am making.

- [x] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [x] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.