### PR TITLE
fix(notes): append -n flag for non-default namespaces in helm hint

### DIFF
--- a/templates/NOTES.txt
+++ b/templates/NOTES.txt
@@ -9,8 +9,9 @@ https://developer.hashicorp.com/vault/docs
 
 Your release is named {{ .Release.Name }}. To learn more about the release, try:
 
-  $ helm status {{ .Release.Name }}
-  $ helm get manifest {{ .Release.Name }}
+  $ helm status {{ .Release.Name }} {{- if and .Release.Namespace (ne .Release.Namespace "default") }} -n {{ .Release.Namespace }} {{- end }}
+  $ helm get manifest {{ .Release.Name }} {{- if and .Release.Namespace (ne .Release.Namespace "default") }} -n {{ .Release.Namespace }} {{- end }}
+
 {{- if and (eq (.Values.server.ha.raft.redundancyZones.enabled | toString) "true") (not .Values.server.topologySpreadConstraints) }}
 
 ##############################################################################


### PR DESCRIPTION
Using the Helm chart to install into a different namespace results in incorrect status output because the generated Helm hint assumes the release namespace. This PR fixes the issue by ensuring namespace handling is consistent with the actual release context.

Additionally, the `-n` flag is not required for the default namespace, and this is now handled correctly by conditionally including the namespace only when it is explicitly set.