### PR TITLE
feat: add global.imageRegistry to prefix all chart images 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 Features:
 
+* Add `global.imageRegistry` to optionally prefix a single registry to all chart images (server, injector, injector agent, CSI provider, and CSI agent)
 * Add support for Kubernetes Gateway API HTTPRoute resource [#1142](https://github.com/hashicorp/vault-helm/pull/1142)
 
 ## 0.33.0 (June 8, 2026)

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -37,6 +37,24 @@ Expand the name of the chart.
 {{- end -}}
 
 {{/*
+Returns the global image registry prefix, including a trailing slash, when
+global.imageRegistry is set; otherwise returns an empty string.
+
+Prepend the result to a component's image.repository so a single
+global.imageRegistry value can repoint every image in the chart (useful for
+private mirrors / air-gapped installs) while preserving the existing
+per-component image.repository values as the default when unset.
+
+Usage:
+  image: {{ include "vault.imageRegistry" . }}{{ .Values.server.image.repository }}:{{ .Values.server.image.tag }}
+*/}}
+{{- define "vault.imageRegistry" -}}
+{{- if .Values.global.imageRegistry -}}
+{{- printf "%s/" (.Values.global.imageRegistry | trimSuffix "/") -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
 Allow the release namespace to be overridden
 */}}
 {{- define "vault.namespace" -}}

--- a/templates/csi-daemonset.yaml
+++ b/templates/csi-daemonset.yaml
@@ -52,7 +52,7 @@ spec:
         - name: {{ include "vault.name" . }}-csi-provider
           {{ template "csi.resources" . }}
           {{ template "csi.daemonSet.securityContext.container" . }}
-          image: "{{ .Values.csi.image.repository }}:{{ .Values.csi.image.tag }}"
+          image: "{{ include "vault.imageRegistry" . }}{{ .Values.csi.image.repository }}:{{ .Values.csi.image.tag }}"
           imagePullPolicy: {{ .Values.csi.image.pullPolicy }}
           args:
             - --endpoint=/provider/vault.sock
@@ -108,7 +108,7 @@ spec:
             timeoutSeconds: {{ .Values.csi.readinessProbe.timeoutSeconds }}
         {{- if eq (.Values.csi.agent.enabled | toString) "true" }}
         - name: {{ include "vault.name" . }}-agent
-          image: "{{ .Values.csi.agent.image.repository }}:{{ .Values.csi.agent.image.tag }}"
+          image: "{{ include "vault.imageRegistry" . }}{{ .Values.csi.agent.image.repository }}:{{ .Values.csi.agent.image.tag }}"
           imagePullPolicy: {{ .Values.csi.agent.image.pullPolicy }}
           {{ template "csi.agent.resources" . }}
           command:

--- a/templates/injector-deployment.yaml
+++ b/templates/injector-deployment.yaml
@@ -50,7 +50,7 @@ spec:
       containers:
         - name: sidecar-injector
           {{ template "injector.resources" . }}
-          image: "{{ .Values.injector.image.repository }}:{{ .Values.injector.image.tag }}"
+          image: "{{ include "vault.imageRegistry" . }}{{ .Values.injector.image.repository }}:{{ .Values.injector.image.tag }}"
           imagePullPolicy: "{{ .Values.injector.image.pullPolicy }}"
           {{- template "injector.securityContext.container" . }}
           env:
@@ -69,7 +69,7 @@ spec:
             - name: AGENT_INJECT_VAULT_AUTH_PATH
               value: {{ .Values.injector.authPath }}
             - name: AGENT_INJECT_VAULT_IMAGE
-              value: "{{ .Values.injector.agentImage.repository }}:{{ .Values.injector.agentImage.tag }}"
+              value: "{{ include "vault.imageRegistry" . }}{{ .Values.injector.agentImage.repository }}:{{ .Values.injector.agentImage.tag }}"
             {{- if .Values.injector.certs.secretName }}
             - name: AGENT_INJECT_TLS_CERT_FILE
               value: "/etc/webhook/certs/{{ .Values.injector.certs.certName }}"

--- a/templates/server-statefulset.yaml
+++ b/templates/server-statefulset.yaml
@@ -76,7 +76,7 @@ spec:
       containers:
         - name: vault
           {{ template "vault.resources" . }}
-          image: {{ .Values.server.image.repository }}:{{ .Values.server.image.tag | default "latest" }}
+          image: {{ include "vault.imageRegistry" . }}{{ .Values.server.image.repository }}:{{ .Values.server.image.tag | default "latest" }}
           imagePullPolicy: {{ .Values.server.image.pullPolicy }}
           command:
           - "/bin/sh"

--- a/templates/tests/server-test.yaml
+++ b/templates/tests/server-test.yaml
@@ -21,7 +21,7 @@ spec:
   {{- include "imagePullSecrets" . | nindent 2 }}
   containers:
     - name: {{ .Release.Name }}-server-test
-      image: {{ .Values.server.image.repository }}:{{ .Values.server.image.tag | default "latest" }}
+      image: {{ include "vault.imageRegistry" . }}{{ .Values.server.image.repository }}:{{ .Values.server.image.tag | default "latest" }}
       imagePullPolicy: {{ .Values.server.image.pullPolicy }}
       env:
         - name: VAULT_ADDR

--- a/test/unit/csi-daemonset.bats
+++ b/test/unit/csi-daemonset.bats
@@ -113,6 +113,25 @@ load _helpers
   [ "${actual}" = "PullPolicy2" ]
 }
 
