### PR TITLE
Add OpenShift service-ca operator automation

### DIFF
--- a/templates/server-service.yaml
+++ b/templates/server-service.yaml
@@ -20,6 +20,9 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
   annotations:
 {{ template "vault.service.annotations" .}}
+{{- if and .Values.global.openshift .Values.server.serviceCA.enabled }}
+    service.beta.openshift.io/serving-cert-secret-name: {{ .Values.server.serviceCA.secretName | quote }}
+{{- end }}
 spec:
   {{- if .Values.server.service.type}}
   type: {{ .Values.server.service.type }}

--- a/templates/server-serviceca-configmap.yaml
+++ b/templates/server-serviceca-configmap.yaml
@@ -1,0 +1,23 @@
+{{/*
+Copyright (c) HashiCorp, Inc.
+SPDX-License-Identifier: MPL-2.0
+*/}}
+
+{{- if and .Values.global.openshift .Values.server.serviceCA.enabled }}
+# ConfigMap for OpenShift service-ca operator
+# The service-ca operator will automatically inject the CA bundle
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Values.server.serviceCA.configMapName }}
+  namespace: {{ include "vault.namespace" . }}
+  labels:
+    helm.sh/chart: {{ include "vault.chart" . }}
+    app.kubernetes.io/name: {{ include "vault.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+  annotations:
+    service.beta.openshift.io/inject-cabundle: "true"
+data: {}
+{{- end }}
+

--- a/test/unit/server-serviceca-configmap.bats
+++ b/test/unit/server-serviceca-configmap.bats
@@ -1,0 +1,100 @@
+#!/usr/bin/env bats
+
+load _helpers
+
+@test "server/serviceCA ConfigMap: disabled by default" {
+  cd `chart_dir`
+  local actual=$( (helm template \
+      --show-only templates/server-serviceca-configmap.yaml \
+      . || echo "---") | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+}
+
+@test "server/serviceCA ConfigMap: not created when only global.openshift=true" {
+  cd `chart_dir`
+  local actual=$( (helm template \
+      --show-only templates/server-serviceca-configmap.yaml \
+      --set 'global.openshift=true' \
+      . || echo "---") | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+}
+
+@test "server/serviceCA ConfigMap: not created when only server.serviceCA.enabled=true" {
+  cd `chart_dir`
+  local actual=$( (helm template \
+      --show-only templates/server-serviceca-configmap.yaml \
+      --set 'server.serviceCA.enabled=true' \
+      . || echo "---") | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+}
+
+@test "server/serviceCA ConfigMap: created when both flags are true" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/server-serviceca-configmap.yaml \
+      --set 'global.openshift=true' \
+      --set 'server.serviceCA.enabled=true' \
+      . | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}
+
+@test "server/serviceCA ConfigMap: has correct annotation" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/server-serviceca-configmap.yaml \
+      --set 'global.openshift=true' \
+      --set 'server.serviceCA.enabled=true' \
+      . | tee /dev/stderr |
+      yq -r '.metadata.annotations["service.beta.openshift.io/inject-cabundle"]' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}
+
+@test "server/serviceCA ConfigMap: uses default name" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/server-serviceca-configmap.yaml \
+      --set 'global.openshift=true' \
+      --set 'server.serviceCA.enabled=true' \
+      . | tee /dev/stderr |
+      yq -r '.metadata.name' | tee /dev/stderr)
+  [ "${actual}" = "service-ca-bundle" ]
+}
+
+@test "server/serviceCA ConfigMap: name is configurable" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/server-serviceca-configmap.yaml \
+      --set 'global.openshift=true' \
+      --set 'server.serviceCA.enabled=true' \
+      --set 'server.serviceCA.configMapName=custom-ca-bundle' \
+      . | tee /dev/stderr |
+      yq -r '.metadata.name' | tee /dev/stderr)
+  [ "${actual}" = "custom-ca-bundle" ]
+}
+
+@test "server/serviceCA ConfigMap: has correct labels" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/server-serviceca-configmap.yaml \
+      --set 'global.openshift=true' \
+      --set 'server.serviceCA.enabled=true' \
+      . | tee /dev/stderr |
+      yq -r '.metadata.labels["app.kubernetes.io/name"]' | tee /dev/stderr)
+  [ "${actual}" = "vault" ]
+}
+
+@test "server/serviceCA ConfigMap: has empty data" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/server-serviceca-configmap.yaml \
+      --set 'global.openshift=true' \
+      --set 'server.serviceCA.enabled=true' \
+      . | tee /dev/stderr |
+      yq -r '.data' | tee /dev/stderr)
+  [ "${actual}" = "{}" ]
+}
+

