### PR TITLE
Add namespace reader RBAC for Kubernetes auth selector support

### DIFF
--- a/templates/server-namespace-reader-clusterrole.yaml
+++ b/templates/server-namespace-reader-clusterrole.yaml
@@ -1,0 +1,26 @@
+{{/*
+Copyright IBM Corp. 2018, 2025
+SPDX-License-Identifier: MPL-2.0
+*/}}
+
+{{/*
+ClusterRole for reading namespaces - required for Kubernetes auth
+bound_service_account_namespace_selector feature
+*/}}
+
+{{ template "vault.serverAuthDelegator" . }}
+{{- if .serverAuthDelegator -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ template "vault.fullname" . }}-namespace-reader
+  labels:
+    helm.sh/chart: {{ include "vault.chart" . }}
+    app.kubernetes.io/name: {{ include "vault.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+rules:
+  - apiGroups: [""]
+    resources: ["namespaces"]
+    verbs: ["get"]
+{{ end }}

--- a/templates/server-namespace-reader-clusterrolebinding.yaml
+++ b/templates/server-namespace-reader-clusterrolebinding.yaml
@@ -1,0 +1,30 @@
+{{/*
+Copyright IBM Corp. 2018, 2025
+SPDX-License-Identifier: MPL-2.0
+*/}}
+
+{{/*
+ClusterRoleBinding for namespace reader - required for Kubernetes auth
+bound_service_account_namespace_selector feature
+*/}}
+
+{{ template "vault.serverAuthDelegator" . }}
+{{- if .serverAuthDelegator -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ template "vault.fullname" . }}-namespace-reader-binding
+  labels:
+    helm.sh/chart: {{ include "vault.chart" . }}
+    app.kubernetes.io/name: {{ include "vault.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ template "vault.fullname" . }}-namespace-reader
+subjects:
+  - kind: ServiceAccount
+    name: {{ template "vault.serviceAccount.name" . }}
+    namespace: {{ include "vault.namespace" . }}
+{{ end }}

--- a/test/unit/server-namespace-reader-clusterrole.bats
+++ b/test/unit/server-namespace-reader-clusterrole.bats
@@ -1,0 +1,95 @@
+#!/usr/bin/env bats
+
+load _helpers
+
+@test "server/namespace-reader/ClusterRole: enabled by default" {
+  cd `chart_dir`
+  local actual=$( (helm template \
+      --show-only templates/server-namespace-reader-clusterrole.yaml  \
+      --set 'server.dev.enabled=true' \
+      . || echo "---") | tee /dev/stderr | \
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+
+  local actual=$( (helm template \
+      --show-only templates/server-namespace-reader-clusterrole.yaml  \
+      --set 'server.ha.enabled=true' \
+      . || echo "---") | tee /dev/stderr | \
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+
+  local actual=$( (helm template \
+      --show-only templates/server-namespace-reader-clusterrole.yaml  \
+      . || echo "---") | tee /dev/stderr | \
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}
+
+@test "server/namespace-reader/ClusterRole: disable with global.enabled" {
+  cd `chart_dir`
+  local actual=$( (helm template \
+      --show-only templates/server-namespace-reader-clusterrole.yaml  \
+      --set 'global.enabled=false' \
+      . || echo "---") | tee /dev/stderr | \
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+}
+
+@test "server/namespace-reader/ClusterRole: can disable with server.authDelegator" {
+  cd `chart_dir`
+  local actual=$( (helm template \
+      --show-only templates/server-namespace-reader-clusterrole.yaml  \
+      --set 'server.authDelegator.enabled=false' \
+      . || echo "---") | tee /dev/stderr | \
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+
+  local actual=$( (helm template \
+      --show-only templates/server-namespace-reader-clusterrole.yaml  \
+      --set 'server.authDelegator.enabled=false' \
+      --set 'server.ha.enabled=true' \
+      . || echo "---") | tee /dev/stderr | \
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+
+  local actual=$( (helm template \
+      --show-only templates/server-namespace-reader-clusterrole.yaml  \
+      --set 'server.authDelegator.enabled=false' \
+      --set 'server.dev.enabled=true' \
+      . || echo "---") | tee /dev/stderr | \
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+}
+
+@test "server/namespace-reader/ClusterRole: rules contain namespaces resource" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/server-namespace-reader-clusterrole.yaml  \
+      . | tee /dev/stderr | \
+      yq -r '.rules[0].resources[0]' | tee /dev/stderr)
+  [ "${actual}" = "namespaces" ]
+}
+
+@test "server/namespace-reader/ClusterRole: rules contain get verb" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/server-namespace-reader-clusterrole.yaml  \
+      . | tee /dev/stderr | \
+      yq -r '.rules[0].verbs | length' | tee /dev/stderr)
+  [ "${actual}" = "1" ]
+
+  local actual=$(helm template \
+      --show-only templates/server-namespace-reader-clusterrole.yaml  \
+      . | tee /dev/stderr | \
+      yq -r '.rules[0].verbs[0]' | tee /dev/stderr)
+  [ "${actual}" = "get" ]
+}
+
+@test "server/namespace-reader/ClusterRole: correct name" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/server-namespace-reader-clusterrole.yaml  \
+      . | tee /dev/stderr | \
+      yq -r '.metadata.name' | tee /dev/stderr)
+  [ "${actual}" = "release-name-vault-namespace-reader" ]
+}

--- a/test/unit/server-namespace-reader-clusterrolebinding.bats
+++ b/test/unit/server-namespace-reader-clusterrolebinding.bats
@@ -1,0 +1,98 @@
+#!/usr/bin/env bats
+
+load _helpers
+
+@test "server/namespace-reader/ClusterRoleBinding: enabled by default" {
+  cd `chart_dir`
+  local actual=$( (helm template \
+      --show-only templates/server-namespace-reader-clusterrolebinding.yaml  \
+      --set 'server.dev.enabled=true' \
+      . || echo "---") | tee /dev/stderr | \
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+
+  local actual=$( (helm template \
+      --show-only templates/server-namespace-reader-clusterrolebinding.yaml  \
+      --set 'server.ha.enabled=true' \
+      . || echo "---") | tee /dev/stderr | \
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+
+  local actual=$( (helm template \
+      --show-only templates/server-namespace-reader-clusterrolebinding.yaml  \
+      . || echo "---") | tee /dev/stderr | \
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}
+
+@test "server/namespace-reader/ClusterRoleBinding: disable with global.enabled" {
+  cd `chart_dir`
+  local actual=$( (helm template \
+      --show-only templates/server-namespace-reader-clusterrolebinding.yaml  \
+      --set 'global.enabled=false' \
+      . || echo "---") | tee /dev/stderr | \
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+}
+
+@test "server/namespace-reader/ClusterRoleBinding: can disable with server.authDelegator" {
+  cd `chart_dir`
+  local actual=$( (helm template \
+      --show-only templates/server-namespace-reader-clusterrolebinding.yaml  \
+      --set 'server.authDelegator.enabled=false' \
+      . || echo "---") | tee /dev/stderr | \
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+
+  local actual=$( (helm template \
+      --show-only templates/server-namespace-reader-clusterrolebinding.yaml  \
+      --set 'server.authDelegator.enabled=false' \
+      --set 'server.ha.enabled=true' \
+      . || echo "---") | tee /dev/stderr | \
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+
+  local actual=$( (helm template \
+      --show-only templates/server-namespace-reader-clusterrolebinding.yaml  \
+      --set 'server.authDelegator.enabled=false' \
+      --set 'server.dev.enabled=true' \
+      . || echo "---") | tee /dev/stderr | \
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+}
+
+@test "server/namespace-reader/ClusterRoleBinding: service account namespace" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/server-namespace-reader-clusterrolebinding.yaml \
+      --namespace foo \
+      . | tee /dev/stderr | \
+      yq -r '.subjects[0].namespace' | tee /dev/stderr)
+  [ "${actual}" = "foo" ]
+  
+  local actual=$(helm template \
+      --show-only templates/server-namespace-reader-clusterrolebinding.yaml \
+      --set 'global.namespace=bar' \
+      --namespace foo \
+      . | tee /dev/stderr | \
+      yq -r '.subjects[0].namespace' | tee /dev/stderr)
+  [ "${actual}" = "bar" ]
+}
+
+@test "server/namespace-reader/ClusterRoleBinding: roleRef name" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/server-namespace-reader-clusterrolebinding.yaml  \
+      . | tee /dev/stderr | \
+      yq -r '.roleRef.name' | tee /dev/stderr)
+  [ "${actual}" = "release-name-vault-namespace-reader" ]
+}
+
+@test "server/namespace-reader/ClusterRoleBinding: roleRef kind" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/server-namespace-reader-clusterrolebinding.yaml  \
+      . | tee /dev/stderr | \
+      yq -r '.roleRef.kind' | tee /dev/stderr)
+  [ "${actual}" = "ClusterRole" ]
+}


### PR DESCRIPTION
## Problem
When using `bound_service_account_namespace_selector` in Vault's Kubernetes auth method configuration, authentication fails with a 403 error because Vault lacks permissions to read namespace metadata.

### Error Observed
I wanted to use the "Bound service account namespace selector" option as 
`{"matchLabels":{"vault-secrets-operator/enabled":"true"}}`
After creating a "VaultStaticSecret" within a namespace containing the relevant label, I encountered the following logs in the Vault Secrets Operator "VSO" pod logs.
```json
{
  "level": "error",
  "ts": "2026-01-24T18:23:03Z",
  "msg": "Failed to get NewClientWithLogin",
  "error": "Error making API request.\n\nURL: PUT [https://vault-active.vault.svc.cluster.local](https://vault-active.vault.svc.cluster.local):8200/v1/auth/kubernetes/login\nCode: 403. Errors:\n\n* namespace not authorized err=failed to get namespace (code 403 status namespaces \"minio\" is forbidden: User \"system:serviceaccount:vault:vault\" cannot get resource \"namespaces\" in API group \"\" in the namespace \"minio\")"
}
```

## Determination

```
kubectl auth can-i get namespaces --as=system:serviceaccount:vault:vault
Warning: resource 'namespaces' is not namespace scoped
no
```
## Root Cause
To verify namespace labels, Vault must read namespace resources from the Kubernetes API. However, the Helm chart only creates a ClusterRoleBinding for system:auth-delegator (token review), not for namespace reading.

## Solution
- ClusterRole granting get permission on namespaces resources
- Binds the ClusterRole to Vault's ServiceAccount
- Unit tests - 12 tests covering enable/disable conditions and RBAC validation

## Design Decisions
- Minimal permissions: Only get verb (not list or watch) as Vault only needs to read specific namespaces
- Conditional creation: Uses serverAuthDelegator condition - only created when Kubernetes auth is enabled
- No configuration required: Automatically enabled when applicable, no values.yaml changes needed

## Backwards Compatibility
Fully backwards compatible - existing deployments are unaffected.