### PR TITLE
feat: Customizable injector cluster role

### DIFF
--- a/templates/injector-clusterrole.yaml
+++ b/templates/injector-clusterrole.yaml
@@ -14,13 +14,21 @@ metadata:
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
 rules:
-- apiGroups: ["admissionregistration.k8s.io"]
-  resources: ["mutatingwebhookconfigurations"]
+- apiGroups:
+    {{- $apiGroups := .Values.injector.clusterRole.apiGroups | default (list "admissionregistration.k8s.io") }}
+    {{- range $apiGroups }}
+    - {{ . | quote }}
+    {{- end }}
+  resources:
+    {{- $resources := .Values.injector.clusterRole.resources | default (list "mutatingwebhookconfigurations") }}
+    {{- range $resources }}
+    - {{ . | quote }}
+    {{- end }}
   verbs:
-    - "get"
-    - "list"
-    - "watch"
-    - "patch"
+    {{- $verbs := .Values.injector.clusterRole.verbs | default (list "get" "list" "watch" "patch") }}
+    {{- range $verbs }}
+    - {{ . | quote }}
+    {{- end }}
 {{- if and (eq (.Values.injector.leaderElector.enabled | toString) "true") (gt (.Values.injector.replicas | int) 1) }}
 - apiGroups: [""]
   resources: ["nodes"]

--- a/test/unit/injector-clusterrole.bats
+++ b/test/unit/injector-clusterrole.bats
@@ -50,3 +50,79 @@ load _helpers
   resource=$(echo "${rules}" | yq -r '.[1].resources[0]')
   [ "${resource}" = "nodes" ]
 }
+
+@test "injector/ClusterRole: default webhook verbs" {
+  cd `chart_dir`
+  local verbs=$(helm template \
+      --show-only templates/injector-clusterrole.yaml  \
+      . | tee /dev/stderr |
+      yq '.rules[0].verbs' | tee /dev/stderr)
+
+  [ "$(echo "${verbs}" | yq 'length')" = "4" ]
+  [ "$(echo "${verbs}" | yq -r '.[0]')" = "get" ]
+  [ "$(echo "${verbs}" | yq -r '.[1]')" = "list" ]
+  [ "$(echo "${verbs}" | yq -r '.[2]')" = "watch" ]
+  [ "$(echo "${verbs}" | yq -r '.[3]')" = "patch" ]
+}
+
+@test "injector/ClusterRole: custom webhook verbs" {
+  cd `chart_dir`
+  local verbs=$(helm template \
+      --show-only templates/injector-clusterrole.yaml  \
+      --set 'injector.clusterRole.verbs={get,list}' \
+      . | tee /dev/stderr |
+      yq '.rules[0].verbs' | tee /dev/stderr)
+
+  [ "$(echo "${verbs}" | yq 'length')" = "2" ]
+  [ "$(echo "${verbs}" | yq -r '.[0]')" = "get" ]
+  [ "$(echo "${verbs}" | yq -r '.[1]')" = "list" ]
+}
+
+@test "injector/ClusterRole: default webhook apiGroups" {
+  cd `chart_dir`
+  local apiGroups=$(helm template \
+      --show-only templates/injector-clusterrole.yaml  \
+      . | tee /dev/stderr |
+      yq '.rules[0].apiGroups' | tee /dev/stderr)
+
+  [ "$(echo "${apiGroups}" | yq 'length')" = "1" ]
+  [ "$(echo "${apiGroups}" | yq -r '.[0]')" = "admissionregistration.k8s.io" ]
+}
+
+@test "injector/ClusterRole: custom webhook apiGroups" {
+  cd `chart_dir`
+  local apiGroups=$(helm template \
+      --show-only templates/injector-clusterrole.yaml  \
+      --set 'injector.clusterRole.apiGroups={admissionregistration.k8s.io,apps}' \
+      . | tee /dev/stderr |
+      yq '.rules[0].apiGroups' | tee /dev/stderr)
+
+  [ "$(echo "${apiGroups}" | yq 'length')" = "2" ]
+  [ "$(echo "${apiGroups}" | yq -r '.[0]')" = "admissionregistration.k8s.io" ]
+  [ "$(echo "${apiGroups}" | yq -r '.[1]')" = "apps" ]
+}
+
+@test "injector/ClusterRole: default webhook resources" {
+  cd `chart_dir`
+  local resources=$(helm template \
+      --show-only templates/injector-clusterrole.yaml  \
+      . | tee /dev/stderr |
+      yq '.rules[0].resources' | tee /dev/stderr)
+
+  [ "$(echo "${resources}" | yq 'length')" = "1" ]
+  [ "$(echo "${resources}" | yq -r '.[0]')" = "mutatingwebhookconfigurations" ]
+}
+
+@test "injector/ClusterRole: custom webhook resources" {
+  cd `chart_dir`
+  local resources=$(helm template \
+      --show-only templates/injector-clusterrole.yaml  \
+      --set 'injector.clusterRole.resources={mutatingwebhookconfigurations,validatingwebhookconfigurations}' \
+      . | tee /dev/stderr |
+      yq '.rules[0].resources' | tee /dev/stderr)
+
+  [ "$(echo "${resources}" | yq 'length')" = "2" ]
+  [ "$(echo "${resources}" | yq -r '.[0]')" = "mutatingwebhookconfigurations" ]
+  [ "$(echo "${resources}" | yq -r '.[1]')" = "validatingwebhookconfigurations" ]
+}
+

--- a/values.schema.json
+++ b/values.schema.json
@@ -416,6 +416,29 @@
                         }
                     }
                 },
+                "clusterRole": {
+                    "type": "object",
+                    "properties": {
+                        "apiGroups": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "resources": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "verbs": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                },
                 "livenessProbe": {
                     "type": "object",
                     "properties": {

--- a/values.yaml
+++ b/values.yaml
@@ -58,6 +58,24 @@ injector:
   leaderElector:
     enabled: true
 
+  # ClusterRole config for the injector.
+  clusterRole:
+    # apiGroups granted for the mutatingwebhookconfigurations rule. Customize
+    # if you need to restrict or extend the default permissions.
+    apiGroups:
+      - "admissionregistration.k8s.io"
+    # resources granted for the rule. Customize if you need to restrict or
+    # extend the default permissions.
+    resources:
+      - "mutatingwebhookconfigurations"
+    # verbs granted on the resources above. Customize if you need to
+    # restrict or extend the default permissions.
+    verbs:
+      - "get"
+      - "list"
+      - "watch"
+      - "patch"
+
   # If true, will enable a node exporter metrics endpoint at /metrics.
   metrics:
     enabled: false


### PR DESCRIPTION
== DETAILS
I want to use the chart in my organization to setup Vault agent injectors but our k8s policies do not allow to use the verb "patch" in cluster role rules. My changes make the cluster role api group rules customizable if it's necessary.

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [x] I have documented a clear reason for, and description of, the change I am making.
- [x] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [x] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.