### PR TITLE
httproute resource addition

### DIFF
--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -687,6 +687,21 @@ Sets extra ingress annotations
 {{- end -}}
 
 {{/*
+Sets extra httproute annotations
+*/}}
+{{- define "vault.httproute.annotations" -}}
+  {{- if .Values.server.httproute.annotations }}
+  annotations:
+    {{- $tp := typeOf .Values.server.httproute.annotations }}
+    {{- if eq $tp "string" }}
+      {{- tpl .Values.server.httproute.annotations . | nindent 4 }}
+    {{- else }}
+      {{- toYaml .Values.server.httproute.annotations | nindent 4 }}
+    {{- end }}
+  {{- end }}
+{{- end -}}
+
+{{/*
 Sets extra route annotations
 */}}
 {{- define "vault.route.annotations" -}}

--- a/templates/server-httproute.yaml
+++ b/templates/server-httproute.yaml
@@ -1,0 +1,58 @@
+{{/*
+Copyright (c) HashiCorp, Inc.
+SPDX-License-Identifier: MPL-2.0
+*/}}
+
+{{- if not .Values.global.openshift }}
+{{ template "vault.mode" . }}
+{{- if ne .mode "external" }}
+{{- if .Values.server.httproute.enabled -}}
+{{- $serviceName := include "vault.fullname" . -}}
+{{- template "vault.serverServiceEnabled" . -}}
+{{- if .serverServiceEnabled -}}
+{{- if and (eq .mode "ha" ) (eq (.Values.server.httproute.activeService | toString) "true") }}
+{{- $serviceName = printf "%s-%s" $serviceName "active" -}}
+{{- end }}
+{{- $servicePort := .Values.server.service.port -}}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ template "vault.fullname" . }}
+  namespace: {{ include "vault.namespace" . }}
+  labels:
+    helm.sh/chart: {{ include "vault.chart" . }}
+    app.kubernetes.io/name: {{ include "vault.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    {{- with .Values.server.httproute.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- template "vault.httproute.annotations" . }}
+spec:
+  {{- with .Values.server.httproute.parentRefs }}
+  parentRefs:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.server.httproute.hostnames }}
+  hostnames:
+    {{- tpl (toYaml .) $ | nindent 4 }}
+  {{- end }}
+  rules:
+    {{- if .Values.server.httproute.additionalRules }}
+    {{- tpl (toYaml .Values.server.httproute.additionalRules) $ | nindent 4 }}
+    {{- end }}
+    - backendRefs:
+        - name: {{ $serviceName }}
+          port: {{ $servicePort }}
+      {{- with .Values.server.httproute.filters }}
+      filters:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.server.httproute.matches }}
+      matches:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+  {{- end }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/test/unit/server-httproute.bats
+++ b/test/unit/server-httproute.bats
@@ -1,0 +1,364 @@
+#!/usr/bin/env bats
+
+load _helpers
+
+@test "server/httproute: disabled by default" {
+  cd `chart_dir`
+  local actual=$( (helm template \
+      --show-only templates/server-httproute.yaml  \
+      . || echo "---") | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+}
+
+@test "server/httproute: namespace" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/server-httproute.yaml  \
+      --set 'server.httproute.enabled=true' \
+      --namespace foo \
+      . | tee /dev/stderr |
+      yq -r '.metadata.namespace' | tee /dev/stderr)
+  [ "${actual}" = "foo" ]
+  local actual=$(helm template \
+      --show-only templates/server-httproute.yaml  \
+      --set 'server.httproute.enabled=true' \
+      --set 'global.namespace=bar' \
+      --namespace foo \
+      . | tee /dev/stderr |
+      yq -r '.metadata.namespace' | tee /dev/stderr)
+  [ "${actual}" = "bar" ]
+}
+
+@test "server/httproute: disable by injector.externalVaultAddr" {
+  cd `chart_dir`
+  local actual=$( (helm template \
+      --show-only templates/server-httproute.yaml  \
+      --set 'server.httproute.enabled=true' \
+      --set 'injector.externalVaultAddr=http://vault-outside' \
+      . || echo "---") | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+}
+
+@test "server/httproute: checking host entry gets added and path is /" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/server-httproute.yaml \
+      --set 'server.httproute.enabled=true' \
+      --set 'server.httproute.hostnames[0]=test.com' \
+      --set 'server.httproute.matches.path[0].type=PathPrefix' \
+      --set 'server.httproute.matches.path[0].value=/' \
+      . | tee /dev/stderr |
+      yq  -r '.spec.hostnames[0]' | tee /dev/stderr)
+  [ "${actual}" = 'test.com' ]
+
+  local actual=$(helm template \
+      --show-only templates/server-httproute.yaml \
+      --set 'server.httproute.enabled=true' \
+      --set 'server.httproute.hostnames[0]=test.com' \
+      --set 'server.httproute.matches.path[0].type=PathPrefix' \
+      --set 'server.httproute.matches.path[0].value=/' \
+      . | tee /dev/stderr |
+      yq  -r '.spec.rules[0].matches.path[0].value' | tee /dev/stderr)
+  [ "${actual}" = '/' ]
+}
+
+@test "server/httproute: checking custom matches path" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/server-httproute.yaml \
+      --set 'server.httproute.enabled=true' \
+      --set 'server.httproute.matches.path[0].type=PathPrefix' \
+      --set 'server.httproute.matches.path[0].value=/foo/' \
+      . | tee /dev/stderr |
+      yq  -r '.spec.rules[0].matches.path[0].type' | tee /dev/stderr)
+  [ "${actual}" = 'PathPrefix' ]
+
+  local actual=$(helm template \
+      --show-only templates/server-httproute.yaml \
+      --set 'server.httproute.enabled=true' \
+      --set 'server.httproute.hostnames[0]=test.com' \
+      --set 'server.httproute.matches.path[0].type=PathPrefix' \
+      --set 'server.httproute.matches.path[0].value=/foo/' \
+      . | tee /dev/stderr |
+      yq  -r '.spec.rules[0].matches.path[0].value' | tee /dev/stderr)
+  [ "${actual}" = '/foo/' ]
+}
+
+@test "server/httproute: vault backend should be added when I specify a path" {
+  cd `chart_dir`
+
+  local actual=$(helm template \
+      --show-only templates/server-httproute.yaml \
+      --set 'server.httproute.enabled=true' \
+      --set 'server.httproute.hostnames[0]=test.com' \
+      --set 'server.httproute.matches.path[0].type=PathPrefix' \
+      --set 'server.httproute.matches.path[0].value=/' \
+      . | tee /dev/stderr |
+      yq  -r '.spec.rules[0].backendRefs[0].name  | length > 0' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+
+}
+
+@test "server/httproute: labels gets added to object" {
+  cd `chart_dir`
+
+  local actual=$(helm template \
+      --show-only templates/server-httproute.yaml \
+      --set 'server.httproute.enabled=true' \
+      --set 'server.httproute.labels.traffic=external' \
+      --set 'server.httproute.labels.team=dev' \
+      . | tee /dev/stderr |
+      yq -r '.metadata.labels.traffic' | tee /dev/stderr)
+  [ "${actual}" = "external" ]
+}
+
+@test "server/httproute: annotations added to object - string" {
+  cd `chart_dir`
+
+  local actual=$(helm template \
+      --show-only templates/server-httproute.yaml \
+      --set 'server.httproute.enabled=true' \
+      --set 'server.httproute.annotations=kubernetes.io/httproute.class: nginx' \
+      . | tee /dev/stderr |
+      yq -r '.metadata.annotations["kubernetes.io/httproute.class"]' | tee /dev/stderr)
+  [ "${actual}" = "nginx" ]
+}
+
+@test "server/httproute: annotations added to object - yaml" {
+  cd `chart_dir`
+
+  local actual=$(helm template \
+      --show-only templates/server-httproute.yaml \
+      --set 'server.httproute.enabled=true' \
+      --set server.httproute.annotations."kubernetes\.io/httproute\.class"=nginx \
+      . | tee /dev/stderr |
+      yq -r '.metadata.annotations["kubernetes.io/httproute.class"]' | tee /dev/stderr)
+  [ "${actual}" = "nginx" ]
+}
+
+@test "server/httproute: parentRefs added to object spec" {
+  cd `chart_dir`
+
+  local actual=$(helm template \
+      --show-only templates/server-httproute.yaml \
+      --set 'server.httproute.enabled=true' \
+      --set server.httproute.parentRefs[0].name=test-gateway \
+      --set server.httproute.parentRefs[0].namespace=test-ns \
+      . | tee /dev/stderr |
+      yq -r '.spec.parentRefs[0].name' | tee /dev/stderr)
+  [ "${actual}" = "test-gateway" ]
+
+  local actual=$(helm template \
+      --show-only templates/server-httproute.yaml \
+      --set 'server.httproute.enabled=true' \
+      --set server.httproute.parentRefs[0].name=test-gateway \
+      --set server.httproute.parentRefs[0].namespace=test-ns \
+      . | tee /dev/stderr |
+      yq -r '.spec.parentRefs[0].namespace' | tee /dev/stderr)
+  [ "${actual}" = "test-ns" ]  
+}
+
+@test "server/httproute: parentRefs not added by default" {
+  cd `chart_dir`
+
+  local actual=$(helm template \
+      --show-only templates/server-httproute.yaml \
+      --set 'server.httproute.enabled=true' \
+      . | tee /dev/stderr |
+      yq -r '.spec.parentRefs[0]' | tee /dev/stderr)
+  [ "${actual}" = "null" ]
+}
+
+
+@test "server/httproute: uses active service when ha by default - yaml" {
+  cd `chart_dir`
+
+  local actual=$(helm template \
+      --show-only templates/server-httproute.yaml \
+      --set 'server.httproute.enabled=true' \
+      --set 'server.dev.enabled=false' \
+      --set 'server.ha.enabled=true' \
+      --set 'server.service.enabled=true' \
+      . | tee /dev/stderr |
+      yq -r '.spec.rules[0].backendRefs[0].name' | tee /dev/stderr)
+  [ "${actual}" = "release-name-vault-active" ]
+}
+
+@test "server/httproute: uses regular service when configured with ha - yaml" {
+  cd `chart_dir`
+
+  local actual=$(helm template \
+      --show-only templates/server-httproute.yaml \
+      --set 'server.httproute.enabled=true' \
+      --set 'server.httproute.activeService=false' \
+      --set 'server.dev.enabled=false' \
+      --set 'server.ha.enabled=true' \
+      --set 'server.service.enabled=true' \
+      . | tee /dev/stderr |
+      yq -r '.spec.rules[0].backendRefs[0].name' | tee /dev/stderr)
+  [ "${actual}" = "release-name-vault" ]
+}
+
+@test "server/httproute: uses regular service when not ha - yaml" {
+  cd `chart_dir`
+
+  local actual=$(helm template \
+      --show-only templates/server-httproute.yaml \
+      --set 'server.httproute.enabled=true' \
+      --set 'server.dev.enabled=false' \
+      --set 'server.ha.enabled=false' \
+      --set 'server.service.enabled=true' \
+      . | tee /dev/stderr |
+      yq -r '.spec.rules[0].backendRefs[0].name' | tee /dev/stderr)
+  [ "${actual}" = "release-name-vault" ]
+}
+
+@test "server/httproute: k8s 1.26.3 uses correct service format when not ha - yaml" {
+  cd `chart_dir`
+
+  local actual=$(helm template \
+      --show-only templates/server-httproute.yaml \
+      --set 'server.httproute.enabled=true' \
+      --set 'server.dev.enabled=false' \
+      --set 'server.ha.enabled=false' \
+      --set 'server.service.enabled=true' \
+      --kube-version 1.26.3 \
+      . | tee /dev/stderr |
+      yq -r '.spec.rules[0].backendRefs[0].name' | tee /dev/stderr)
+  [ "${actual}" = "release-name-vault" ]
+}
+
+@test "server/httproute: uses regular service when not ha and activeService is true - yaml" {
+  cd `chart_dir`
+
+  local actual=$(helm template \
+      --show-only templates/server-httproute.yaml \
+      --set 'server.httproute.enabled=true' \
+      --set 'server.httproute.activeService=true' \
+      --set 'server.dev.enabled=false' \
+      --set 'server.ha.enabled=false' \
+      --set 'server.service.enabled=true' \
+      . | tee /dev/stderr |
+      yq -r '.spec.rules[0].backendRefs[0].name' | tee /dev/stderr)
+  [ "${actual}" = "release-name-vault" ]
+}
+
+@test "server/httproute: checking custom filters" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/server-httproute.yaml \
+      --set 'server.httproute.enabled=true' \
+      --set 'server.httproute.filters[0].type=RequestHeaderModifier' \
+      --set 'server.httproute.filters[0].requestHeaderModifier.set[0].name=test-header-name' \
+      --set 'server.httproute.filters[0].requestHeaderModifier.set[0].value=new-test-header-value' \
+      . | tee /dev/stderr |
+      yq  -r '.spec.rules[0].filters[0].type' | tee /dev/stderr)
+  [ "${actual}" = 'RequestHeaderModifier' ]
+
+  local actual=$(helm template \
+      --show-only templates/server-httproute.yaml \
+      --set 'server.httproute.enabled=true' \
+      --set 'server.httproute.filters[0].type=RequestHeaderModifier' \
+      --set 'server.httproute.filters[0].requestHeaderModifier.set[0].name=test-header-name' \
+      --set 'server.httproute.filters[0].requestHeaderModifier.set[0].value=new-test-header-value' \
+      . | tee /dev/stderr |
+      yq  -r '.spec.rules[0].filters[0].requestHeaderModifier.set[0].name' | tee /dev/stderr)
+  [ "${actual}" = 'test-header-name' ]
+
+  local actual=$(helm template \
+      --show-only templates/server-httproute.yaml \
+      --set 'server.httproute.enabled=true' \
+      --set 'server.httproute.filters[0].type=RequestHeaderModifier' \
+      --set 'server.httproute.filters[0].requestHeaderModifier.set[0].name=test-header-name' \
+      --set 'server.httproute.filters[0].requestHeaderModifier.set[0].value=new-test-header-value' \
+      . | tee /dev/stderr |
+      yq  -r '.spec.rules[0].filters[0].requestHeaderModifier.set[0].value' | tee /dev/stderr)
+  [ "${actual}" = 'new-test-header-value' ]
+}
+
+@test "server/httproute: filters not added by default" {
+  cd `chart_dir`
+
+  local actual=$(helm template \
+      --show-only templates/server-httproute.yaml \
+      --set 'server.httproute.enabled=true' \
+      . | tee /dev/stderr |
+      yq -r '.spec.rules[0].filters[0]' | tee /dev/stderr)
+  [ "${actual}" = "null" ]
+}
+
+@test "server/httproute: checking fullyCustomizedRule" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/server-httproute.yaml \
+      --set 'server.httproute.enabled=true' \
+      --set 'server.httproute.additionalRules[0].filters[0].type=RequestHeaderModifier' \
+      --set 'server.httproute.additionalRules[0].filters[0].requestHeaderModifier.set[0].name=test-header-name' \
+      --set 'server.httproute.additionalRules[0].filters[0].requestHeaderModifier.set[0].value=new-test-header-value' \
+      --set 'server.httproute.additionalRules[0].matches[0].path.type=PathPrefix' \
+      --set 'server.httproute.additionalRules[0].matches[0].path.value=/foo/' \
+      . | tee /dev/stderr |
+      yq  -r '.spec.rules[0].filters[0].type' | tee /dev/stderr)
+  [ "${actual}" = 'RequestHeaderModifier' ]
+
+  local actual=$(helm template \
+      --show-only templates/server-httproute.yaml \
+      --set 'server.httproute.enabled=true' \
+      --set 'server.httproute.additionalRules[0].filters[0].type=RequestHeaderModifier' \
+      --set 'server.httproute.additionalRules[0].filters[0].requestHeaderModifier.set[0].name=test-header-name' \
+      --set 'server.httproute.additionalRules[0].filters[0].requestHeaderModifier.set[0].value=new-test-header-value' \
+      --set 'server.httproute.additionalRules[0].matches[0].path.type=PathPrefix' \
+      --set 'server.httproute.additionalRules[0].matches[0].path.value=/foo/' \
+      . | tee /dev/stderr |
+      yq  -r '.spec.rules[0].filters[0].requestHeaderModifier.set[0].name' | tee /dev/stderr)
+  [ "${actual}" = 'test-header-name' ]
+
+  local actual=$(helm template \
+      --show-only templates/server-httproute.yaml \
+      --set 'server.httproute.enabled=true' \
+      --set 'server.httproute.additionalRules[0].filters[0].type=RequestHeaderModifier' \
+      --set 'server.httproute.additionalRules[0].filters[0].requestHeaderModifier.set[0].name=test-header-name' \
+      --set 'server.httproute.additionalRules[0].filters[0].requestHeaderModifier.set[0].value=new-test-header-value' \
+      --set 'server.httproute.additionalRules[0].matches[0].path.type=PathPrefix' \
+      --set 'server.httproute.additionalRules[0].matches[0].path.value=/foo/' \
+      . | tee /dev/stderr |
+      yq  -r '.spec.rules[0].filters[0].requestHeaderModifier.set[0].value' | tee /dev/stderr)
+  [ "${actual}" = 'new-test-header-value' ]
+
+  local actual=$(helm template \
+      --show-only templates/server-httproute.yaml \
+      --set 'server.httproute.enabled=true' \
+      --set 'server.httproute.additionalRules[0].filters[0].type=RequestHeaderModifier' \
+      --set 'server.httproute.additionalRules[0].filters[0].requestHeaderModifier.set[0].name=test-header-name' \
+      --set 'server.httproute.additionalRules[0].filters[0].requestHeaderModifier.set[0].value=new-test-header-value' \
+      --set 'server.httproute.additionalRules[0].matches[0].path.type=PathPrefix' \
+      --set 'server.httproute.additionalRules[0].matches[0].path.value=/foo/' \
+      . | tee /dev/stderr |
+      yq  -r '.spec.rules[0].matches[0].path.type' | tee /dev/stderr)
+  [ "${actual}" = 'PathPrefix' ]
+
+  local actual=$(helm template \
+      --show-only templates/server-httproute.yaml \
+      --set 'server.httproute.enabled=true' \
+      --set 'server.httproute.additionalRules[0].filters[0].type=RequestHeaderModifier' \
+      --set 'server.httproute.additionalRules[0].filters[0].requestHeaderModifier.set[0].name=test-header-name' \
+      --set 'server.httproute.additionalRules[0].filters[0].requestHeaderModifier.set[0].value=new-test-header-value' \
+      --set 'server.httproute.additionalRules[0].matches[0].path.type=PathPrefix' \
+      --set 'server.httproute.additionalRules[0].matches[0].path.value=/foo/' \
+      . | tee /dev/stderr |
+      yq  -r '.spec.rules[0].matches[0].path.value' | tee /dev/stderr)
+  [ "${actual}" = '/foo/' ]
+}
+
+@test "server/httproute: additionalRules not added by default" {
+  cd `chart_dir`
+
+  local actual=$(helm template \
+      --show-only templates/server-httproute.yaml \
+      --set 'server.httproute.enabled=true' \
+      . | tee /dev/stderr |
+      yq -r '.spec.rules[1]' | tee /dev/stderr)
+  [ "${actual}" = "null" ]
+}

