### PR TITLE
Preparing release v0.32.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 Changes:
 
 * Default `vault` version updated to 1.21.2
-* Default `vault-csi-provider` version updated to 1.6.0
+* Default `vault-csi-provider` version updated to 1.7.0
 * Default `vault-k8s` version updated to 1.7.2
 * Tested with Vault versions 1.21-1.19, 1.16
 * Tested with Kubernetes versions 1.35-1.31

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,29 @@
 ## Unreleased
 
+## 0.32.0 (January 14, 2026)
+
 Changes:
 
-* Default `vault` version updated to 1.21.0
+* Default `vault` version updated to 1.21.2
 * Default `vault-csi-provider` version updated to 1.6.0
-* Default `vault-k8s` version updated to 1.7.1
+* Default `vault-k8s` version updated to 1.7.2
 * Tested with Vault versions 1.21-1.19, 1.16
 * Tested with Kubernetes versions 1.35-1.31
 * Test with Kind v0.31.0
+
+Features:
+
+* server: Add OpenShift service-ca operator automation [GH-1165](https://github.com/hashicorp/vault-helm/pull/1165)
+
+Improvements:
+
+* server: Allow users to specify the target service for the ServiceMonitor [GH-1148](https://github.com/hashicorp/vault-helm/pull/1148)
+
+Bugs:
+
+* server: Add namespace to network policy template [GH-1152](https://github.com/hashicorp/vault-helm/pull/1152)
+* server: Check if `disable_mlock` is already set before adding to end of HCL config [GH-1154](https://github.com/hashicorp/vault-helm/pull/1154)
+* server: provide declarative parameters for volumeClaimTemplates [GH-982](https://github.com/hashicorp/vault-helm/pull/982)
 
 ## 0.31.0 (September 25, 2025)
 

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -3,8 +3,8 @@
 
 apiVersion: v2
 name: vault
-version: 0.31.0
-appVersion: 1.20.4
+version: 0.32.0
+appVersion: 1.21.2
 kubeVersion: ">= 1.20.0-0"
 description: Official HashiCorp Vault Chart
 home: https://www.vaultproject.io

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -1,5 +1,5 @@
 {{/*
-Copyright (c) HashiCorp, Inc.
+Copyright IBM Corp. 2018, 2025
 SPDX-License-Identifier: MPL-2.0
 */}}
 

--- a/templates/server-serviceca-configmap.yaml
+++ b/templates/server-serviceca-configmap.yaml
@@ -1,5 +1,5 @@
 {{/*
-Copyright (c) HashiCorp, Inc.
+Copyright IBM Corp. 2018, 2025
 SPDX-License-Identifier: MPL-2.0
 */}}
 
@@ -20,4 +20,3 @@ metadata:
     service.beta.openshift.io/inject-cabundle: "true"
 data: {}
 {{- end }}
-

--- a/values.openshift.yaml
+++ b/values.openshift.yaml
@@ -9,16 +9,16 @@ global:
 injector:
   image:
     repository: "registry.connect.redhat.com/hashicorp/vault-k8s"
-    tag: "1.7.1-ubi"
+    tag: "1.7.2-ubi"
 
   agentImage:
     repository: "registry.connect.redhat.com/hashicorp/vault"
-    tag: "1.21.0-ubi"
+    tag: "1.21.2-ubi"
 
 server:
   image:
     repository: "registry.connect.redhat.com/hashicorp/vault"
-    tag: "1.21.0-ubi"
+    tag: "1.21.2-ubi"
 
   readinessProbe:
     path: "/v1/sys/health?uninitcode=204"
@@ -31,4 +31,4 @@ csi:
   agent:
     image:
       repository: "registry.connect.redhat.com/hashicorp/vault"
-      tag: "1.21.0-ubi"
+      tag: "1.21.2-ubi"

--- a/values.openshift.yaml
+++ b/values.openshift.yaml
@@ -26,7 +26,7 @@ server:
 csi:
   image:
     repository: "registry.connect.redhat.com/hashicorp/vault-csi-provider"
-    tag: "1.6.0-ubi"
+    tag: "1.7.0-ubi"
 
   agent:
     image:

--- a/values.yaml
+++ b/values.yaml
@@ -1140,7 +1140,7 @@ csi:
 
   image:
     repository: "hashicorp/vault-csi-provider"
-    tag: "1.6.0"
+    tag: "1.7.0"
     pullPolicy: IfNotPresent
 
   # volumes is a list of volumes made available to all containers. These are rendered

--- a/values.yaml
+++ b/values.yaml
@@ -68,7 +68,7 @@ injector:
   # image sets the repo and tag of the vault-k8s image to use for the injector.
   image:
     repository: "hashicorp/vault-k8s"
-    tag: "1.7.1"
+    tag: "1.7.2"
     pullPolicy: IfNotPresent
 
   # agentImage sets the repo and tag of the Vault image to use for the Vault Agent
@@ -76,7 +76,7 @@ injector:
   # required.
   agentImage:
     repository: "hashicorp/vault"
-    tag: "1.21.0"
+    tag: "1.21.2"
 
   # The default values for the injected Vault Agent containers.
   agentDefaults:
@@ -417,7 +417,7 @@ server:
 
   image:
     repository: "hashicorp/vault"
-    tag: "1.21.0"
+    tag: "1.21.2"
     # Overrides the default Image Pull Policy
     pullPolicy: IfNotPresent
 
@@ -1231,7 +1231,7 @@ csi:
 
     image:
       repository: "hashicorp/vault"
-      tag: "1.21.0"
+      tag: "1.21.2"
       pullPolicy: IfNotPresent
 
     logFormat: standard


### PR DESCRIPTION
Updating image defaults and changelog for [v0.32.0](https://github.com/hashicorp/vault-helm/milestone/12?closed=1)

---

## 0.32.0 (January 14, 2026)

Changes:

* Default `vault` version updated to 1.21.2
* Default `vault-csi-provider` version updated to 1.7.0
* Default `vault-k8s` version updated to 1.7.2
* Tested with Vault versions 1.21-1.19, 1.16
* Tested with Kubernetes versions 1.35-1.31
* Test with Kind v0.31.0

Features:

* server: Add OpenShift service-ca operator automation [GH-1165](https://github.com/hashicorp/vault-helm/pull/1165)

Improvements:

* server: Allow users to specify the target service for the ServiceMonitor [GH-1148](https://github.com/hashicorp/vault-helm/pull/1148)

Bugs:

* server: Add namespace to network policy template [GH-1152](https://github.com/hashicorp/vault-helm/pull/1152)
* server: Check if `disable_mlock` is already set before adding to end of HCL config [GH-1154](https://github.com/hashicorp/vault-helm/pull/1154)
* server: provide declarative parameters for volumeClaimTemplates [GH-982](https://github.com/hashicorp/vault-helm/pull/982)

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [x] I have documented a clear reason for, and description of, the change I am making.

- [x] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [x] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