+@test "csi/daemonset: global.imageRegistry prepends registry to csi and agent images" {
+  cd `chart_dir`
+  local object=$(helm template \
+      --show-only templates/csi-daemonset.yaml \
+      --set "csi.enabled=true" \
+      --set "global.imageRegistry=registry.example.com" \
+      --set "csi.image.repository=Image1" \
+      --set "csi.image.tag=0.0.1" \
+      --set "csi.agent.image.repository=Image2" \
+      --set "csi.agent.image.tag=0.0.2" \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.containers' | tee /dev/stderr)
+
+  local actual=$(echo $object | yq -r '.[0].image' | tee /dev/stderr)
+  [ "${actual}" = "registry.example.com/Image1:0.0.1" ]
+  local actual=$(echo $object | yq -r '.[1].image' | tee /dev/stderr)
+  [ "${actual}" = "registry.example.com/Image2:0.0.2" ]
+}
+
 @test "csi/daemonset: Custom imagePullSecrets" {
   cd `chart_dir`
   local object=$(helm template \

--- a/test/unit/injector-deployment.bats
+++ b/test/unit/injector-deployment.bats
@@ -80,6 +80,27 @@ load _helpers
   [ "${actual}" = "foo:1.2.3" ]
 }
 
+@test "injector/deployment: global.imageRegistry prepends registry to injector and agent images" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/injector-deployment.yaml  \
+      --set 'global.imageRegistry=registry.example.com' \
+      --set 'injector.image.repository=foo' \
+      --set 'injector.image.tag=1.2.3' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.containers[0].image' | tee /dev/stderr)
+  [ "${actual}" = "registry.example.com/foo:1.2.3" ]
+
+  local actual=$(helm template \
+      --show-only templates/injector-deployment.yaml  \
+      --set 'global.imageRegistry=registry.example.com' \
+      --set 'injector.agentImage.repository=bar' \
+      --set 'injector.agentImage.tag=4.5.6' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.containers[0].env[] | select(.name=="AGENT_INJECT_VAULT_IMAGE") | .value' | tee /dev/stderr)
+  [ "${actual}" = "registry.example.com/bar:4.5.6" ]
+}
+
 @test "injector/deployment: default imagePullPolicy" {
   cd `chart_dir`
   local actual=$(helm template \

--- a/test/unit/server-statefulset.bats
+++ b/test/unit/server-statefulset.bats
@@ -137,6 +137,29 @@ load _helpers
   [ "${actual}" = "foo:latest" ]
 }
 
+@test "server/standalone-StatefulSet: global.imageRegistry prepends registry to image" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/server-statefulset.yaml  \
+      --set 'global.imageRegistry=registry.example.com' \
+      --set 'server.image.repository=foo' \
+      --set 'server.image.tag=1.2.3' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.containers[0].image' | tee /dev/stderr)
+  [ "${actual}" = "registry.example.com/foo:1.2.3" ]
+}
+
+@test "server/standalone-StatefulSet: global.imageRegistry unset keeps default image" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/server-statefulset.yaml  \
+      --set 'server.image.repository=foo' \
+      --set 'server.image.tag=1.2.3' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.containers[0].image' | tee /dev/stderr)
+  [ "${actual}" = "foo:1.2.3" ]
+}
+
 @test "server/standalone-StatefulSet: default imagePullPolicy" {
   cd `chart_dir`
   local actual=$(helm template \

--- a/values.schema.json
+++ b/values.schema.json
@@ -254,6 +254,9 @@
                 "imagePullSecrets": {
                     "type": "array"
                 },
+                "imageRegistry": {
+                    "type": "string"
+                },
                 "namespace": {
                     "type": "string"
                 },

--- a/values.yaml
+++ b/values.yaml
@@ -11,6 +11,14 @@ global:
   # The namespace to deploy to. Defaults to the `helm` installation namespace.
   namespace: ""
 
+  # Image registry to prefix to all image repositories in this chart. When set,
+  # it is prepended to server.image.repository, injector.image.repository,
+  # injector.agentImage.repository, csi.image.repository and
+  # csi.agent.image.repository. Leave empty ("") to use each image.repository as
+  # configured (the default behavior). Useful for private mirrors / air-gapped
+  # installs where every image is served from a single registry.
+  imageRegistry: ""
+
   # Image pull secret to use for registry authentication.
   # Alternatively, the value may be specified as an array of strings.
   imagePullSecrets: []


### PR DESCRIPTION
## What

Adds an optional `global.imageRegistry` value to the chart. When set, it is prepended to every image rendered by the chart:

- `server.image` — server StatefulSet and the server test pod (`templates/server-statefulset.yaml`, `templates/tests/server-test.yaml`)
- `injector.image` — agent-injector Deployment (`templates/injector-deployment.yaml`)
- `injector.agentImage` — the `AGENT_INJECT_VAULT_IMAGE` value used for injected Vault Agent sidecars (`templates/injector-deployment.yaml`)
- `csi.image` — CSI provider DaemonSet (`templates/csi-daemonset.yaml`)
- `csi.agent.image` — CSI Vault Agent sidecar (`templates/csi-daemonset.yaml`)

A new `vault.imageRegistry` helper in `templates/_helpers.tpl` performs the prefixing. When `global.imageRegistry` is empty (the default), image rendering is unchanged — each component's `image.repository` is used exactly as before — so the change is fully backwards compatible.

## Why

When mirroring images to a single private registry (air-gapped or otherwise restricted environments), operators currently have to override each component's `image.repository` independently and keep all of them in sync. A single `global.imageRegistry` value lets the entire chart be repointed at one mirror in one place, matching the common pattern used by many other Helm charts.

This is a **registry-prefix-only** global. It does not reintroduce a shared `global.image`, so it does not recreate the cross-subchart collision that led to removing global image configuration in #68 / #103: each component keeps its own `image.repository`, and only the registry host is prefixed.

## How it works

The helper returns the registry prefix (with a trailing slash) when the value is set, and an empty string otherwise:

```gotemplate
{{- define "vault.imageRegistry" -}}
{{- if .Values.global.imageRegistry -}}
{{- printf "%s/" (.Values.global.imageRegistry | trimSuffix "/") -}}
{{- end -}}
{{- end -}}
```

Each image line is prefixed with `{{ include "vault.imageRegistry" . }}`, for example:

```gotemplate
image: {{ include "vault.imageRegistry" . }}{{ .Values.server.image.repository }}:{{ .Values.server.image.tag | default "latest" }}
```

## Example

```yaml
global:
  imageRegistry: registry.example.com
```

Renders:

| Component | Result |
| --- | --- |
| server | `registry.example.com/hashicorp/vault:2.0.2` |
| injector | `registry.example.com/hashicorp/vault-k8s:1.7.4` |
| injector agent (`AGENT_INJECT_VAULT_IMAGE`) | `registry.example.com/hashicorp/vault:2.0.2` |
| csi provider | `registry.example.com/hashicorp/vault-csi-provider:1.7.2` |
| csi agent | `registry.example.com/hashicorp/vault:2.0.2` |

Leaving `global.imageRegistry` unset keeps `hashicorp/vault:2.0.2` etc. — identical to current behavior.

## Changes

- `templates/_helpers.tpl` — new `vault.imageRegistry` helper
- `templates/server-statefulset.yaml`, `templates/tests/server-test.yaml`, `templates/injector-deployment.yaml`, `templates/csi-daemonset.yaml` — wire the helper into all image references
- `values.yaml` — document `global.imageRegistry` (defaults to `""`)
- `values.schema.json` — add `global.imageRegistry` (`string`)
- `test/unit/server-statefulset.bats`, `test/unit/injector-deployment.bats`, `test/unit/csi-daemonset.bats` — add tests for set and unset behavior
- `CHANGELOG.md` — add entry under Unreleased

## Tests

- Added unit tests asserting the prefixed result when `global.imageRegistry` is set, and the unchanged default when it is unset, for the server StatefulSet, injector Deployment (both the injector image and the injected agent image), and CSI DaemonSet (provider and agent containers).
- `helm lint` passes.
- Run locally with:
  ```bash
  bats ./test/unit
  ```

## Backwards compatibility

No behavior change when `global.imageRegistry` is unset; rendered output is identical to before. No existing values are renamed or removed.

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [x] I have documented a clear reason for, and description of, the change I am making.
- [x] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [x] If applicable, I've documented the impact of any changes to security controls.

**Revert plan:** revert this PR. The change is additive and gated on `global.imageRegistry` being set. With it unset, rendered manifests are byte-identical to the previous behavior, so no data migration or follow-up cleanup is required.

**Impact on security controls:** none. No access control methods, authentication, authorization, or logging pipelines are added, removed, or modified. The only effect is an optional registry-host prefix applied to image references, which can additionally help enforce pulling images from an approved internal registry.
