### PR TITLE
feat: Support extraLabels in Service

### DIFF
--- a/templates/server-service.yaml
+++ b/templates/server-service.yaml
@@ -18,6 +18,9 @@ metadata:
     app.kubernetes.io/name: {{ include "vault.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
+    {{- with .Values.server.service.extraLabels -}}
+      {{- toYaml . | nindent 4 -}}
+    {{- end }}
   annotations:
 {{ template "vault.service.annotations" .}}
 {{- if and .Values.global.openshift .Values.server.serviceCA.enabled }}

--- a/test/unit/server-service.bats
+++ b/test/unit/server-service.bats
@@ -585,3 +585,13 @@ load _helpers
       yq -r '.metadata.annotations["custom-annotation"]' | tee /dev/stderr)
   [ "${custom}" = "custom-value" ]
 }
+
+@test "server/Service: specify extraLabels" {
+  cd `chart_dir`
+  local custom=$(helm template \
+      --show-only templates/server-service.yaml \
+      --set 'server.service.extraLabels.foo=bar' \
+      . | tee /dev/stderr |
+      yq -r '.metadata.labels["foo"]' | tee /dev/stderr)
+  [ "${custom}" = "bar" ]
+}


### PR DESCRIPTION
# Changes

This PR adds support for a new `extraLabels` field on the Vault server Service definition in the Helm chart. The goal is to let users attach additional Kubernetes labels to the Service object that exposes the Vault server. This came up as a requirement when using Teleport product to attach the label `teleport.dev/name: ...`

Currently, it is not possible to attach new labels
See: https://github.com/hashicorp/vault-helm/blob/main/templates/server-service.yaml#L13-L20

Overview:
* A new value `server.service.extraLabels` can be defined in the chart’s values.yaml.
* When set, these labels are merged into the metadata.labels block of the Vault Service resource.
* This does not change defaults; it only takes effect if users explicitly set the `extraLabels` field.


## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [x] I have documented a clear reason for, and description of, the change I am making.

- [x] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [x] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
