### PR TITLE
Add Vault redundancy zones support 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Unreleased
 
+Features:
+
+* server: Add Vault Enterprise redundancy zones support (requires Kubernetes 1.35+)
+
 ## 0.32.0 (January 14, 2026)
 
 Changes:

--- a/templates/NOTES.txt
+++ b/templates/NOTES.txt
@@ -11,4 +11,37 @@ Your release is named {{ .Release.Name }}. To learn more about the release, try:
 
   $ helm status {{ .Release.Name }}
   $ helm get manifest {{ .Release.Name }}
+{{- if and (eq (.Values.server.ha.raft.redundancyZones.enabled | toString) "true") (not .Values.server.topologySpreadConstraints) }}
+
+##############################################################################
+######   WARNING: Redundancy Zones Enabled Without topologySpreadConstraints
+##############################################################################
+
+You have enabled Vault Enterprise redundancy zones (server.ha.raft.redundancyZones.enabled=true)
+but have not configured topologySpreadConstraints.
+
+The chart's default pod anti-affinity spreads pods across nodes (kubernetes.io/hostname),
+but does NOT guarantee distribution across availability zones.
+
+Without topologySpreadConstraints, Kubernetes may schedule multiple Vault pods
+in the same availability zone, which defeats the purpose of redundancy zones.
+
+To ensure pods are distributed across zones, add topologySpreadConstraints to your values:
+
+  server:
+    topologySpreadConstraints: |
+      - maxSkew: 1
+        topologyKey: topology.kubernetes.io/zone
+        whenUnsatisfiable: DoNotSchedule
+        labelSelector:
+          matchLabels:
+            app.kubernetes.io/name: {{ template "vault.name" . }}
+            app.kubernetes.io/instance: {{ .Release.Name }}
+            component: server
+
+For more information, see:
+https://developer.hashicorp.com/vault/docs/enterprise/redundancy-zones
+
+##############################################################################
+{{- end }}
 

--- a/templates/NOTES.txt
+++ b/templates/NOTES.txt
@@ -26,7 +26,8 @@ but does NOT guarantee distribution across availability zones.
 Without topologySpreadConstraints, Kubernetes may schedule multiple Vault pods
 in the same availability zone, which defeats the purpose of redundancy zones.
 
-To ensure pods are distributed across zones, add topologySpreadConstraints to your values:
+To ensure pods are distributed across zones, add topologySpreadConstraints
+with topologyKey "topology.kubernetes.io/zone" to your values:
 
   server:
     topologySpreadConstraints: |

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -228,7 +228,7 @@ for users looking to use this chart with Consul Helm.
             if [ -n "${VAULT_REDUNDANCY_ZONE}" ]; then
               sed -Ei 's|(\"?autopilot_redundancy_zone\"?[[:space:]]*[=:][[:space:]]*)\"VAULT_REDUNDANCY_ZONE\"|\1\"'"${VAULT_REDUNDANCY_ZONE}"'\"|g' /tmp/storageconfig.hcl;
             else
-              echo "ERROR: Missing zone label on node. Redundancy zones require Kubernetes 1.35+ and nodes labeled with topology.kubernetes.io/zone. Verify: kubectl get nodes -L topology.kubernetes.io/zone" >&2;
+              echo "ERROR: Missing zone label on node. Enabling redundancy zones in vault-helm requires the PodTopologyLabels admission controller (enabled by default in Kubernetes 1.35+) and nodes labeled with topology.kubernetes.io/zone. Verify: kubectl get nodes -L topology.kubernetes.io/zone" >&2;
               exit 1;
             fi;
 {{- else if eq (.Values.server.ha.raft.enabled | toString) "true" }}

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -232,7 +232,7 @@ for users looking to use this chart with Consul Helm.
               exit 1;
             fi;
 {{- else if eq (.Values.server.ha.raft.enabled | toString) "true" }}
