### PR TITLE
server: add per-service annotations for main and internal services

### DIFF
--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -725,7 +725,11 @@ Sets extra route annotations
 {{- end -}}
 
 {{/*
-Sets extra vault server Service annotations
+Sets extra vault server Service annotations.
+These are applied to all services: main, internal, active, and standby.
+Use the per-service annotation templates (vault.service.main.annotations,
+vault.service.internal.annotations, vault.service.active.annotations,
+vault.service.standby.annotations) to target a specific service.
 */}}
 {{- define "vault.service.annotations" -}}
   {{- if .Values.server.service.annotations }}
@@ -734,6 +738,34 @@ Sets extra vault server Service annotations
       {{- tpl .Values.server.service.annotations . | nindent 4 }}
     {{- else }}
       {{- toYaml .Values.server.service.annotations | nindent 4 }}
+    {{- end }}
+  {{- end }}
+{{- end -}}
+
+{{/*
+Sets extra vault server Service annotations for the main service
+*/}}
+{{- define "vault.service.main.annotations" -}}
+  {{- if .Values.server.service.main.annotations }}
+    {{- $tp := typeOf .Values.server.service.main.annotations }}
+    {{- if eq $tp "string" }}
+      {{- tpl .Values.server.service.main.annotations . | nindent 4 }}
+    {{- else }}
+      {{- toYaml .Values.server.service.main.annotations | nindent 4 }}
+    {{- end }}
+  {{- end }}
+{{- end -}}
+
+{{/*
+Sets extra vault server Service annotations for the internal headless service
+*/}}
+{{- define "vault.service.internal.annotations" -}}
+  {{- if .Values.server.service.internal.annotations }}
+    {{- $tp := typeOf .Values.server.service.internal.annotations }}
+    {{- if eq $tp "string" }}
+      {{- tpl .Values.server.service.internal.annotations . | nindent 4 }}
+    {{- else }}
+      {{- toYaml .Values.server.service.internal.annotations | nindent 4 }}
     {{- end }}
   {{- end }}
 {{- end -}}

--- a/templates/server-headless-service.yaml
+++ b/templates/server-headless-service.yaml
@@ -21,6 +21,7 @@ metadata:
     vault-internal: "true"
   annotations:
 {{ template "vault.service.annotations" .}}
+{{ template "vault.service.internal.annotations" .}}
 spec:
   {{- if (semverCompare ">= 1.23-0" .Capabilities.KubeVersion.Version) }}
   {{- if .Values.server.service.ipFamilyPolicy }}

--- a/templates/server-service.yaml
+++ b/templates/server-service.yaml
@@ -20,6 +20,7 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
   annotations:
 {{ template "vault.service.annotations" .}}
+{{ template "vault.service.main.annotations" .}}
 {{- if and .Values.global.openshift .Values.server.serviceCA.enabled }}
     service.beta.openshift.io/serving-cert-secret-name: {{ .Values.server.serviceCA.secretName | quote }}
 {{- end }}

--- a/test/unit/server-headless-service.bats
+++ b/test/unit/server-headless-service.bats
@@ -2,6 +2,66 @@
 
 load _helpers
 