--- a/test/unit/server-httproute.bats
+++ b/test/unit/server-httproute.bats
@@ -2,6 +2,7 @@
 
 load _helpers
 
+# Verifies the HTTPRoute template is not rendered unless explicitly enabled.
 @test "server/httproute: disabled by default" {
   cd `chart_dir`
   local actual=$( (helm template \
@@ -11,6 +12,7 @@ load _helpers
   [ "${actual}" = "false" ]
 }
 
+# Verifies namespace selection and that global.namespace overrides the release namespace.
 @test "server/httproute: namespace" {
   cd `chart_dir`
   local actual=$(helm template \
@@ -30,6 +32,7 @@ load _helpers
   [ "${actual}" = "bar" ]
 }
 
+# Verifies HTTPRoute rendering is disabled when injector.externalVaultAddr is configured.
 @test "server/httproute: disable by injector.externalVaultAddr" {
   cd `chart_dir`
   local actual=$( (helm template \
@@ -41,6 +44,7 @@ load _helpers
   [ "${actual}" = "false" ]
 }
 
+# Verifies hostnames are rendered and the configured root path (/) match is preserved.
 @test "server/httproute: checking host entry gets added and path is /" {
   cd `chart_dir`
   local actual=$(helm template \
@@ -64,6 +68,7 @@ load _helpers
   [ "${actual}" = '/' ]
 }
 
+# Verifies custom path match type and value are rendered in rule matches.
 @test "server/httproute: checking custom matches path" {
   cd `chart_dir`
   local actual=$(helm template \
@@ -86,6 +91,7 @@ load _helpers
   [ "${actual}" = '/foo/' ]
 }
 
+# Verifies a Vault backendRef is rendered when a route match/path is configured.
 @test "server/httproute: vault backend should be added when I specify a path" {
   cd `chart_dir`
 
@@ -101,6 +107,7 @@ load _helpers
 
 }
 
+# Verifies custom labels are added to HTTPRoute metadata.
 @test "server/httproute: labels gets added to object" {
   cd `chart_dir`
 
@@ -114,6 +121,7 @@ load _helpers
   [ "${actual}" = "external" ]
 }
 
+# Verifies annotations supplied as a string are parsed into metadata.annotations.
 @test "server/httproute: annotations added to object - string" {
   cd `chart_dir`
 
@@ -126,6 +134,7 @@ load _helpers
   [ "${actual}" = "nginx" ]
 }
 
+# Verifies annotations with escaped dotted keys are rendered correctly.
 @test "server/httproute: annotations added to object - yaml" {
   cd `chart_dir`
 
@@ -138,6 +147,7 @@ load _helpers
   [ "${actual}" = "nginx" ]
 }
 
+# Verifies configured parentRefs are rendered in spec.parentRefs.
 @test "server/httproute: parentRefs added to object spec" {
   cd `chart_dir`
 
@@ -160,6 +170,7 @@ load _helpers
   [ "${actual}" = "test-ns" ]  
 }
 
+# Verifies parentRefs are omitted when not explicitly configured.
 @test "server/httproute: parentRefs not added by default" {
   cd `chart_dir`
 
@@ -172,6 +183,7 @@ load _helpers
 }
 
 
+# Verifies HA mode defaults backendRef service selection to the active service.
 @test "server/httproute: uses active service when ha by default - yaml" {
   cd `chart_dir`
 
@@ -186,6 +198,7 @@ load _helpers
   [ "${actual}" = "release-name-vault-active" ]
 }
 
+# Verifies HA mode can be configured to use the regular service instead of active.
 @test "server/httproute: uses regular service when configured with ha - yaml" {
   cd `chart_dir`
 
@@ -201,6 +214,7 @@ load _helpers
   [ "${actual}" = "release-name-vault" ]
 }
 
+# Verifies non-HA mode uses the regular Vault service backend.
 @test "server/httproute: uses regular service when not ha - yaml" {
   cd `chart_dir`
 
@@ -215,6 +229,7 @@ load _helpers
   [ "${actual}" = "release-name-vault" ]
 }
 
+# Verifies backend service reference formatting remains correct on Kubernetes 1.26.3.
 @test "server/httproute: k8s 1.26.3 uses correct service format when not ha - yaml" {
   cd `chart_dir`
 
@@ -230,6 +245,7 @@ load _helpers
   [ "${actual}" = "release-name-vault" ]
 }
 
+# Verifies activeService does not alter backend selection when HA is disabled.
 @test "server/httproute: uses regular service when not ha and activeService is true - yaml" {
   cd `chart_dir`
 
@@ -245,6 +261,7 @@ load _helpers
   [ "${actual}" = "release-name-vault" ]
 }
 
+# Verifies custom rule filters are rendered, including header name and value.
 @test "server/httproute: checking custom filters" {
   cd `chart_dir`
   local actual=$(helm template \
@@ -278,6 +295,7 @@ load _helpers
   [ "${actual}" = 'new-test-header-value' ]
 }
 
+# Verifies filters are omitted when not configured.
 @test "server/httproute: filters not added by default" {
   cd `chart_dir`
 
@@ -289,6 +307,7 @@ load _helpers
   [ "${actual}" = "null" ]
 }
 
+# Verifies fully customized additionalRules are rendered with filters and path matches.
 @test "server/httproute: checking fullyCustomizedRule" {
   cd `chart_dir`
   local actual=$(helm template \
@@ -352,6 +371,7 @@ load _helpers
   [ "${actual}" = '/foo/' ]
 }
 
+# Verifies no additionalRules are rendered by default.
 @test "server/httproute: additionalRules not added by default" {
   cd `chart_dir`
 

--- a/test/unit/server-httproute.bats
+++ b/test/unit/server-httproute.bats
@@ -47,8 +47,8 @@ load _helpers
       --show-only templates/server-httproute.yaml \
       --set 'server.httproute.enabled=true' \
       --set 'server.httproute.hostnames[0]=test.com' \
-      --set 'server.httproute.matches.path[0].type=PathPrefix' \
-      --set 'server.httproute.matches.path[0].value=/' \
+      --set 'server.httproute.matches[0].path.type=PathPrefix' \
+      --set 'server.httproute.matches[0].path.value=/' \
       . | tee /dev/stderr |
       yq  -r '.spec.hostnames[0]' | tee /dev/stderr)
   [ "${actual}" = 'test.com' ]
@@ -57,10 +57,10 @@ load _helpers
       --show-only templates/server-httproute.yaml \
       --set 'server.httproute.enabled=true' \
       --set 'server.httproute.hostnames[0]=test.com' \
-      --set 'server.httproute.matches.path[0].type=PathPrefix' \
-      --set 'server.httproute.matches.path[0].value=/' \
+      --set 'server.httproute.matches[0].path.type=PathPrefix' \
+      --set 'server.httproute.matches[0].path.value=/' \
       . | tee /dev/stderr |
-      yq  -r '.spec.rules[0].matches.path[0].value' | tee /dev/stderr)
+      yq  -r '.spec.rules[0].matches[0].path.value' | tee /dev/stderr)
   [ "${actual}" = '/' ]
 }
 
@@ -69,20 +69,20 @@ load _helpers
   local actual=$(helm template \
       --show-only templates/server-httproute.yaml \
       --set 'server.httproute.enabled=true' \
-      --set 'server.httproute.matches.path[0].type=PathPrefix' \
-      --set 'server.httproute.matches.path[0].value=/foo/' \
+      --set 'server.httproute.matches[0].path.type=PathPrefix' \
+      --set 'server.httproute.matches[0].path.value=/foo/' \
       . | tee /dev/stderr |
-      yq  -r '.spec.rules[0].matches.path[0].type' | tee /dev/stderr)
+      yq  -r '.spec.rules[0].matches[0].path.type' | tee /dev/stderr)
   [ "${actual}" = 'PathPrefix' ]
 
   local actual=$(helm template \
       --show-only templates/server-httproute.yaml \
       --set 'server.httproute.enabled=true' \
       --set 'server.httproute.hostnames[0]=test.com' \
-      --set 'server.httproute.matches.path[0].type=PathPrefix' \
-      --set 'server.httproute.matches.path[0].value=/foo/' \
+      --set 'server.httproute.matches[0].path.type=PathPrefix' \
+      --set 'server.httproute.matches[0].path.value=/foo/' \
       . | tee /dev/stderr |
-      yq  -r '.spec.rules[0].matches.path[0].value' | tee /dev/stderr)
+      yq  -r '.spec.rules[0].matches[0].path.value' | tee /dev/stderr)
   [ "${actual}" = '/foo/' ]
 }
 
@@ -93,8 +93,8 @@ load _helpers
       --show-only templates/server-httproute.yaml \
       --set 'server.httproute.enabled=true' \
       --set 'server.httproute.hostnames[0]=test.com' \
-      --set 'server.httproute.matches.path[0].type=PathPrefix' \
-      --set 'server.httproute.matches.path[0].value=/' \
+      --set 'server.httproute.matches[0].path.type=PathPrefix' \
+      --set 'server.httproute.matches[0].path.value=/' \
       . | tee /dev/stderr |
       yq  -r '.spec.rules[0].backendRefs[0].name  | length > 0' | tee /dev/stderr)
   [ "${actual}" = "true" ]

--- a/values.schema.json
+++ b/values.schema.json
@@ -846,6 +846,44 @@
                 "hostNetwork": {
                     "type": "boolean"
                 },
+                "httproute": {
+                    "type": "object",
+                    "properties": {
+                        "activeService": {
+                            "type": "boolean"
+                        },
+                        "additionalRules": {
+                            "type": "array"
+                        },
+                        "annotations": {
+                            "type": [
+                                "object",
+                                "string"
+                            ]
+                        },
+                        "enabled": {
+                            "type": "boolean"
+                        },
+                        "filters": {
+                            "type": "array"
+                        },
+                        "hostnames": {
+                            "type": "array"
+                        },
+                        "labels": {
+                            "type": "object"
+                        },
+                        "matches": {
+                            "type": [
+                                "array",
+                                "object"
+                            ]
+                        },
+                        "parentRefs": {
+                            "type": "array"
+                        }
+                    }
+                },
                 "image": {
                     "type": "object",
                     "properties": {

--- a/values.schema.json
+++ b/values.schema.json
@@ -874,10 +874,8 @@
                             "type": "object"
                         },
                         "matches": {
-                            "type": [
-                                "array",
-                                "object"
-                            ]
+                            "type":
+                                "array"
                         },
                         "parentRefs": {
                             "type": "array"

--- a/values.yaml
+++ b/values.yaml
@@ -444,6 +444,30 @@ server:
     #    hosts:
     #      - chart-example.local
 
+  httproute:
+    enabled: false
+    labels: {}
+    annotations: {}
+
+    activeService: true
+    
+    hostnames: []
+      # - host-example
+    
+    parentRefs: []
+      # - name: vault-gateway-example
+      #   namespace: example-ns
+    
+    matches:
+      - path:
+          type: PathPrefix
+          value: /
+    ## Filters define the filters that are applied to requests that match this rule.
+    filters: []
+
+    ## Additional custom rules that can be added to the route
+    additionalRules: []
+
   # hostAliases is a list of aliases to be added to /etc/hosts. Specified as a YAML list.
   hostAliases: []
   # - ip: 127.0.0.1


### PR DESCRIPTION
## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

This PR adds support for the Gateway API's httproute resource, which can now be used alongside the existing ingress API resource.

- [x] I have documented a clear reason for, and description of, the change I am making.

- [x] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [x] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
