### PR TITLE
Prepare release v0.33.0

### DIFF
--- a/.github/actions/acceptance-test/action.yaml
+++ b/.github/actions/acceptance-test/action.yaml
@@ -18,7 +18,7 @@ inputs:
     default: 'vault-helm'
   bats-version:
     description: 'Version of bats to run tests with'
-    default: '1.12.0'
+    default: '1.13.0'
   vault-license:
     description: 'Vault license to use for enterprise tests'
     required: true
@@ -33,7 +33,7 @@ runs:
         cluster_name: ${{ inputs.kind-cluster-name }}
         config: test/kind/config.yaml
         node_image: kindest/node:v${{ inputs.k8s-version }}
-        version: "v0.31.0"
+        version: "v0.32.0"
 
     - name: Create kind export log root
       id: create_kind_export_log_root

--- a/.github/workflows/acceptance.yaml
+++ b/.github/workflows/acceptance.yaml
@@ -6,15 +6,15 @@ jobs:
     steps:
       - run: echo "setting versions"
     outputs:
-      K8S_1: "1.35.0"
-      K8S_2: "1.34.3"
-      K8S_3: "1.33.7"
-      K8S_4: "1.32.11"
-      K8S_5: "1.31.14"
-      VAULT_N: "1.21.2"
-      VAULT_N_1: "1.20.7"
-      VAULT_N_2: "1.19.13"
-      VAULT_LTS_1: "1.16.29"
+      K8S_1: "1.36.1"
+      K8S_2: "1.35.5"
+      K8S_3: "1.34.8"
+      K8S_4: "1.33.12"
+      K8S_5: "1.32.11"
+      VAULT_N: "2.0.2"
+      VAULT_N_1: "1.21.7"
+      VAULT_N_2: "1.20.12"
+      VAULT_LTS_1: "1.19.18"
 
   kind-ce-vault:
     name: ce vault:${{ matrix.vault-version }} k8s:${{ matrix.k8s-version }}

--- a/.github/workflows/acceptance.yaml
+++ b/.github/workflows/acceptance.yaml
@@ -32,7 +32,7 @@ jobs:
           - ${{ needs.versions.outputs.K8S_4 }}
           - ${{ needs.versions.outputs.K8S_5 }}
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - uses: ./.github/actions/acceptance-test
         name: vault:${{ matrix.vault-version }} kind:${{ matrix.k8s-version }}
         with:
@@ -60,7 +60,7 @@ jobs:
           - ${{ needs.versions.outputs.K8S_4 }}
           - ${{ needs.versions.outputs.K8S_5 }}
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - uses: ./.github/actions/acceptance-test
         name: vault:${{ matrix.vault-version }} kind:${{ matrix.k8s-version }}
         with:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -4,7 +4,7 @@ jobs:
   bats-unit-tests:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - uses: ./.github/actions/setup-test-tools
       - run: bats --tap --timing ./test/unit
   chart-verifier:
@@ -12,7 +12,7 @@ jobs:
     env:
       CHART_VERIFIER_VERSION: '1.13.12'
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Setup test tools
         uses: ./.github/actions/setup-test-tools
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0

