### PR TITLE
Release v0.34.0 preparation

### DIFF
--- a/.github/workflows/acceptance.yaml
+++ b/.github/workflows/acceptance.yaml
@@ -11,10 +11,10 @@ jobs:
       K8S_3: "1.34.8"
       K8S_4: "1.33.12"
       K8S_5: "1.32.11"
-      VAULT_N: "2.0.2"
-      VAULT_N_1: "1.21.7"
-      VAULT_N_2: "1.20.12"
-      VAULT_LTS_1: "1.19.18"
+      VAULT_N: "2.0.3"
+      VAULT_N_1: "1.21.8"
+      VAULT_N_2: "1.20.13"
+      VAULT_LTS_1: "1.19.19"
 
   kind-ce-vault:
     name: ce vault:${{ matrix.vault-version }} k8s:${{ matrix.k8s-version }}

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Setup test tools
         uses: ./.github/actions/setup-test-tools
-      - uses: actions/setup-go@924ae3a05336d9a00e2f9dbd7265da8bb0e1a1c5 # v6.5.0
+      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
           go-version: '1.24.5'
       - run: go install "github.com/redhat-certification/chart-verifier@${CHART_VERIFIER_VERSION}"

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Setup test tools
         uses: ./.github/actions/setup-test-tools
-      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+      - uses: actions/setup-go@924ae3a05336d9a00e2f9dbd7265da8bb0e1a1c5 # v6.5.0
         with:
           go-version: '1.24.5'
       - run: go install "github.com/redhat-certification/chart-verifier@${CHART_VERIFIER_VERSION}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Changes:
 * Default `vault-k8s` version updated to v1.7.5
 * Tested with Vault v2.0.3, v1.21-v1.19
 * build(deps): bump actions/checkout from 6.0.3 to 7.0.0 in the github-actions-breaking group across 1 directory [#1142](https://github.com/hashicorp/vault-helm/pull/1142)
+* build(deps): bump actions/setup-go from 6.4.0 to 6.5.0
 
 Features:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,12 @@
-## Unreleased
+## 0.34.0 (July 2, 2026)
+
+Changes:
+
+* Default `vault` version updated to v2.0.3
+* Default `vault-csi-provider` version updated to v1.7.3
+* Default `vault-k8s` version updated to v1.7.5
+* Tested with Vault v2.0.3, v1.21-v1.19
+* build(deps): bump actions/checkout from 6.0.3 to 7.0.0 in the github-actions-breaking group across 1 directory [#1142](https://github.com/hashicorp/vault-helm/pull/1142)
 
 Features:
 

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -3,8 +3,8 @@
 
 apiVersion: v2
 name: vault
-version: 0.33.0
-appVersion: 2.0.2
+version: 0.34.0
+appVersion: 2.0.3
 kubeVersion: ">= 1.20.0-0"
 description: Official HashiCorp Vault Chart
 home: https://www.vaultproject.io

--- a/values.openshift.yaml
+++ b/values.openshift.yaml
@@ -9,16 +9,16 @@ global:
 injector:
   image:
     repository: "registry.connect.redhat.com/hashicorp/vault-k8s"
-    tag: "1.7.4-ubi"
+    tag: "1.7.5-ubi"
 
   agentImage:
     repository: "registry.connect.redhat.com/hashicorp/vault"
-    tag: "2.0.2-ubi"
+    tag: "2.0.3-ubi"
 
 server:
   image:
     repository: "registry.connect.redhat.com/hashicorp/vault"
-    tag: "2.0.2-ubi"
+    tag: "2.0.3-ubi"
 
   readinessProbe:
     path: "/v1/sys/health?uninitcode=204"
@@ -26,9 +26,9 @@ server:
 csi:
   image:
     repository: "registry.connect.redhat.com/hashicorp/vault-csi-provider"
-    tag: "1.7.2-ubi"
+    tag: "1.7.3-ubi"
 
   agent:
     image:
       repository: "registry.connect.redhat.com/hashicorp/vault"
-      tag: "2.0.2-ubi"
+      tag: "2.0.3-ubi"

--- a/values.yaml
+++ b/values.yaml
@@ -68,7 +68,7 @@ injector:
   # image sets the repo and tag of the vault-k8s image to use for the injector.
   image:
     repository: "hashicorp/vault-k8s"
-    tag: "1.7.4"
+    tag: "1.7.5"
     pullPolicy: IfNotPresent
 
   # agentImage sets the repo and tag of the Vault image to use for the Vault Agent
@@ -76,7 +76,7 @@ injector:
   # required.
   agentImage:
     repository: "hashicorp/vault"
-    tag: "2.0.2"
+    tag: "2.0.3"
 
   # The default values for the injected Vault Agent containers.
   agentDefaults:
@@ -417,7 +417,7 @@ server:
 
   image:
     repository: "hashicorp/vault"
-    tag: "2.0.2"
+    tag: "2.0.3"
     # Overrides the default Image Pull Policy
     pullPolicy: IfNotPresent
 
@@ -1187,7 +1187,7 @@ csi:
 
   image:
     repository: "hashicorp/vault-csi-provider"
-    tag: "1.7.2"
+    tag: "1.7.3"
     pullPolicy: IfNotPresent
 
   # volumes is a list of volumes made available to all containers. These are rendered
@@ -1278,7 +1278,7 @@ csi:
 
     image:
       repository: "hashicorp/vault"
-      tag: "2.0.2"
+      tag: "2.0.3"
       pullPolicy: IfNotPresent
 
     logFormat: standard


### PR DESCRIPTION
## Description
Changes:

* Default `vault` version updated to v2.0.3
* Default `vault-csi-provider` version updated to v1.7.3
* Default `vault-k8s` version updated to v1.7.5
* Tested with Vault v2.0.3, v1.21-v1.19
* build(deps): bump actions/checkout from 6.0.3 to 7.0.0 in the github-actions-breaking group across 1 directory [#1142](https://github.com/hashicorp/vault-helm/pull/1142)
* build(deps): bump actions/setup-go from 6.4.0 to 6.5.0

Features:

* Add support for Kubernetes Gateway API HTTPRoute resource [#1142](https://github.com/hashicorp/vault-helm/pull/1142)

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] I have documented a clear reason for, and description of, the change I am making.

- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