-            if grep -qE '(^|[[:space:]])\"?autopilot_redundancy_zone\"?[[:space:]]*[=:][[:space:]]*\"VAULT_REDUNDANCY_ZONE\"' /tmp/storageconfig.hcl; then
+            if grep -vE '^[[:space:]]*(#|//)' /tmp/storageconfig.hcl | grep -qE '\"?autopilot_redundancy_zone\"?[[:space:]]*[=:][[:space:]]*\"VAULT_REDUNDANCY_ZONE\"'; then
               echo "ERROR: autopilot_redundancy_zone placeholder found but server.ha.raft.redundancyZones.enabled=false. Enable the feature or remove the placeholder." >&2;
               exit 1;
             fi;

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -1168,7 +1168,7 @@ Validates redundancy zones configuration:
   {{- $hclMatch := regexMatch "(?m)^(?:[^#/\\n]|/[^/])*autopilot_redundancy_zone\\s*=\\s*\"VAULT_REDUNDANCY_ZONE\"" $config -}}
   {{- $jsonMatch := regexMatch "\"autopilot_redundancy_zone\"\\s*:\\s*\"VAULT_REDUNDANCY_ZONE\"" $config -}}
   {{- if not (or $hclMatch $jsonMatch) -}}
-    {{- fail "server.ha.raft.redundancyZones.enabled=true requires 'autopilot_redundancy_zone = \"VAULT_REDUNDANCY_ZONE\"' (HCL) or '\"autopilot_redundancy_zone\": \"VAULT_REDUNDANCY_ZONE\"' (JSON) in server.ha.raft.config (must not be commented out)" -}}
+    {{- fail "server.ha.raft.redundancyZones.enabled=true requires 'autopilot_redundancy_zone = \"VAULT_REDUNDANCY_ZONE\"' in server.ha.raft.config (must not be commented out)" -}}
   {{- end -}}
 {{- end -}}
 {{- end -}}

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -234,7 +234,7 @@ for users looking to use this chart with Consul Helm.
             if [ -n "${VAULT_REDUNDANCY_ZONE}" ]; then
               sed -Ei 's|(\"?autopilot_redundancy_zone\"?[[:space:]]*[=:][[:space:]]*)\"VAULT_REDUNDANCY_ZONE\"|\1\"'"${VAULT_REDUNDANCY_ZONE}"'\"|g' /tmp/storageconfig.hcl;
             else
-              echo "ERROR: Missing zone label on node. Enabling redundancy zones in vault-helm requires the PodTopologyLabels admission controller (enabled by default in Kubernetes 1.35+) and nodes labeled with topology.kubernetes.io/zone. Verify: kubectl get nodes -L topology.kubernetes.io/zone" >&2;
+              echo "ERROR: Missing zone label on pod. Enabling redundancy zones in vault-helm requires the PodTopologyLabels admission controller (enabled by default in Kubernetes 1.35+) and nodes labeled with topology.kubernetes.io/zone. Verify node labels: kubectl get nodes -L topology.kubernetes.io/zone; verify pod labels: kubectl get pod \${HOSTNAME} -o jsonpath='{.metadata.labels}'" >&2;
               exit 1;
             fi;
 {{- else if eq (.Values.server.ha.raft.enabled | toString) "true" }}
@@ -1158,12 +1158,16 @@ https://github.com/helm/helm/blob/50c22ed7f953fadb32755e5881ba95a92da852b2/pkg/e
 
 {{/*
 Validates redundancy zones configuration:
-1. Requires HA mode enabled
-2. Requires Raft storage enabled
-3. Requires VAULT_REDUNDANCY_ZONE placeholder in config (HCL or JSON)
+1. Requires Kubernetes >= 1.35 (PodTopologyLabelsAdmission)
+2. Requires HA mode enabled
+3. Requires Raft storage enabled
+4. Requires VAULT_REDUNDANCY_ZONE placeholder in config (HCL or JSON)
 */}}
 {{- define "vault.validateRedundancyZones" -}}
 {{- if eq (.Values.server.ha.raft.redundancyZones.enabled | toString) "true" -}}