--- a/.github/workflows/update-helm-charts-index.yml
+++ b/.github/workflows/update-helm-charts-index.yml
@@ -11,7 +11,7 @@ jobs:
   update-helm-charts-index:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: verify Chart version matches tag version
         run: |-
           export TAG=${{ github.ref_name }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,6 @@ Changes:
 * Tested with Bats v1.13.0
 * build(deps): Bump actions/setup-go from 6.0.0 to 6.4.0 in the github-actions-backward-compatible group: [#1159](https://github.com/hashicorp/vault-helm/pull/1159)
 * build(deps): Bump actions/checkout from 5.0.1 to 6.0.2 in the github-actions-breaking group: [#1182](https://github.com/hashicorp/vault-helm/pull/1182)
-* Add consumption team as code owners: [#1181](https://github.com/hashicorp/vault-helm/pull/1181)
 * Dependency update for actions/checkout from 6.0.2 to 6.0.3. Cherry-picked from [#1187](https://github.com/hashicorp/vault-helm/pull/1187)
 
 Features:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 0.33.0 (June 8, 2026)
 
 Changes:
+
 * Default `vault` version updated to v2.0.2
 * Default `vault-csi-provider` version updated to v1.7.2
 * Default `vault-k8s` version updated to v1.7.4
@@ -11,9 +12,10 @@ Changes:
 * build(deps): Bump actions/setup-go from 6.0.0 to 6.4.0 in the github-actions-backward-compatible group: [#1159](https://github.com/hashicorp/vault-helm/pull/1159)
 * build(deps): Bump actions/checkout from 5.0.1 to 6.0.2 in the github-actions-breaking group: [#1182](https://github.com/hashicorp/vault-helm/pull/1182)
 * Add consumption team as code owners: [#1181](https://github.com/hashicorp/vault-helm/pull/1181)
-* Dependency update for actions/checkout from 6.0.2 to 6.0.3
+* Dependency update for actions/checkout from 6.0.2 to 6.0.3. Cherry-picked from [#1187](https://github.com/hashicorp/vault-helm/pull/1187)
 
 Features:
+
 * Add Vault Enterprise redundancy zones support (requires Kubernetes 1.35+) [#1170](https://github.com/hashicorp/vault-helm/pull/1170)
 
 ## 0.32.0 (January 14, 2026)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ Changes:
 * Dependency update for actions/checkout from 6.0.2 to 6.0.3
 
 Features:
-* server: Add Vault Enterprise redundancy zones support (requires Kubernetes 1.35+) [#1170](https://github.com/hashicorp/vault-helm/pull/1170)
+* Add Vault Enterprise redundancy zones support (requires Kubernetes 1.35+) [#1170](https://github.com/hashicorp/vault-helm/pull/1170)
 
 ## 0.32.0 (January 14, 2026)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,13 @@ Changes:
 * Tested with Kubernetes versions v1.36-1.32
 * Tested with Kind v0.32.0
 * Tested with Bats v1.13.0
+* build(deps): Bump actions/setup-go from 6.0.0 to 6.4.0 in the github-actions-backward-compatible group: [#1159](https://github.com/hashicorp/vault-helm/pull/1159)
+* build(deps): Bump actions/checkout from 5.0.1 to 6.0.2 in the github-actions-breaking group: [#1182](https://github.com/hashicorp/vault-helm/pull/1182)
+* Add consumption team as code owners: [#1181](https://github.com/hashicorp/vault-helm/pull/1181)
+* Dependency update for actions/checkout from 6.0.2 to 6.0.3
 
 Features:
-
-* server: Add Vault Enterprise redundancy zones support (requires Kubernetes 1.35+)
+* server: Add Vault Enterprise redundancy zones support (requires Kubernetes 1.35+) [#1170](https://github.com/hashicorp/vault-helm/pull/1170)
 
 ## 0.32.0 (January 14, 2026)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,13 @@
-## Unreleased
+## 0.33.0 (June 8, 2026)
+
+Changes:
+* Default `vault` version updated to v2.0.2
+* Default `vault-csi-provider` version updated to v1.7.2
+* Default `vault-k8s` version updated to v1.7.4
+* Tested with Vault v2.0.2, v1.21-v1.19
+* Tested with Kubernetes versions v1.36-1.32
+* Tested with Kind v0.32.0
+* Tested with Bats v1.13.0
 
 Features:
 

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -3,7 +3,7 @@
 
 apiVersion: v2
 name: vault
-version: 0.33.0
+version: 0.32.1
 appVersion: 2.0.0
 kubeVersion: ">= 1.20.0-0"
 description: Official HashiCorp Vault Chart

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -3,8 +3,8 @@
 
 apiVersion: v2
 name: vault
-version: 0.32.0
-appVersion: 1.21.2
+version: 0.33.0
+appVersion: 2.0.0
 kubeVersion: ">= 1.20.0-0"
 description: Official HashiCorp Vault Chart
 home: https://www.vaultproject.io

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -3,7 +3,7 @@
 
 apiVersion: v2
 name: vault
-version: 0.32.1
+version: 0.33.0
 appVersion: 2.0.0
 kubeVersion: ">= 1.20.0-0"
 description: Official HashiCorp Vault Chart

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -4,7 +4,7 @@
 apiVersion: v2
 name: vault
 version: 0.33.0
-appVersion: 2.0.0
+appVersion: 2.0.2
 kubeVersion: ">= 1.20.0-0"
 description: Official HashiCorp Vault Chart
 home: https://www.vaultproject.io

--- a/values.openshift.yaml
+++ b/values.openshift.yaml
@@ -9,16 +9,16 @@ global:
 injector:
   image:
     repository: "registry.connect.redhat.com/hashicorp/vault-k8s"
-    tag: "1.7.2-ubi"
+    tag: "1.7.4-ubi"
 
   agentImage:
     repository: "registry.connect.redhat.com/hashicorp/vault"
-    tag: "1.21.2-ubi"
+    tag: "2.0.0-ubi"
 
 server:
   image:
     repository: "registry.connect.redhat.com/hashicorp/vault"
-    tag: "1.21.2-ubi"
+    tag: "2.0.0-ubi"
 
   readinessProbe:
     path: "/v1/sys/health?uninitcode=204"
@@ -26,9 +26,9 @@ server:
 csi:
   image:
     repository: "registry.connect.redhat.com/hashicorp/vault-csi-provider"
-    tag: "1.7.0-ubi"
+    tag: "1.7.1-ubi"
 
   agent:
     image:
       repository: "registry.connect.redhat.com/hashicorp/vault"
-      tag: "1.21.2-ubi"
+      tag: "2.0.0-ubi"

--- a/values.openshift.yaml
+++ b/values.openshift.yaml
@@ -13,12 +13,12 @@ injector:
 
   agentImage:
     repository: "registry.connect.redhat.com/hashicorp/vault"
-    tag: "2.0.0-ubi"
+    tag: "2.0.2-ubi"
 
 server:
   image:
     repository: "registry.connect.redhat.com/hashicorp/vault"
-    tag: "2.0.0-ubi"
+    tag: "2.0.2-ubi"
 
   readinessProbe:
     path: "/v1/sys/health?uninitcode=204"
@@ -26,9 +26,9 @@ server:
 csi:
   image:
     repository: "registry.connect.redhat.com/hashicorp/vault-csi-provider"
-    tag: "1.7.1-ubi"
+    tag: "1.7.2-ubi"
 
   agent:
     image:
       repository: "registry.connect.redhat.com/hashicorp/vault"
-      tag: "2.0.0-ubi"
+      tag: "2.0.2-ubi"

--- a/values.yaml
+++ b/values.yaml
@@ -68,7 +68,7 @@ injector:
   # image sets the repo and tag of the vault-k8s image to use for the injector.
   image:
     repository: "hashicorp/vault-k8s"
-    tag: "1.7.2"
+    tag: "1.7.4"
     pullPolicy: IfNotPresent
 
   # agentImage sets the repo and tag of the Vault image to use for the Vault Agent
@@ -76,7 +76,7 @@ injector:
   # required.
   agentImage:
     repository: "hashicorp/vault"
-    tag: "1.21.2"
+    tag: "2.0.0"
 
   # The default values for the injected Vault Agent containers.
   agentDefaults:
@@ -417,7 +417,7 @@ server:
 
   image:
     repository: "hashicorp/vault"
-    tag: "1.21.2"
+    tag: "2.0.0"
     # Overrides the default Image Pull Policy
     pullPolicy: IfNotPresent
 
@@ -1162,7 +1162,7 @@ csi:
 
   image:
     repository: "hashicorp/vault-csi-provider"
-    tag: "1.7.0"
+    tag: "1.7.1"
     pullPolicy: IfNotPresent
 
   # volumes is a list of volumes made available to all containers. These are rendered
@@ -1253,7 +1253,7 @@ csi:
 
     image:
       repository: "hashicorp/vault"
-      tag: "1.21.2"
+      tag: "2.0.0"
       pullPolicy: IfNotPresent
 
     logFormat: standard

--- a/values.yaml
+++ b/values.yaml
@@ -76,7 +76,7 @@ injector:
   # required.
   agentImage:
     repository: "hashicorp/vault"
-    tag: "2.0.0"
+    tag: "2.0.2"
 
   # The default values for the injected Vault Agent containers.
   agentDefaults:
@@ -417,7 +417,7 @@ server:
 
   image:
     repository: "hashicorp/vault"
-    tag: "2.0.0"
+    tag: "2.0.2"
     # Overrides the default Image Pull Policy
     pullPolicy: IfNotPresent
 
@@ -1162,7 +1162,7 @@ csi:
 
   image:
     repository: "hashicorp/vault-csi-provider"
-    tag: "1.7.1"
+    tag: "1.7.2"
     pullPolicy: IfNotPresent
 
   # volumes is a list of volumes made available to all containers. These are rendered
@@ -1253,7 +1253,7 @@ csi:
 
     image:
       repository: "hashicorp/vault"
-      tag: "2.0.0"
+      tag: "2.0.2"
       pullPolicy: IfNotPresent
 
     logFormat: standard


### PR DESCRIPTION
## Description
**Changes:**
- Default `vault` version updated to v2.0.2
- Default `vault-csi-provider` version updated to v1.7.2
- Default `vault-k8s` version updated to v1.7.4
- Tested with Vault v2.0.2, v1.21-v1.19
- Tested with Kubernetes versions v1.36-1.32
- Tested with Kind v0.32.0
- Tested with Bats v1.13.0
- build(deps): Bump actions/setup-go from 6.0.0 to 6.4.0 in the github-actions-backward-compatible group: https://github.com/hashicorp/vault-helm/pull/1159
- build(deps): Bump actions/checkout from 5.0.1 to 6.0.2 in the github-actions-breaking group: https://github.com/hashicorp/vault-helm/pull/1182
- Add consumption team as code owners: https://github.com/hashicorp/vault-helm/pull/1181
- Dependency update for actions/checkout from 6.0.2 to 6.0.3

**Features:**
- Add Vault Enterprise redundancy zones support (requires Kubernetes 1.35+) https://github.com/hashicorp/vault-helm/pull/1170

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [x] I have documented a clear reason for, and description of, the change I am making.

- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