--- a/values.schema.json
+++ b/values.schema.json
@@ -1043,6 +1043,20 @@
                         }
                     }
                 },
+                "serviceCA": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean"
+                        },
+                        "secretName": {
+                            "type": "string"
+                        },
+                        "configMapName": {
+                            "type": "string"
+                        }
+                    }
+                },
                 "service": {
                     "type": "object",
                     "properties": {

--- a/values.yaml
+++ b/values.yaml
@@ -371,6 +371,50 @@ server:
     # The key within the Kubernetes secret that holds the enterprise license.
     secretKey: "license"
 
+  # OpenShift service-ca operator integration
+  # Automates TLS certificate generation via the service-ca operator
+  serviceCA:
+    # Enable service-ca operator annotations and ConfigMap creation
+    # Requires: global.openshift=true
+    enabled: false
+    
+    # Secret name where service-ca will store the generated certificate
+    # IMPORTANT: Must match the secret name in server.volumes below
+    secretName: "vault-tls"
+    
+    # ConfigMap name for service-ca CA bundle injection
+    # IMPORTANT: Must match the ConfigMap name in server.volumes below
+    configMapName: "service-ca-bundle"
+  
+  # IMPORTANT: Configure server.volumes, server.volumeMounts, AND server config to use service-ca
+  #
+  # Step 1: Mount the service-ca resources as volumes
+  # volumes:
+  #   - name: vault-tls
+  #     secret:
+  #       secretName: vault-tls  # Must match serviceCA.secretName above
+  #   - name: service-ca-bundle
+  #     configMap:
+  #       name: service-ca-bundle  # Must match serviceCA.configMapName above
+  #
+  # volumeMounts:
+  #   - name: vault-tls
+  #     mountPath: /vault/userconfig/vault-tls
+  #     readOnly: true
+  #   - name: service-ca-bundle
+  #     mountPath: /vault/userconfig/service-ca-bundle
+  #     readOnly: true
+  #
+  # Step 2: Configure Vault listener to use the certificates (in server.ha.config or server.ha.raft.config)
+  # listener "tcp" {
+  #   tls_disable = 0
+  #   address = "[::]:8200"
+  #   cluster_address = "[::]:8201"
+  #   tls_cert_file = "/vault/userconfig/vault-tls/tls.crt"
+  #   tls_key_file  = "/vault/userconfig/vault-tls/tls.key"
+  #   tls_client_ca_file = "/vault/userconfig/service-ca-bundle/service-ca.crt"
+  # }
+
   image:
     repository: "hashicorp/vault"
     tag: "1.21.0"


### PR DESCRIPTION
## Summary
Automates OpenShift service-ca operator integration, eliminating manual `oc` commands for TLS certificate setup.

## What Changed
New `server.serviceCA` configuration:
```yaml
server:
  serviceCA:
    enabled: true
    secretName: "vault-tls"
    configMapName: "service-ca-bundle"
```

Automatically creates:
- ConfigMap with CA bundle injection annotation
- Service annotation for certificate generation

## Before/After
**Before:** 5 manual commands (create ConfigMap, annotate, deploy, annotate Service, wait)
**After:** 1 `helm install` command

## Testing
- 13 unit tests (BATS)
- Schema validation added
- Tested on OpenShift 4.x
- Backward compatible (disabled by default)

Fixes: https://github.com/hashicorp/vault-helm/issues/645

## Files
- `values.yaml` - Add serviceCA config
- `values.schema.json` - Add schema
- `templates/server-serviceca-configmap.yaml` - New template
- `templates/server-service.yaml` - Add annotation
- `test/unit/server-serviceca-configmap.bats` - New tests
- `test/unit/server-service.bats` - Update tests
```


## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [x] I have documented a clear reason for, and description of, the change I am making.

- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