+  {{- if semverCompare "< 1.35-0" .Capabilities.KubeVersion.Version -}}
+    {{- fail "server.ha.raft.redundancyZones.enabled=true requires Kubernetes >= 1.35 (PodTopologyLabelsAdmission)" -}}
+  {{- end -}}
   {{- if ne (.Values.server.ha.enabled | toString) "true" -}}
     {{- fail "server.ha.raft.redundancyZones.enabled=true requires server.ha.enabled=true" -}}
   {{- end -}}

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -126,14 +126,20 @@ Compute if the ui is enabled.
 
 {{/*
 Compute the maximum number of unavailable replicas for the PodDisruptionBudget.
-This defaults to (n/2)-1 where n is the number of members of the server cluster.
+This defaults to ⌊(n-1)/2⌋ (equivalently, ceil(n/2)-1) where n is the number of
+members of the server cluster.
 Add a special case for replicas=1, where it should default to 0 as well.
+When redundancy zones are enabled, default to 1 because the PDB cannot distinguish
+between voting and non-voting pods. The standard formula may allow enough simultaneous
+evictions to lose quorum among the voting members.
 */}}
 {{- define "vault.pdb.maxUnavailable" -}}
 {{- if eq (int .Values.server.ha.replicas) 1 -}}
 {{ 0 }}
 {{- else if .Values.server.ha.disruptionBudget.maxUnavailable -}}
 {{ .Values.server.ha.disruptionBudget.maxUnavailable -}}
+{{- else if and (eq (.Values.server.ha.raft.enabled | toString) "true") (eq (.Values.server.ha.raft.redundancyZones.enabled | toString) "true") -}}
+{{ 1 }}
 {{- else -}}
 {{- div (sub (div (mul (int .Values.server.ha.replicas) 10) 2) 1) 10 -}}
 {{- end -}}

--- a/templates/server-statefulset.yaml
+++ b/templates/server-statefulset.yaml
@@ -7,6 +7,7 @@ SPDX-License-Identifier: MPL-2.0
 {{- if ne .mode "external" }}
 {{- if ne .mode "" }}
 {{- if .serverEnabled -}}
+{{- include "vault.validateRedundancyZones" . -}}
 # StatefulSet to run the actual vault server cluster.
 apiVersion: apps/v1
 kind: StatefulSet
@@ -126,6 +127,12 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.name
+            {{- end }}
+            {{- if and (eq (.Values.server.ha.raft.enabled | toString) "true") (eq (.Values.server.ha.raft.redundancyZones.enabled | toString) "true") }}
+            - name: VAULT_REDUNDANCY_ZONE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.labels['topology.kubernetes.io/zone']
             {{- end }}
             - name: HOME
               value: "/home/vault"

--- a/test/acceptance/_helpers.bash
+++ b/test/acceptance/_helpers.bash
@@ -187,3 +187,19 @@ wait_for_complete_job() {
     echo "${POD_NAME} never completed."
     return 1
 }
+
+# skip_if_k8s_version_lt skips the test if Kubernetes version is less than the specified version
+# Usage: skip_if_k8s_version_lt "1.35"
+skip_if_k8s_version_lt() {
+    local required_version=$1
+    local required_major=$(echo $required_version | cut -d. -f1)
+    local required_minor=$(echo $required_version | cut -d. -f2)
+
+    local k8s_version=$(kubectl version -o json | jq -r '.serverVersion.gitVersion' | sed 's/v//')
+    local k8s_major=$(echo $k8s_version | cut -d. -f1)
+    local k8s_minor=$(echo $k8s_version | cut -d. -f2)
+
+    if [ "$k8s_major" -lt "$required_major" ] || ([ "$k8s_major" -eq "$required_major" ] && [ "$k8s_minor" -lt "$required_minor" ]); then
+        skip "Test requires Kubernetes >= ${required_version}, current version is ${k8s_version}"
+    fi
+}

