### PR TITLE
fix(server): add IPC_LOCK capability to default container securityContext for Vault 2.0.1+

### DIFF
--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -603,6 +603,9 @@ securityContext for the statefulset vault container
   {{- else if not .Values.global.openshift }}
           securityContext:
             allowPrivilegeEscalation: false
+            capabilities:
+              add:
+                - IPC_LOCK
   {{- end }}
 {{- end -}}
 


### PR DESCRIPTION
 - Vault 2.0.1 introduced a breaking change: the cap_ipc_lock file capability is no longer set on the vault binary at image build time, so the container runtime must grant IPC_LOCK instead. 
[https://github.com/hashicorp/vault/blob/main/CHANGELOG.md?plain=1#L8C1-L11C1](https://github.com/hashicorp/vault/blob/main/CHANGELOG.md?plain=1#L8C1-L11C1)
  - This change adds a Linux capability (IPC_LOCK) to the Vault server container. 

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [x] I have documented a clear reason for, and description of, the change I am making.

- [x] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [x] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