+@test "server/headless-Service: internal annotations string" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/server-headless-service.yaml \
+      --set 'server.service.internal.annotations=vaultIsAwesome: true' \
+      . | tee /dev/stderr |
+      yq -r '.metadata.annotations["vaultIsAwesome"]' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}
+
+@test "server/headless-Service: internal annotations yaml" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/server-headless-service.yaml \
+      --set 'server.service.internal.annotations.vaultIsAwesome=true' \
+      . | tee /dev/stderr |
+      yq -r '.metadata.annotations["vaultIsAwesome"]' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}
+
+@test "server/headless-Service: with both generic and internal annotations set" {
+  cd `chart_dir`
+  local object=$(helm template \
+      --show-only templates/server-headless-service.yaml \
+      --set 'server.service.internal.annotations=vaultIsAwesome: true' \
+      --set 'server.service.annotations=vaultIsNotAwesome: false' \
+      . | tee /dev/stderr |
+      yq -r '.metadata' | tee /dev/stderr)
+
+  local actual=$(echo "$object" | yq '.annotations["vaultIsAwesome"]' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+  actual=$(echo "$object" | yq '.annotations["vaultIsNotAwesome"]' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+}
+
+@test "server/headless-Service: internal annotations override generic annotations" {
+  cd "$(chart_dir)"
+  local metadata
+  metadata=$(helm template \
+      --show-only templates/server-headless-service.yaml \
+      --set 'server.service.internal.annotations=myAnnotation: internal' \
+      --set 'server.service.annotations=myAnnotation: general' \
+      . | tee /dev/stderr |
+      yq -r '.metadata' | tee /dev/stderr)
+
+  local actual
+  actual=$(echo "$metadata" | yq -r '.annotations["myAnnotation"]' | tee /dev/stderr)
+  [ "${actual}" = "internal" ]
+}
+
+@test "server/headless-Service: internal annotations not applied to main service" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/server-service.yaml \
+      --set 'server.service.internal.annotations=vaultIsAwesome: true' \
+      . | tee /dev/stderr |
+      yq -r '.metadata.annotations["vaultIsAwesome"]' | tee /dev/stderr)
+  [ "${actual}" = "null" ]
+}
+
 @test "server/headless-Service: publishNotReadyAddresses cannot be changed" {
   cd `chart_dir`
   local actual=$(helm template \

--- a/test/unit/server-service.bats
+++ b/test/unit/server-service.bats
@@ -172,6 +172,66 @@ load _helpers
   [ "${actual}" = "true" ]
 }
 
+@test "server/Service: main annotations string" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/server-service.yaml \
+      --set 'server.service.main.annotations=vaultIsAwesome: true' \
+      . | tee /dev/stderr |
+      yq -r '.metadata.annotations["vaultIsAwesome"]' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}
+
+@test "server/Service: main annotations yaml" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/server-service.yaml \
+      --set 'server.service.main.annotations.vaultIsAwesome=true' \
+      . | tee /dev/stderr |
+      yq -r '.metadata.annotations["vaultIsAwesome"]' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}
+
+@test "server/Service: with both generic and main annotations set" {
+  cd `chart_dir`
+  local object=$(helm template \
+      --show-only templates/server-service.yaml \
+      --set 'server.service.main.annotations=vaultIsAwesome: true' \
+      --set 'server.service.annotations=vaultIsNotAwesome: false' \
+      . | tee /dev/stderr |
+      yq -r '.metadata' | tee /dev/stderr)
+
+  local actual=$(echo "$object" | yq '.annotations["vaultIsAwesome"]' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+  actual=$(echo "$object" | yq '.annotations["vaultIsNotAwesome"]' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+}
+
+@test "server/Service: main annotations override generic annotations" {
+  cd "$(chart_dir)"
+  local metadata
+  metadata=$(helm template \
+      --show-only templates/server-service.yaml \
+      --set 'server.service.main.annotations=myAnnotation: main' \
+      --set 'server.service.annotations=myAnnotation: general' \
+      . | tee /dev/stderr |
+      yq -r '.metadata' | tee /dev/stderr)
+
+  local actual
+  actual=$(echo "$metadata" | yq -r '.annotations["myAnnotation"]' | tee /dev/stderr)
+  [ "${actual}" = "main" ]
+}
+
+@test "server/Service: main annotations not applied to headless service" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/server-headless-service.yaml \
+      --set 'server.service.main.annotations=vaultIsAwesome: true' \
+      . | tee /dev/stderr |
+      yq -r '.metadata.annotations["vaultIsAwesome"]' | tee /dev/stderr)
+  [ "${actual}" = "null" ]
+}
+
 @test "server/Service: publish not ready" {
   cd `chart_dir`
   local actual=$(helm template \

--- a/values.schema.json
+++ b/values.schema.json
@@ -1137,6 +1137,28 @@
                                 }
                             }
                         },
+                        "main": {
+                            "type": "object",
+                            "properties": {
+                                "annotations": {
+                                    "type": [
+                                        "object",
+                                        "string"
+                                    ]
+                                }
+                            }
+                        },
+                        "internal": {
+                            "type": "object",
+                            "properties": {
+                                "annotations": {
+                                    "type": [
+                                        "object",
+                                        "string"
+                                    ]
+                                }
+                            }
+                        },
                         "standbyNodePort": {
                             "type": "integer"
                         },

--- a/values.yaml
+++ b/values.yaml
@@ -746,6 +746,16 @@ server:
       # YAML-formatted multi-line templated string map of the annotations to apply
       # to the standby service.
       annotations: {}
+    # Extra annotations for the main service definition. This can either be
+    # YAML or a YAML-formatted multi-line templated string map of the
+    # annotations to apply to the main service.
+    main:
+      annotations: {}
+    # Extra annotations for the internal headless service definition. This can
+    # either be YAML or a YAML-formatted multi-line templated string map of the
+    # annotations to apply to the internal service.
+    internal:
+      annotations: {}
     # If enabled, the service selectors will include `app.kubernetes.io/instance: {{ .Release.Name }}`
     # When disabled, services may select Vault pods not deployed from the chart.
     # Does not affect the headless vault-internal service with `ClusterIP: None`


### PR DESCRIPTION
PR #896 added per-service annotation support for the HA active and standby services (server.service.active.annotations and server.service.standby.annotations), partially addressing issue #674. However, it left out two services that still only received the generic server.service.annotations:

  - The main service (server-service.yaml): the primary client-facing service, rendered in every deployment mode (standalone, dev, and HA).
  - The internal headless service (server-headless-service.yaml): the ClusterIP=None service used for pod DNS and Raft join operations.

Without per-service annotations on these two services, setting server.service.annotations applies to *all* four services. This makes it impossible to, for example, set different annotations on the main service versus the internal headless service which is the problem that was described in issue 674 and which I am hitting as well.

This commit adds:

  - server.service.main.annotations: annotations applied only to the main service (server-service.yaml), merged after (and overriding) the generic server.service.annotations.
  - server.service.internal.annotations: annotations applied only to the internal headless service (server-headless-service.yaml), with the same merge/override semantics.

"main" was chosen over "nonha" because this service is rendered in all deployment modes, not just non-HA.

Closes: #647

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [x] I have documented a clear reason for, and description of, the change I am making.

- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