--- a/test/acceptance/notes.bats
+++ b/test/acceptance/notes.bats
@@ -6,6 +6,8 @@ load _helpers
 # Redundancy Zones Warning
 
 @test "Notes: redundancy zones: warns when enabled without topologySpreadConstraints" {
+  skip_if_k8s_version_lt "1.35"
+
   cd `chart_dir`
   local result=$(helm install test . \
       --dry-run \
@@ -21,6 +23,8 @@ load _helpers
 }
 
 @test "Notes: redundancy zones: no warning when enabled with topologySpreadConstraints" {
+  skip_if_k8s_version_lt "1.35"
+
   cd `chart_dir`
   local result=$(helm install test . \
       --dry-run \
@@ -37,6 +41,8 @@ load _helpers
 }
 
 @test "Notes: redundancy zones: no warning when disabled" {
+  skip_if_k8s_version_lt "1.35"
+
   cd `chart_dir`
   local result=$(helm install test . \
       --dry-run \

--- a/test/unit/notes.bats
+++ b/test/unit/notes.bats
@@ -5,7 +5,7 @@ load _helpers
 #--------------------------------------------------------------------
 # Redundancy Zones Warning
 
-@test "notes: warns when redundancyZones enabled without topologySpreadConstraints" {
+@test "Notes: redundancy zones: warns when enabled without topologySpreadConstraints" {
   cd `chart_dir`
   local result=$(helm install test . \
       --dry-run \
@@ -20,7 +20,7 @@ load _helpers
   [[ "${result}" == *"topologySpreadConstraints"* ]]
 }
 
-@test "notes: no warning when redundancyZones enabled with topologySpreadConstraints" {
+@test "Notes: redundancy zones: no warning when enabled with topologySpreadConstraints" {
   cd `chart_dir`
   local result=$(helm install test . \
       --dry-run \
@@ -36,7 +36,7 @@ load _helpers
   [[ "${result}" != *"WARNING: Redundancy Zones Enabled Without topologySpreadConstraints"* ]]
 }
 
-@test "notes: no warning when redundancyZones is disabled" {
+@test "Notes: redundancy zones: no warning when disabled" {
   cd `chart_dir`
   local result=$(helm install test . \
       --dry-run \

--- a/test/unit/notes.bats
+++ b/test/unit/notes.bats
@@ -1,0 +1,49 @@
+#!/usr/bin/env bats
+
+load _helpers
+
+#--------------------------------------------------------------------
+# Redundancy Zones Warning
+
+@test "notes: warns when redundancyZones enabled without topologySpreadConstraints" {
+  cd `chart_dir`
+  local result=$(helm install test . \
+      --dry-run \
+      --set 'server.ha.enabled=true' \
+      --set 'server.ha.raft.enabled=true' \
+      --set 'server.ha.raft.redundancyZones.enabled=true' \
+      --set-string 'server.ha.raft.config=storage "raft" { path = "/vault/data" autopilot_redundancy_zone = "VAULT_REDUNDANCY_ZONE" } service_registration "kubernetes" {}' \
+      2>&1 | tee /dev/stderr)
+
+  [[ "${result}" == *"WARNING: Redundancy Zones Enabled Without topologySpreadConstraints"* ]]
+  [[ "${result}" == *"server.ha.raft.redundancyZones.enabled=true"* ]]
+  [[ "${result}" == *"topologySpreadConstraints"* ]]
+}
+
+@test "notes: no warning when redundancyZones enabled with topologySpreadConstraints" {
+  cd `chart_dir`
+  local result=$(helm install test . \
+      --dry-run \
+      --set 'server.ha.enabled=true' \
+      --set 'server.ha.raft.enabled=true' \
+      --set 'server.ha.raft.redundancyZones.enabled=true' \
+      --set 'server.topologySpreadConstraints[0].maxSkew=1' \
+      --set 'server.topologySpreadConstraints[0].topologyKey=topology.kubernetes.io/zone' \
+      --set 'server.topologySpreadConstraints[0].whenUnsatisfiable=DoNotSchedule' \
+      --set-string 'server.ha.raft.config=storage "raft" { path = "/vault/data" autopilot_redundancy_zone = "VAULT_REDUNDANCY_ZONE" } service_registration "kubernetes" {}' \
+      2>&1 | tee /dev/stderr)
+
+  [[ "${result}" != *"WARNING: Redundancy Zones Enabled Without topologySpreadConstraints"* ]]
+}
+
+@test "notes: no warning when redundancyZones is disabled" {
+  cd `chart_dir`
+  local result=$(helm install test . \
+      --dry-run \
+      --set 'server.ha.enabled=true' \
+      --set 'server.ha.raft.enabled=true' \
+      --set 'server.ha.raft.redundancyZones.enabled=false' \
+      2>&1 | tee /dev/stderr)
+
+  [[ "${result}" != *"WARNING: Redundancy Zones Enabled Without topologySpreadConstraints"* ]]
+}

--- a/test/unit/server-ha-disruptionbudget.bats
+++ b/test/unit/server-ha-disruptionbudget.bats
@@ -128,3 +128,46 @@ load _helpers
       yq '.apiVersion == "policy/v1"' | tee /dev/stderr)
   [ "${actual}" = "true" ]
 }
+
+@test "server/DisruptionBudget: redundancy zones: maxUnavailable defaults to 1 with n=6" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/server-disruptionbudget.yaml  \
+      --set 'server.ha.enabled=true' \
+      --set 'server.ha.replicas=6' \
+      --set 'server.ha.raft.enabled=true' \
+      --set 'server.ha.raft.redundancyZones.enabled=true' \
+      --set-string 'server.ha.raft.config=storage "raft" { path = "/vault/data" autopilot_redundancy_zone = "VAULT_REDUNDANCY_ZONE" } service_registration "kubernetes" {}' \
+      . | tee /dev/stderr |
+      yq '.spec.maxUnavailable' | tee /dev/stderr)
+  [ "${actual}" = "1" ]
+}
+
+@test "server/DisruptionBudget: redundancy zones: maxUnavailable defaults to 1 with n=5" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/server-disruptionbudget.yaml  \
+      --set 'server.ha.enabled=true' \
+      --set 'server.ha.replicas=5' \
+      --set 'server.ha.raft.enabled=true' \
+      --set 'server.ha.raft.redundancyZones.enabled=true' \
+      --set-string 'server.ha.raft.config=storage "raft" { path = "/vault/data" autopilot_redundancy_zone = "VAULT_REDUNDANCY_ZONE" } service_registration "kubernetes" {}' \
+      . | tee /dev/stderr |
+      yq '.spec.maxUnavailable' | tee /dev/stderr)
+  [ "${actual}" = "1" ]
+}
+
+@test "server/DisruptionBudget: redundancy zones: explicit maxUnavailable override still works" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/server-disruptionbudget.yaml  \
+      --set 'server.ha.enabled=true' \
+      --set 'server.ha.replicas=6' \
+      --set 'server.ha.raft.enabled=true' \
+      --set 'server.ha.raft.redundancyZones.enabled=true' \
+      --set 'server.ha.disruptionBudget.maxUnavailable=2' \
+      --set-string 'server.ha.raft.config=storage "raft" { path = "/vault/data" autopilot_redundancy_zone = "VAULT_REDUNDANCY_ZONE" } service_registration "kubernetes" {}' \
+      . | tee /dev/stderr |
+      yq '.spec.maxUnavailable' | tee /dev/stderr)
+  [ "${actual}" = "2" ]
+}

--- a/test/unit/server-ha-statefulset.bats
+++ b/test/unit/server-ha-statefulset.bats
@@ -937,45 +937,6 @@ local value=$(echo $rendered |
   [[ "${args}" == *"ERROR: autopilot_redundancy_zone placeholder found but server.ha.raft.redundancyZones.enabled=false"* ]]
 }
 
-@test "server/ha-StatefulSet: redundancy zones: passes with JSON config" {
-  cd `chart_dir`
-  # Using temp values file since --set doesn't handle JSON braces well
-  local values_file=$(mktemp)
-  cat > "${values_file}" <<'EOF'
-server:
-  ha:
-    enabled: true
-    raft:
-      enabled: true
-      redundancyZones:
-        enabled: true
-      config: |
-        {
-          "ui": true,
-          "listener": {
-            "tcp": {
-              "address": "[::]:8200",
-              "cluster_address": "[::]:8201"
-            }
-          },
-          "storage": {
-            "raft": {
-              "path": "/vault/data",
-              "autopilot_redundancy_zone": "VAULT_REDUNDANCY_ZONE"
-            }
-          },
-          "service_registration": {
-            "kubernetes": {}
-          }
-        }
-EOF
-  helm template \
-      --show-only templates/server-statefulset.yaml  \
-      -f "${values_file}" \
-      .
-  rm -f "${values_file}"
-}
-
 @test "server/ha-StatefulSet: redundancy zones: fails when VAULT_REDUNDANCY_ZONE is empty" {
   cd `chart_dir`
   local args=$(helm template \

--- a/test/unit/server-ha-statefulset.bats
+++ b/test/unit/server-ha-statefulset.bats
@@ -841,6 +841,20 @@ local value=$(echo $rendered |
   [[ "${result}" == *"requires server.ha.raft.enabled=true"* ]]
 }
 
+@test "server/ha-StatefulSet: redundancy zones: requires Kubernetes >= 1.35" {
+  cd `chart_dir`
+  local result=$(helm template \
+      --show-only templates/server-statefulset.yaml  \
+      --kube-version 1.34.0 \
+      --set 'server.ha.enabled=true' \
+      --set 'server.ha.raft.enabled=true' \
+      --set 'server.ha.raft.redundancyZones.enabled=true' \
+      --set-string 'server.ha.raft.config=storage "raft" { path = "/vault/data" autopilot_redundancy_zone = "VAULT_REDUNDANCY_ZONE" } service_registration "kubernetes" {}' \
+      . 2>&1 || true)
+
+  [[ "${result}" == *"requires Kubernetes >= 1.35"* ]]
+}
+
 @test "server/ha-StatefulSet: redundancy zones: requires placeholder in config" {
   cd `chart_dir`
   local result=$(helm template \

--- a/values.schema.json
+++ b/values.schema.json
@@ -832,6 +832,17 @@
                                 },
                                 "setNodeId": {
                                     "type": "boolean"
+                                },
+                                "redundancyZones": {
+                                    "type": "object",
+                                    "description": "Vault Enterprise redundancy zones configuration for autopilot. Requires Kubernetes 1.35+ with PodTopologyLabelsAdmission and nodes labeled with topology.kubernetes.io/zone.",
+                                    "properties": {
+                                        "enabled": {
+                                            "type": "boolean",
+                                            "description": "Enable automatic zone detection for Vault Enterprise autopilot redundancy zones.",
+                                            "default": false
+                                        }
+                                    }
                                 }
                             }
                         },

--- a/values.yaml
+++ b/values.yaml
@@ -949,6 +949,22 @@ server:
       # Set the Node Raft ID to the name of the pod
       setNodeId: false
 
+      # Vault Enterprise Redundancy Zones
+      # Enables automatic zone detection for Vault Enterprise autopilot redundancy zones.
+      # Requires:
+      #   - Kubernetes 1.35+ (PodTopologyLabelsAdmission enabled by default)
+      #   - Vault Enterprise
+      #   - server.ha.enabled=true and server.ha.raft.enabled=true
+      #   - Nodes labeled with topology.kubernetes.io/zone
+      #   - VAULT_REDUNDANCY_ZONE placeholder in server.ha.raft.config
+      #   - server.topologySpreadConstraints with topology.kubernetes.io/zone (optional but recommended for proper zone separation)
+      # When enabled, the zone label from the node is exposed as VAULT_REDUNDANCY_ZONE
+      # environment variable and substituted into the raft config.
+      # See: https://developer.hashicorp.com/vault/docs/enterprise/redundancy-zones
+      # @default -- See values.yaml
+      redundancyZones:
+        enabled: false
+
       # Note: Configuration files are stored in ConfigMaps so sensitive data
       # such as passwords should be either mounted through extraSecretEnvironmentVars
       # or through a Kube secret.  For more information see:
@@ -969,6 +985,8 @@ server:
 
         storage "raft" {
           path = "/vault/data"
+          # Uncomment for Vault Enterprise redundancy zones (requires server.ha.raft.redundancyZones.enabled = true)
+          # autopilot_redundancy_zone = "VAULT_REDUNDANCY_ZONE"
         }
 
         service_registration "kubernetes" {}

--- a/values.yaml
+++ b/values.yaml
@@ -961,7 +961,6 @@ server:
       # When enabled, the zone label from the node is exposed as VAULT_REDUNDANCY_ZONE
       # environment variable and substituted into the raft config.
       # See: https://developer.hashicorp.com/vault/docs/enterprise/redundancy-zones
-      # @default -- See values.yaml
       redundancyZones:
         enabled: false
 

--- a/values.yaml
+++ b/values.yaml
@@ -958,8 +958,12 @@ server:
       #   - Nodes labeled with topology.kubernetes.io/zone
       #   - VAULT_REDUNDANCY_ZONE placeholder in server.ha.raft.config
       #   - server.topologySpreadConstraints with topology.kubernetes.io/zone (optional but recommended for proper zone separation)
-      # When enabled, the zone label from the node is exposed as VAULT_REDUNDANCY_ZONE
-      # environment variable and substituted into the raft config.
+      # When enabled:
+      #   - The zone label from the node is exposed as VAULT_REDUNDANCY_ZONE
+      #     environment variable and substituted into the raft config.
+      #   - The PDB maxUnavailable defaults to 1 (instead of ⌊(n-1)/2⌋) because
+      #     the PDB cannot distinguish voting from non-voting pods. Override with
+      #     server.ha.disruptionBudget.maxUnavailable if needed.
       # See: https://developer.hashicorp.com/vault/docs/enterprise/redundancy-zones
       redundancyZones:
         enabled: false
@@ -1036,8 +1040,9 @@ server:
     disruptionBudget:
       enabled: true
 
-    # maxUnavailable will default to (n/2)-1 where n is the number of
-    # replicas. If you'd like a custom value, you can specify an override here.
+    # maxUnavailable will default to ⌊(n-1)/2⌋ (equivalently, ceil(n/2)-1) where
+    # n is the number of replicas. If you'd like a custom value, you can specify
+    # an override here.
       maxUnavailable: null
 
   # Definition of the serviceAccount used to run Vault.


### PR DESCRIPTION
Kubernetes 1.35+ can now expose node topology labels to pods via the Downward API ([KEP-4742](https://github.com/kubernetes/enhancements/issues/4742)). This MR uses that Kubernetes-native feature to add Vault Enterprise [redundancy zone](https://developer.hashicorp.com/vault/docs/enterprise/redundancy-zones) support, so users can deploy Vault clusters the HashiCorp-recommended way for better availability and fault tolerance across zones.

Tested on GKE `1.35.0-gke.1403000` cluster to validate end-to-end functionality.

**Requirements:**
- Vault Enterprise
- Kubernetes 1.35+ 
- server.ha.enabled=true and server.ha.raft.enabled=true
- Nodes labeled with topology.kubernetes.io/zone
- autopilot_redundancy_zone = "VAULT_REDUNDANCY_ZONE" placeholder in server.ha.raft.config

Related issue: https://github.com/hashicorp/vault-helm/issues/1053

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] I have documented a clear reason for, and description of, the change I am making.

- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
