### PR TITLE
Make the audit and data storage PVCs configurable

### DIFF
--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -244,24 +244,38 @@ Set's additional environment variables based on the mode.
 {{- end -}}
 
 {{/*
+gets the configured audit storage name
+*/}}
+{{- define "vault.auditStorageName" }}
+{{- .Values.server.auditStorage.name | default "audit" }}
+{{- end }}
+
+{{/*
+gets the configured data storage name
+*/}}
+{{- define "vault.dataStorageName" }}
+{{- .Values.server.dataStorage.name | default "data" }}
+{{- end }}
+
+{{/*
 Set's which additional volumes should be mounted to the container
 based on the mode configured.
 */}}
 {{- define "vault.mounts" -}}
-  {{ if eq (.Values.server.auditStorage.enabled | toString) "true" }}
-            - name: audit
+  {{- if eq (.Values.server.auditStorage.enabled | toString) "true" }}
+            - name: {{ include "vault.auditStorageName" . }}
               mountPath: {{ .Values.server.auditStorage.mountPath }}
-  {{ end }}
-  {{ if or (eq .mode "standalone") (and (eq .mode "ha") (eq (.Values.server.ha.raft.enabled | toString) "true"))  }}
-    {{ if eq (.Values.server.dataStorage.enabled | toString) "true" }}
-            - name: data
+  {{- end }}
+  {{- if or (eq .mode "standalone") (and (eq .mode "ha") (eq (.Values.server.ha.raft.enabled | toString) "true"))  }}
+    {{- if eq (.Values.server.dataStorage.enabled | toString) "true" }}
+            - name: {{ include "vault.dataStorageName" . }}
               mountPath: {{ .Values.server.dataStorage.mountPath }}
-    {{ end }}
-  {{ end }}
-  {{ if and (ne .mode "dev") (or (.Values.server.standalone.config)  (.Values.server.ha.config)) }}
+    {{- end }}
+  {{- end }}
+  {{- if and (ne .mode "dev") (or (.Values.server.standalone.config)  (.Values.server.ha.config)) }}
             - name: config
               mountPath: /vault/config
-  {{ end }}
+  {{- end }}
   {{- range .Values.server.extraVolumes }}
             - name: userconfig-{{ .name }}
               readOnly: true

--- a/test/unit/server-statefulset.bats
+++ b/test/unit/server-statefulset.bats
@@ -517,6 +517,27 @@ load _helpers
       yq -r '.spec.template.spec.containers[0].volumeMounts[] | select(.name == "audit")' | tee /dev/stderr)
 }
 
+@test "server-standalone-StatefulSet: can customize audit pvc name" {
+  cd `chart_dir`
+  local object=$(helm template \
+      --show-only templates/server-statefulset.yaml  \
+      --set 'server.auditStorage.enabled=true' \
+      --set 'server.auditStorage.name=customAudit' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.containers[0].volumeMounts[] | select(.name == "customAudit")' | tee /dev/stderr)
+}
+
+@test "server-standalone-StatefulSet: can customize data pvc name" {
+  cd `chart_dir`
+  local object=$(helm template \
+      --show-only templates/server-statefulset.yaml  \
+      --set 'server.dataStorage.enabled=true' \
+      --set 'server.dataStorage.name=customData' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.containers[0].volumeMounts[] | select(.name == "customData")' | tee /dev/stderr)
+}
+
+
 #--------------------------------------------------------------------
 # volumes
 

--- a/values.schema.json
+++ b/values.schema.json
@@ -662,6 +662,9 @@
                         "mountPath": {
                             "type": "string"
                         },
+                        "name": {
+                            "type": "string"
+                        },
                         "size": {
                             "type": "string"
                         },
@@ -706,6 +709,9 @@
                             ]
                         },
                         "mountPath": {
+                            "type": "string"
+                        },
+                        "name": {
                             "type": "string"
                         },
                         "size": {

--- a/values.yaml
+++ b/values.yaml
@@ -817,6 +817,8 @@ server:
   # See https://developer.hashicorp.com/vault/docs/configuration/storage to know more
   dataStorage:
     enabled: true
+    # name of data PVC
+    name: data
     # Size of the PVC created
     size: 10Gi
     # Location where the PVC will be mounted.
@@ -846,6 +848,8 @@ server:
   # See https://developer.hashicorp.com/vault/docs/audit to know more
   auditStorage:
     enabled: false
+    # name of audit PVC
+    name: audit
     # Size of the PVC created
     size: 10Gi
     # Location where the PVC will be mounted.


### PR DESCRIPTION
== DETAILS
The use case here is for migrating from a home-grown Vault kubernetes deployment to using the official Helm chart.

Our home-grown deployment used a different name for the statefulset PVCs ("raft" instead of "data"). While it is certainly possible to do some kubernetes magic to rename the existing PVCs, doing so would require some downtime and risks an extended outage if things go sideways.

It would be much less risky if the chart provided a way to specify the name of the PVC, so that we can point it at our existing data with minimal fuss.

This commit provides this functionality in the following way:

- add a `name` field under `.server.auditStorage` and `.server.dataStorage`
- updates `values.yaml` to set these to a default that matches the hardcoded default names
- updates the templates to look up the name provided in values instead of using the hardcoded names

unit tests are included to validate this functionality works as expected.

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [x] I have documented a clear reason for, and description of, the change I am making.
- [x] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [x] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
