### PR TITLE
Update default vault-k8s and vault-csi-provider versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Unreleased
 
+Changes:
+
+* Default `vault-k8s` version updated to 1.7.3
+
 ## 0.32.0 (January 14, 2026)
 
 Changes:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 Changes:
 
 * Default `vault-k8s` version updated to 1.7.3
+* Default `vault-csi-provider` version updated to 1.7.1
 
 ## 0.32.0 (January 14, 2026)
 

--- a/values.openshift.yaml
+++ b/values.openshift.yaml
@@ -26,7 +26,7 @@ server:
 csi:
   image:
     repository: "registry.connect.redhat.com/hashicorp/vault-csi-provider"
-    tag: "1.7.0-ubi"
+    tag: "1.7.1-ubi"
 
   agent:
     image:

--- a/values.openshift.yaml
+++ b/values.openshift.yaml
@@ -9,7 +9,7 @@ global:
 injector:
   image:
     repository: "registry.connect.redhat.com/hashicorp/vault-k8s"
-    tag: "1.7.2-ubi"
+    tag: "1.7.3-ubi"
 
   agentImage:
     repository: "registry.connect.redhat.com/hashicorp/vault"

--- a/values.yaml
+++ b/values.yaml
@@ -1140,7 +1140,7 @@ csi:
 
   image:
     repository: "hashicorp/vault-csi-provider"
-    tag: "1.7.0"
+    tag: "1.7.1"
     pullPolicy: IfNotPresent
 
   # volumes is a list of volumes made available to all containers. These are rendered

--- a/values.yaml
+++ b/values.yaml
@@ -68,7 +68,7 @@ injector:
   # image sets the repo and tag of the vault-k8s image to use for the injector.
   image:
     repository: "hashicorp/vault-k8s"
-    tag: "1.7.2"
+    tag: "1.7.3"
     pullPolicy: IfNotPresent
 
   # agentImage sets the repo and tag of the Vault image to use for the Vault Agent


### PR DESCRIPTION
Update the default vault-k8s version to the [v1.7.3](https://github.com/hashicorp/vault-k8s/releases/tag/v1.7.3) release and the default vault-csi-provider version to the [v1.7.1](https://github.com/hashicorp/vault-csi-provider/releases/tag/v1.7.1) release.

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [x] I have documented a clear reason for, and description of, the change I am making.

- [x] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [x] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.

<!-- VAULT-42344 -->