### PR TITLE
Add global.extraLabels for chart-wide common labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Unreleased
+
+Features:
+
+* Add `global.extraLabels` to apply custom labels to every resource created by the chart (including the server, injector, and CSI provider pod templates), and add the standard `app.kubernetes.io/version` (set from the chart's `appVersion`, overridable via `global.extraLabels`) and `helm.sh/chart` labels to every resource. Rendering fails with a clear error if `global.extraLabels` attempts to override a chart-managed label [GH-1197](https://github.com/hashicorp/vault-helm/issues/1197)
+
 ## 0.34.0 (July 2, 2026)
 
 Changes:

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -37,6 +37,38 @@ Expand the name of the chart.
 {{- end -}}
 
 {{/*
+Common labels added to every resource created by this chart: the standard
+helm.sh/chart and app.kubernetes.io/version labels, plus any user-defined
+global.extraLabels. app.kubernetes.io/version defaults to the chart's
+appVersion and is the only chart-managed label that global.extraLabels may
+override, since the deployed app version can legitimately differ from the
+chart default. Overriding any other chart-managed label fails rendering:
+it would produce duplicate label keys (ambiguous YAML that trips linters
+and policy engines) and conflict with the labels used in selectors and HA
+request routing. Values are coerced to strings since Kubernetes rejects
+non-string label values. These labels are intentionally never included in
+selectors or other immutable fields (such as the server StatefulSet
+volumeClaimTemplates), so they stay safe to add or change on existing
+installations. Resource-specific labels (e.g. server.extraLabels) are
+rendered after these and take precedence on duplicate keys.
+*/}}
+{{- define "vault.commonLabels" -}}
+{{- $reserved := list "app.kubernetes.io/name" "app.kubernetes.io/instance" "app.kubernetes.io/managed-by" "helm.sh/chart" "component" "vault-active" "vault-internal" -}}
+{{- range $k, $v := .Values.global.extraLabels -}}
+{{- if has $k $reserved -}}
+{{- fail (printf "global.extraLabels must not set %q: this label is managed by the chart and overriding it would produce duplicate label keys. app.kubernetes.io/version may be overridden here; use custom label keys for everything else." $k) -}}
+{{- end -}}
+{{- end -}}
+{{- $labels := dict
+      "helm.sh/chart" (include "vault.chart" .)
+      "app.kubernetes.io/version" (.Chart.AppVersion | toString | replace "+" "_" | trunc 63 | trimSuffix "-") -}}
+{{- range $k, $v := .Values.global.extraLabels -}}
+{{- $_ := set $labels $k ($v | toString) -}}
+{{- end -}}
+{{- toYaml $labels -}}
+{{- end -}}
+
+{{/*
 Allow the release namespace to be overridden
 */}}
 {{- define "vault.namespace" -}}

--- a/templates/csi-agent-configmap.yaml
+++ b/templates/csi-agent-configmap.yaml
@@ -11,10 +11,10 @@ metadata:
   name: {{ template "vault.fullname" . }}-csi-provider-agent-config
   namespace: {{ include "vault.namespace" . }}
   labels:
-    helm.sh/chart: {{ include "vault.chart" . }}
     app.kubernetes.io/name: {{ include "vault.name" . }}-csi-provider
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
+    {{- include "vault.commonLabels" . | nindent 4 }}
 data:
   config.hcl: |
     vault {

--- a/templates/csi-clusterrole.yaml
+++ b/templates/csi-clusterrole.yaml
@@ -13,6 +13,7 @@ metadata:
     app.kubernetes.io/name: {{ include "vault.name" . }}-csi-provider
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
+    {{- include "vault.commonLabels" . | nindent 4 }}
 rules:
 - apiGroups:
   - ""

--- a/templates/csi-clusterrolebinding.yaml
+++ b/templates/csi-clusterrolebinding.yaml
@@ -13,6 +13,7 @@ metadata:
     app.kubernetes.io/name: {{ include "vault.name" . }}-csi-provider
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
+    {{- include "vault.commonLabels" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/templates/csi-daemonset.yaml
+++ b/templates/csi-daemonset.yaml
@@ -14,6 +14,7 @@ metadata:
     app.kubernetes.io/name: {{ include "vault.name" . }}-csi-provider
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
+    {{- include "vault.commonLabels" . | nindent 4 }}
     {{- if  .Values.csi.daemonSet.extraLabels -}}
       {{- toYaml .Values.csi.daemonSet.extraLabels | nindent 4 -}}
     {{- end -}}
@@ -34,6 +35,7 @@ spec:
       labels:
         app.kubernetes.io/name: {{ template "vault.name" . }}-csi-provider
         app.kubernetes.io/instance: {{ .Release.Name }}
+        {{- include "vault.commonLabels" . | nindent 8 }}
         {{- if  .Values.csi.pod.extraLabels -}}
           {{- toYaml .Values.csi.pod.extraLabels | nindent 8 -}}
         {{- end -}}

--- a/templates/csi-role.yaml
+++ b/templates/csi-role.yaml
@@ -14,6 +14,7 @@ metadata:
     app.kubernetes.io/name: {{ include "vault.name" . }}-csi-provider
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
+    {{- include "vault.commonLabels" . | nindent 4 }}
 rules:
 - apiGroups: [""]
   resources: ["secrets"]

--- a/templates/csi-rolebinding.yaml
+++ b/templates/csi-rolebinding.yaml
@@ -14,6 +14,7 @@ metadata:
     app.kubernetes.io/name: {{ include "vault.name" . }}-csi-provider
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
+    {{- include "vault.commonLabels" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/templates/csi-serviceaccount.yaml
+++ b/templates/csi-serviceaccount.yaml
@@ -14,6 +14,7 @@ metadata:
     app.kubernetes.io/name: {{ include "vault.name" . }}-csi-provider
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
+    {{- include "vault.commonLabels" . | nindent 4 }}
     {{- if  .Values.csi.serviceAccount.extraLabels -}}
       {{- toYaml .Values.csi.serviceAccount.extraLabels | nindent 4 -}}
     {{- end -}}

--- a/templates/injector-certs-secret.yaml
+++ b/templates/injector-certs-secret.yaml
@@ -15,5 +15,6 @@ metadata:
     app.kubernetes.io/name: {{ include "vault.name" . }}-agent-injector
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
+    {{- include "vault.commonLabels" . | nindent 4 }}
 {{- end }}
 {{- end }}

--- a/templates/injector-clusterrole.yaml
+++ b/templates/injector-clusterrole.yaml
@@ -13,6 +13,7 @@ metadata:
     app.kubernetes.io/name: {{ include "vault.name" . }}-agent-injector
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
+    {{- include "vault.commonLabels" . | nindent 4 }}
 rules:
 - apiGroups: ["admissionregistration.k8s.io"]
   resources: ["mutatingwebhookconfigurations"]

--- a/templates/injector-clusterrolebinding.yaml
+++ b/templates/injector-clusterrolebinding.yaml
@@ -13,6 +13,7 @@ metadata:
     app.kubernetes.io/name: {{ include "vault.name" . }}-agent-injector
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
+    {{- include "vault.commonLabels" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/templates/injector-deployment.yaml
+++ b/templates/injector-deployment.yaml
@@ -16,6 +16,7 @@ metadata:
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     component: webhook
+    {{- include "vault.commonLabels" . | nindent 4 }}
 spec:
   replicas: {{ .Values.injector.replicas }}
   selector:
@@ -30,6 +31,7 @@ spec:
         app.kubernetes.io/name: {{ template "vault.name" . }}-agent-injector
         app.kubernetes.io/instance: {{ .Release.Name }}
         component: webhook
+        {{- include "vault.commonLabels" . | nindent 8 }}
         {{- if  .Values.injector.extraLabels -}}
           {{- toYaml .Values.injector.extraLabels | nindent 8 -}}
         {{- end -}}

--- a/templates/injector-disruptionbudget.yaml
+++ b/templates/injector-disruptionbudget.yaml
@@ -10,11 +10,11 @@ metadata:
   name: {{ template "vault.fullname" . }}-agent-injector
   namespace: {{ include "vault.namespace" . }}
   labels:
-    helm.sh/chart: {{ include "vault.chart" . }}
     app.kubernetes.io/name: {{ include "vault.name" . }}-agent-injector
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     component: webhook
+    {{- include "vault.commonLabels" . | nindent 4 }}
 spec:
   selector:
     matchLabels:

--- a/templates/injector-mutating-webhook.yaml
+++ b/templates/injector-mutating-webhook.yaml
@@ -17,6 +17,7 @@ metadata:
     app.kubernetes.io/name: {{ include "vault.name" . }}-agent-injector
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
+    {{- include "vault.commonLabels" . | nindent 4 }}
   {{- template "injector.webhookAnnotations" . }}
 webhooks:
   - name: vault.hashicorp.com

--- a/templates/injector-network-policy.yaml
+++ b/templates/injector-network-policy.yaml
@@ -13,6 +13,7 @@ metadata:
   labels:
     app.kubernetes.io/name: {{ template "vault.name" . }}-agent-injector
     app.kubernetes.io/instance: {{ .Release.Name }}
+    {{- include "vault.commonLabels" . | nindent 4 }}
 spec:
   podSelector:
     matchLabels:

--- a/templates/injector-psp-role.yaml
+++ b/templates/injector-psp-role.yaml
@@ -15,6 +15,7 @@ metadata:
     app.kubernetes.io/name: {{ include "vault.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
+    {{- include "vault.commonLabels" . | nindent 4 }}
 rules:
 - apiGroups: ['policy']
   resources: ['podsecuritypolicies']

--- a/templates/injector-psp-rolebinding.yaml
+++ b/templates/injector-psp-rolebinding.yaml
@@ -15,6 +15,7 @@ metadata:
     app.kubernetes.io/name: {{ include "vault.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
+    {{- include "vault.commonLabels" . | nindent 4 }}
 roleRef:
   kind: Role
   name: {{ template "vault.fullname" . }}-agent-injector-psp

--- a/templates/injector-psp.yaml
+++ b/templates/injector-psp.yaml
@@ -14,6 +14,7 @@ metadata:
     app.kubernetes.io/name: {{ include "vault.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
+    {{- include "vault.commonLabels" . | nindent 4 }}
 {{- template "vault.psp.annotations" . }}
 spec:
   privileged: false

--- a/templates/injector-role.yaml
+++ b/templates/injector-role.yaml
@@ -15,6 +15,7 @@ metadata:
     app.kubernetes.io/name: {{ include "vault.name" . }}-agent-injector
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
+    {{- include "vault.commonLabels" . | nindent 4 }}
 rules:
   - apiGroups: [""]
     resources: ["secrets", "configmaps"]

--- a/templates/injector-rolebinding.yaml
+++ b/templates/injector-rolebinding.yaml
@@ -15,6 +15,7 @@ metadata:
     app.kubernetes.io/name: {{ include "vault.name" . }}-agent-injector
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
+    {{- include "vault.commonLabels" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/templates/injector-service.yaml
+++ b/templates/injector-service.yaml
@@ -14,6 +14,7 @@ metadata:
     app.kubernetes.io/name: {{ include "vault.name" . }}-agent-injector
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
+    {{- include "vault.commonLabels" . | nindent 4 }}
   {{ template "injector.service.annotations" . }}
 spec:
   ports:

--- a/templates/injector-serviceaccount.yaml
+++ b/templates/injector-serviceaccount.yaml
@@ -14,5 +14,6 @@ metadata:
     app.kubernetes.io/name: {{ include "vault.name" . }}-agent-injector
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
+    {{- include "vault.commonLabels" . | nindent 4 }}
   {{ template "injector.serviceAccount.annotations" . }}
 {{ end }}

--- a/templates/prometheus-prometheusrules.yaml
+++ b/templates/prometheus-prometheusrules.yaml
@@ -12,10 +12,10 @@ kind: PrometheusRule
 metadata:
   name: {{ template "vault.fullname" . }}
   labels:
-    helm.sh/chart: {{ include "vault.chart" . }}
     app.kubernetes.io/name: {{ include "vault.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
+    {{- include "vault.commonLabels" . | nindent 4 }}
     {{- /* update the selectors docs in values.yaml whenever the defaults below change. */ -}}
     {{- $selectors := .Values.serverTelemetry.prometheusRules.selectors }}
     {{- if $selectors }}

--- a/templates/prometheus-servicemonitor.yaml
+++ b/templates/prometheus-servicemonitor.yaml
@@ -11,10 +11,10 @@ kind: ServiceMonitor
 metadata:
   name: {{ template "vault.fullname" . }}
   labels:
-    helm.sh/chart: {{ include "vault.chart" . }}
     app.kubernetes.io/name: {{ include "vault.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
+    {{- include "vault.commonLabels" . | nindent 4 }}
     {{- /* update the selectors docs in values.yaml whenever the defaults below change. */ -}}
     {{- $selectors := .Values.serverTelemetry.serviceMonitor.selectors }}
     {{- if $selectors }}

--- a/templates/server-clusterrolebinding.yaml
+++ b/templates/server-clusterrolebinding.yaml
@@ -14,10 +14,10 @@ kind: ClusterRoleBinding
 metadata:
   name: {{ template "vault.fullname" . }}-server-binding
   labels:
-    helm.sh/chart: {{ include "vault.chart" . }}
     app.kubernetes.io/name: {{ include "vault.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
+    {{- include "vault.commonLabels" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/templates/server-config-configmap.yaml
+++ b/templates/server-config-configmap.yaml
@@ -14,10 +14,10 @@ metadata:
   name: {{ template "vault.fullname" . }}-config
   namespace: {{ include "vault.namespace" . }}
   labels:
-    helm.sh/chart: {{ include "vault.chart" . }}
     app.kubernetes.io/name: {{ include "vault.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
+    {{- include "vault.commonLabels" . | nindent 4 }}
 {{- if .Values.server.includeConfigAnnotation }}
   annotations:
     vault.hashicorp.com/config-checksum: {{ include "vault.config" . | sha256sum }}

--- a/templates/server-discovery-role.yaml
+++ b/templates/server-discovery-role.yaml
@@ -13,10 +13,10 @@ metadata:
   namespace: {{ include "vault.namespace" . }}
   name: {{ template "vault.fullname" . }}-discovery-role
   labels:
-    helm.sh/chart: {{ include "vault.chart" . }}
     app.kubernetes.io/name: {{ include "vault.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
+    {{- include "vault.commonLabels" . | nindent 4 }}
 rules:
 - apiGroups: [""]
   resources: ["pods"]

--- a/templates/server-discovery-rolebinding.yaml
+++ b/templates/server-discovery-rolebinding.yaml
@@ -17,10 +17,10 @@ metadata:
   name: {{ template "vault.fullname" . }}-discovery-rolebinding
   namespace: {{ include "vault.namespace" . }}
   labels:
-    helm.sh/chart: {{ include "vault.chart" . }}
     app.kubernetes.io/name: {{ include "vault.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
+    {{- include "vault.commonLabels" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/templates/server-disruptionbudget.yaml
+++ b/templates/server-disruptionbudget.yaml
@@ -15,10 +15,10 @@ metadata:
   name: {{ template "vault.fullname" . }}
   namespace: {{ include "vault.namespace" . }}
   labels:
-    helm.sh/chart: {{ include "vault.chart" . }}
     app.kubernetes.io/name: {{ include "vault.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
+    {{- include "vault.commonLabels" . | nindent 4 }}
 spec:
   maxUnavailable: {{ template "vault.pdb.maxUnavailable" . }}
   selector:

--- a/templates/server-ha-active-service.yaml
+++ b/templates/server-ha-active-service.yaml
@@ -16,11 +16,11 @@ metadata:
   name: {{ template "vault.fullname" . }}-active
   namespace: {{ include "vault.namespace" . }}
   labels:
-    helm.sh/chart: {{ include "vault.chart" . }}
     app.kubernetes.io/name: {{ include "vault.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     vault-active: "true"
+    {{- include "vault.commonLabels" . | nindent 4 }}
   annotations:
 {{- template "vault.service.annotations" . }}
 {{- template "vault.service.active.annotations" . }}

--- a/templates/server-ha-standby-service.yaml
+++ b/templates/server-ha-standby-service.yaml
@@ -16,10 +16,10 @@ metadata:
   name: {{ template "vault.fullname" . }}-standby
   namespace: {{ include "vault.namespace" . }}
   labels:
-    helm.sh/chart: {{ include "vault.chart" . }}
     app.kubernetes.io/name: {{ include "vault.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
+    {{- include "vault.commonLabels" . | nindent 4 }}
   annotations:
 {{- template "vault.service.annotations" . }}
 {{- template "vault.service.standby.annotations" . }}

--- a/templates/server-headless-service.yaml
+++ b/templates/server-headless-service.yaml
@@ -14,11 +14,11 @@ metadata:
   name: {{ template "vault.fullname" . }}-internal
   namespace: {{ include "vault.namespace" . }}
   labels:
-    helm.sh/chart: {{ include "vault.chart" . }}
     app.kubernetes.io/name: {{ include "vault.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     vault-internal: "true"
+    {{- include "vault.commonLabels" . | nindent 4 }}
   annotations:
 {{ template "vault.service.annotations" .}}
 spec:

--- a/templates/server-httproute.yaml
+++ b/templates/server-httproute.yaml
@@ -23,10 +23,10 @@ metadata:
   name: {{ template "vault.fullname" . }}
   namespace: {{ include "vault.namespace" . }}
   labels:
-    helm.sh/chart: {{ include "vault.chart" . }}
     app.kubernetes.io/name: {{ include "vault.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
+    {{- include "vault.commonLabels" . | nindent 4 }}
     {{- with .Values.server.httproute.labels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}

--- a/templates/server-ingress.yaml
+++ b/templates/server-ingress.yaml
@@ -23,10 +23,10 @@ metadata:
   name: {{ template "vault.fullname" . }}
   namespace: {{ include "vault.namespace" . }}
   labels:
-    helm.sh/chart: {{ include "vault.chart" . }}
     app.kubernetes.io/name: {{ include "vault.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
+    {{- include "vault.commonLabels" . | nindent 4 }}
     {{- with .Values.server.ingress.labels }}
       {{- toYaml . | nindent 4 }}
     {{- end }}

--- a/templates/server-network-policy.yaml
+++ b/templates/server-network-policy.yaml
@@ -12,6 +12,7 @@ metadata:
   labels:
     app.kubernetes.io/name: {{ template "vault.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
+    {{- include "vault.commonLabels" . | nindent 4 }}
 spec:
   podSelector:
     matchLabels:

--- a/templates/server-psp-role.yaml
+++ b/templates/server-psp-role.yaml
@@ -15,6 +15,7 @@ metadata:
     app.kubernetes.io/name: {{ include "vault.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
+    {{- include "vault.commonLabels" . | nindent 4 }}
 rules:
 - apiGroups: ['policy']
   resources: ['podsecuritypolicies']

--- a/templates/server-psp-rolebinding.yaml
+++ b/templates/server-psp-rolebinding.yaml
@@ -15,6 +15,7 @@ metadata:
     app.kubernetes.io/name: {{ include "vault.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
+    {{- include "vault.commonLabels" . | nindent 4 }}
 roleRef:
   kind: Role
   name: {{ template "vault.fullname" . }}-psp

--- a/templates/server-psp.yaml
+++ b/templates/server-psp.yaml
@@ -14,6 +14,7 @@ metadata:
     app.kubernetes.io/name: {{ include "vault.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
+    {{- include "vault.commonLabels" . | nindent 4 }}
 {{- template "vault.psp.annotations" . }}
 spec:
   privileged: false

--- a/templates/server-route.yaml
+++ b/templates/server-route.yaml
@@ -16,10 +16,10 @@ metadata:
   name: {{ template "vault.fullname" . }}
   namespace: {{ include "vault.namespace" . }}
   labels:
-    helm.sh/chart: {{ include "vault.chart" . }}
     app.kubernetes.io/name: {{ include "vault.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
+    {{- include "vault.commonLabels" . | nindent 4 }}
     {{- with .Values.server.route.labels }}
       {{- toYaml . | nindent 4 }}
     {{- end }}

--- a/templates/server-service.yaml
+++ b/templates/server-service.yaml
@@ -14,10 +14,10 @@ metadata:
   name: {{ template "vault.fullname" . }}
   namespace: {{ include "vault.namespace" . }}
   labels:
-    helm.sh/chart: {{ include "vault.chart" . }}
     app.kubernetes.io/name: {{ include "vault.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
+    {{- include "vault.commonLabels" . | nindent 4 }}
   annotations:
 {{ template "vault.service.annotations" .}}
 {{- if and .Values.global.openshift .Values.server.serviceCA.enabled }}

--- a/templates/server-serviceaccount-secret.yaml
+++ b/templates/server-serviceaccount-secret.yaml
@@ -13,9 +13,9 @@ metadata:
   annotations:
     kubernetes.io/service-account.name: {{ template "vault.serviceAccount.name" . }}
   labels:
-    helm.sh/chart: {{ include "vault.chart" . }}
     app.kubernetes.io/name: {{ include "vault.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
+    {{- include "vault.commonLabels" . | nindent 4 }}
 type: kubernetes.io/service-account-token
 {{ end }}

--- a/templates/server-serviceaccount.yaml
+++ b/templates/server-serviceaccount.yaml
@@ -11,10 +11,10 @@ metadata:
   name: {{ template "vault.serviceAccount.name" . }}
   namespace: {{ include "vault.namespace" . }}
   labels:
-    helm.sh/chart: {{ include "vault.chart" . }}
     app.kubernetes.io/name: {{ include "vault.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
+    {{- include "vault.commonLabels" . | nindent 4 }}
     {{- if  .Values.server.serviceAccount.extraLabels -}}
       {{- toYaml .Values.server.serviceAccount.extraLabels | nindent 4 -}}
     {{- end -}}

--- a/templates/server-serviceca-configmap.yaml
+++ b/templates/server-serviceca-configmap.yaml
@@ -12,10 +12,10 @@ metadata:
   name: {{ .Values.server.serviceCA.configMapName }}
   namespace: {{ include "vault.namespace" . }}
   labels:
-    helm.sh/chart: {{ include "vault.chart" . }}
     app.kubernetes.io/name: {{ include "vault.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
+    {{- include "vault.commonLabels" . | nindent 4 }}
   annotations:
     service.beta.openshift.io/inject-cabundle: "true"
 data: {}

--- a/templates/server-statefulset.yaml
+++ b/templates/server-statefulset.yaml
@@ -18,6 +18,7 @@ metadata:
     app.kubernetes.io/name: {{ include "vault.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
+    {{- include "vault.commonLabels" . | nindent 4 }}
   {{- template "vault.statefulSet.annotations" . }}
 spec:
   serviceName: {{ template "vault.fullname" . }}-internal
@@ -36,10 +37,10 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: {{ template "vault.chart" . }}
         app.kubernetes.io/name: {{ template "vault.name" . }}
         app.kubernetes.io/instance: {{ .Release.Name }}
         component: server
+        {{- include "vault.commonLabels" . | nindent 8 }}
         {{- if  .Values.server.extraLabels -}}
           {{- toYaml .Values.server.extraLabels | nindent 8 -}}
         {{- end -}}

--- a/templates/tests/server-test.yaml
+++ b/templates/tests/server-test.yaml
@@ -13,10 +13,14 @@ metadata:
   namespace: {{ include "vault.namespace" . }}
   annotations:
     "helm.sh/hook": test
-  {{- with .Values.server.extraLabels }}
   labels:
+    app.kubernetes.io/name: {{ include "vault.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    {{- include "vault.commonLabels" . | nindent 4 }}
+    {{- with .Values.server.extraLabels }}
     {{- toYaml . | nindent 4 }}
-  {{- end }}
+    {{- end }}
 spec:
   {{- include "imagePullSecrets" . | nindent 2 }}
   containers:

--- a/templates/ui-service.yaml
+++ b/templates/ui-service.yaml
@@ -14,10 +14,10 @@ metadata:
   name: {{ template "vault.fullname" . }}-ui
   namespace: {{ include "vault.namespace" . }}
   labels:
-    helm.sh/chart: {{ include "vault.chart" . }}
     app.kubernetes.io/name: {{ include "vault.name" . }}-ui
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
+    {{- include "vault.commonLabels" . | nindent 4 }}
   {{- template "vault.ui.annotations" . }}
 spec:
   {{- if (semverCompare ">= 1.23-0" .Capabilities.KubeVersion.Version) }}

--- a/test/unit/csi-daemonset.bats
+++ b/test/unit/csi-daemonset.bats
@@ -484,6 +484,17 @@ load _helpers
   [ "${actual}" = "bar" ]
 }
 
+@test "csi/daemonset: specify global.extraLabels" {
+  cd `chart_dir`
+  local output=$(helm template \
+      --show-only templates/csi-daemonset.yaml \
+      --set 'csi.enabled=true' \
+      --set 'global.extraLabels.foo=bar' \
+      . | tee /dev/stderr)
+  [ "$(echo "$output" | yq -r '.metadata.labels.foo')" = "bar" ]
+  [ "$(echo "$output" | yq -r '.spec.template.metadata.labels.foo')" = "bar" ]
+}
+
 
 #--------------------------------------------------------------------
 # volumes

--- a/test/unit/global-labels.bats
+++ b/test/unit/global-labels.bats
@@ -1,0 +1,210 @@
+#!/usr/bin/env bats
+
+load _helpers
+
+# The value overrides used by the helpers below are chosen so that, between
+# the three modes rendered (standalone with every optional component enabled,
+# HA with raft, and OpenShift), every template in the chart renders at least
+# one resource. If a resource is missing the expected label, the `unique`
+# filter returns more than one element and the assertion fails.
+
+# Renders the chart in standalone mode with every optional component enabled.
+_template_standalone() {
+  helm template \
+      --set 'csi.enabled=true' \
+      --set 'ui.enabled=true' \
+      --set 'global.psp.enable=true' \
+      --set 'injector.replicas=2' \
+      --set 'injector.podDisruptionBudget.maxUnavailable=1' \
+      --set 'server.ingress.enabled=true' \
+      --set 'server.httproute.enabled=true' \
+      --set 'server.httproute.parentRefs[0].name=test-gateway' \
+      --set 'server.networkPolicy.enabled=true' \
+      --set 'server.serviceAccount.createSecret=true' \
+      --set 'serverTelemetry.serviceMonitor.enabled=true' \
+      --set 'serverTelemetry.prometheusRules.enabled=true' \
+      --set 'serverTelemetry.prometheusRules.rules[0].alert=test' \
+      "$@" \
+      .
+}
+
+# Renders the chart in HA mode with raft storage.
+_template_ha() {
+  helm template \
+      --set 'server.ha.enabled=true' \
+      --set 'server.ha.raft.enabled=true' \
+      "$@" \
+      .
+}
+
+# Renders the chart with the OpenShift specific resources enabled.
+_template_openshift() {
+  helm template \
+      --set 'global.openshift=true' \
+      --set 'server.route.enabled=true' \
+      --set 'server.serviceCA.enabled=true' \
+      "$@" \
+      .
+}
+
+#--------------------------------------------------------------------
+# global.extraLabels
+
+@test "global/extraLabels: added to all resources in standalone mode" {
+  cd `chart_dir`
+  local actual=$(_template_standalone --set 'global.extraLabels.foo=bar' |
+      yq -s -r 'map(.metadata.labels.foo) | unique | join(",")' | tee /dev/stderr)
+  [ "${actual}" = "bar" ]
+}
+
+@test "global/extraLabels: added to all resources in ha mode" {
+  cd `chart_dir`
+  local actual=$(_template_ha --set 'global.extraLabels.foo=bar' |
+      yq -s -r 'map(.metadata.labels.foo) | unique | join(",")' | tee /dev/stderr)
+  [ "${actual}" = "bar" ]
+}
+
+@test "global/extraLabels: added to all resources on OpenShift" {
+  cd `chart_dir`
+  local actual=$(_template_openshift --set 'global.extraLabels.foo=bar' |
+      yq -s -r 'map(.metadata.labels.foo) | unique | join(",")' | tee /dev/stderr)
+  [ "${actual}" = "bar" ]
+}
+
+@test "global/extraLabels: added to workload pod templates" {
+  cd `chart_dir`
+  local output=$(_template_standalone --set 'global.extraLabels.foo=bar' |
+      yq -s 'map(select(.kind == "StatefulSet" or .kind == "Deployment" or .kind == "DaemonSet"))' | tee /dev/stderr)
+  [ "$(echo "$output" | yq -r 'length')" = "3" ]
+  [ "$(echo "$output" | yq -r 'map(.spec.template.metadata.labels.foo) | unique | join(",")')" = "bar" ]
+}
+
+@test "global/extraLabels: not added to selectors or volumeClaimTemplates" {
+  cd `chart_dir`
+  local output=$(helm template \
+      --show-only templates/server-statefulset.yaml \
+      --set 'server.auditStorage.enabled=true' \
+      --set 'global.extraLabels.foo=bar' \
+      . | tee /dev/stderr)
+  [ "$(echo "$output" | yq -r '.spec.selector.matchLabels.foo')" = "null" ]
+  [ "$(echo "$output" | yq -r '[.spec.volumeClaimTemplates[].metadata.labels.foo] | unique | join(",")')" = "" ]
+}
+
+@test "global/extraLabels: default is empty" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/server-statefulset.yaml \
+      . | tee /dev/stderr |
+      yq -r '.metadata.labels | length' | tee /dev/stderr)
+  [ "${actual}" = "5" ]
+}
+
+@test "global/extraLabels: reserved chart-managed labels are rejected" {
+  cd `chart_dir`
+  for key in 'app\.kubernetes\.io/name' 'app\.kubernetes\.io/instance' 'app\.kubernetes\.io/managed-by' 'helm\.sh/chart' 'component' 'vault-active' 'vault-internal'; do
+    run helm template \
+        --set-string "global.extraLabels.${key}=custom" \
+        .
+    [ "$status" -eq 1 ]
+    echo "$output" | grep 'global.extraLabels must not set'
+  done
+}
+
+@test "global/extraLabels: values are coerced to strings" {
+  cd `chart_dir`
+  local output=$(helm template \
+      --show-only templates/server-service.yaml \
+      --set 'global.extraLabels.numeric=123' \
+      --set 'global.extraLabels.boolean=true' \
+      . | tee /dev/stderr)
+  [ "$(echo "$output" | yq '.metadata.labels.numeric')" = '"123"' ]
+  [ "$(echo "$output" | yq '.metadata.labels.boolean')" = '"true"' ]
+}
+
+@test "global/extraLabels: composes with resource-specific extraLabels" {
+  cd `chart_dir`
+  local output=$(helm template \
+      --show-only templates/server-statefulset.yaml \
+      --set 'global.extraLabels.foo=bar' \
+      --set 'server.extraLabels.baz=qux' \
+      . | tee /dev/stderr)
+  [ "$(echo "$output" | yq -r '.spec.template.metadata.labels.foo')" = "bar" ]
+  [ "$(echo "$output" | yq -r '.spec.template.metadata.labels.baz')" = "qux" ]
+}
+
+@test "global/extraLabels: resource-specific extraLabels take precedence" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/server-statefulset.yaml \
+      --set 'global.extraLabels.foo=global' \
+      --set 'server.extraLabels.foo=server' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.metadata.labels.foo' | tee /dev/stderr)
+  [ "${actual}" = "server" ]
+}
+
+#--------------------------------------------------------------------
+# app.kubernetes.io/version
+
+@test "global/versionLabel: set from chart appVersion on all resources" {
+  cd `chart_dir`
+  local appVersion=$(yq -r '.appVersion' Chart.yaml)
+
+  local actual=$(_template_standalone |
+      yq -s -r 'map(.metadata.labels."app.kubernetes.io/version") | unique | join(",")' | tee /dev/stderr)
+  [ "${actual}" = "${appVersion}" ]
+
+  actual=$(_template_ha |
+      yq -s -r 'map(.metadata.labels."app.kubernetes.io/version") | unique | join(",")' | tee /dev/stderr)
+  [ "${actual}" = "${appVersion}" ]
+
+  actual=$(_template_openshift |
+      yq -s -r 'map(.metadata.labels."app.kubernetes.io/version") | unique | join(",")' | tee /dev/stderr)
+  [ "${actual}" = "${appVersion}" ]
+}
+
+@test "global/versionLabel: set on workload pod templates" {
+  cd `chart_dir`
+  local appVersion=$(yq -r '.appVersion' Chart.yaml)
+  local actual=$(_template_standalone |
+      yq -s -r 'map(select(.kind == "StatefulSet" or .kind == "Deployment" or .kind == "DaemonSet") | .spec.template.metadata.labels."app.kubernetes.io/version") | unique | join(",")' | tee /dev/stderr)
+  [ "${actual}" = "${appVersion}" ]
+}
+
+@test "global/versionLabel: overridable via global.extraLabels" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/server-statefulset.yaml \
+      --set-string 'global.extraLabels.app\.kubernetes\.io/version=overridden' \
+      . | tee /dev/stderr |
+      yq -r '.metadata.labels."app.kubernetes.io/version"' | tee /dev/stderr)
+  [ "${actual}" = "overridden" ]
+}
+
+#--------------------------------------------------------------------
+# helm.sh/chart
+
+@test "global/chartLabel: set on all resources" {
+  cd `chart_dir`
+  local chart=$(yq -r '"\(.name)-\(.version)"' Chart.yaml)
+
+  local actual=$(_template_standalone |
+      yq -s -r 'map(.metadata.labels."helm.sh/chart") | unique | join(",")' | tee /dev/stderr)
+  [ "${actual}" = "${chart}" ]
+
+  actual=$(_template_ha |
+      yq -s -r 'map(.metadata.labels."helm.sh/chart") | unique | join(",")' | tee /dev/stderr)
+  [ "${actual}" = "${chart}" ]
+
+  actual=$(_template_openshift |
+      yq -s -r 'map(.metadata.labels."helm.sh/chart") | unique | join(",")' | tee /dev/stderr)
+  [ "${actual}" = "${chart}" ]
+}
+
+@test "global/chartLabel: set on workload pod templates" {
+  cd `chart_dir`
+  local chart=$(yq -r '"\(.name)-\(.version)"' Chart.yaml)
+  local actual=$(_template_standalone |
+      yq -s -r 'map(select(.kind == "StatefulSet" or .kind == "Deployment" or .kind == "DaemonSet") | .spec.template.metadata.labels."helm.sh/chart") | unique | join(",")' | tee /dev/stderr)
+  [ "${actual}" = "${chart}" ]
+}

--- a/test/unit/injector-deployment.bats
+++ b/test/unit/injector-deployment.bats
@@ -938,6 +938,16 @@ EOF
   [ "${actual}" = "bar" ]
 }
 
+@test "injector/deployment: specify global.extraLabels" {
+  cd `chart_dir`
+  local output=$(helm template \
+      --show-only templates/injector-deployment.yaml \
+      --set 'global.extraLabels.foo=bar' \
+      . | tee /dev/stderr)
+  [ "$(echo "$output" | yq -r '.metadata.labels.foo')" = "bar" ]
+  [ "$(echo "$output" | yq -r '.spec.template.metadata.labels.foo')" = "bar" ]
+}
+
 #--------------------------------------------------------------------
 # hostNetwork
 

--- a/test/unit/prometheus-prometheusrules.bats
+++ b/test/unit/prometheus-prometheusrules.bats
@@ -46,7 +46,7 @@ load _helpers
       --set 'serverTelemetry.prometheusRules.rules[0].foo=bar' \
       . ) | tee /dev/stderr)
 
-  [ "$(echo "$output" | yq -r '.metadata.labels | length')" = "5" ]
+  [ "$(echo "$output" | yq -r '.metadata.labels | length')" = "6" ]
   [ "$(echo "$output" | yq -r '.metadata.labels.release')" = "prometheus" ]
 }
 
@@ -60,7 +60,7 @@ load _helpers
       --set 'serverTelemetry.prometheusRules.selectors.bar=foo' \
       . ) | tee /dev/stderr)
 
-  [ "$(echo "$output" | yq -r '.metadata.labels | length')" = "6" ]
+  [ "$(echo "$output" | yq -r '.metadata.labels | length')" = "7" ]
   [ "$(echo "$output" | yq -r '.metadata.labels | has("app")')" = "false" ]
   [ "$(echo "$output" | yq -r '.metadata.labels | has("kube-prometheus-stack")')" = "false" ]
   [ "$(echo "$output" | yq -r '.metadata.labels.baz')" = "qux" ]

--- a/test/unit/prometheus-servicemonitor.bats
+++ b/test/unit/prometheus-servicemonitor.bats
@@ -81,7 +81,7 @@ load _helpers
       --set 'serverTelemetry.serviceMonitor.enabled=true' \
       . ) | tee /dev/stderr)
 
-  [ "$(echo "$output" | yq -r '.metadata.labels | length')" = "5" ]
+  [ "$(echo "$output" | yq -r '.metadata.labels | length')" = "6" ]
   [ "$(echo "$output" | yq -r '.metadata.labels.release')" = "prometheus" ]
 }
 
@@ -94,7 +94,7 @@ load _helpers
       --set 'serverTelemetry.serviceMonitor.selectors.bar=foo' \
       . ) | tee /dev/stderr)
 
-  [ "$(echo "$output" | yq -r '.metadata.labels | length')" = "6" ]
+  [ "$(echo "$output" | yq -r '.metadata.labels | length')" = "7" ]
   [ "$(echo "$output" | yq -r '.metadata.labels | has("app")')" = "false" ]
   [ "$(echo "$output" | yq -r '.metadata.labels.baz')" = "qux" ]
   [ "$(echo "$output" | yq -r '.metadata.labels.bar')" = "foo" ]

--- a/test/unit/server-statefulset.bats
+++ b/test/unit/server-statefulset.bats
@@ -1141,6 +1141,16 @@ load _helpers
   [ "${actual}" = "bar" ]
 }
 
+@test "server/standalone-StatefulSet: specify global.extraLabels" {
+  cd `chart_dir`
+  local output=$(helm template \
+      --show-only templates/server-statefulset.yaml \
+      --set 'global.extraLabels.foo=bar' \
+      . | tee /dev/stderr)
+  [ "$(echo "$output" | yq -r '.metadata.labels.foo')" = "bar" ]
+  [ "$(echo "$output" | yq -r '.spec.template.metadata.labels.foo')" = "bar" ]
+}
+
 # extra annotations
 
 @test "server/standalone-StatefulSet: default statefulSet.annotations" {

--- a/test/unit/server-test.bats
+++ b/test/unit/server-test.bats
@@ -323,7 +323,19 @@ load _helpers
   local actual=$(helm template \
       --show-only templates/tests/server-test.yaml  \
       . | tee /dev/stderr |
-      yq -r '.metadata.labels // "null"' | tee /dev/stderr)
+      yq -r '.metadata.labels | keys | join(",")' | tee /dev/stderr)
 
-  [ "${actual}" = "null" ]
+  [ "${actual}" = "app.kubernetes.io/instance,app.kubernetes.io/managed-by,app.kubernetes.io/name,app.kubernetes.io/version,helm.sh/chart" ]
+}
+
+@test "server/standalone=server-test-Pod: specify global.extraLabels" {
+  cd `chart_dir`
+
+  local actual=$(helm template \
+      --show-only templates/tests/server-test.yaml  \
+      --set 'global.extraLabels.foo=bar' \
+      . | tee /dev/stderr |
+      yq -r '.metadata.labels.foo' | tee /dev/stderr)
+
+  [ "${actual}" = "bar" ]
 }

--- a/values.schema.json
+++ b/values.schema.json
@@ -251,6 +251,9 @@
                 "externalVaultAddr": {
                     "type": "string"
                 },
+                "extraLabels": {
+                    "type": "object"
+                },
                 "imagePullSecrets": {
                     "type": "array"
                 },

--- a/values.yaml
+++ b/values.yaml
@@ -17,6 +17,25 @@ global:
   # imagePullSecrets:
   #   - name: image-pull-secret
 
+  # extraLabels is a map of extra labels added to every resource created by
+  # this chart, including the pod templates of the server StatefulSet, the
+  # injector Deployment and the CSI provider DaemonSet, so the labels also
+  # appear on the pods themselves. Labels set here are never added to
+  # selectors or other immutable fields (such as the server StatefulSet
+  # volumeClaimTemplates), so they can be safely added or changed on an
+  # existing installation. Resource-specific labels
+  # (e.g. server.extraLabels) take precedence on duplicate keys. The chart
+  # itself adds the recommended helm.sh/chart and app.kubernetes.io/version
+  # labels to every resource; app.kubernetes.io/version defaults to the
+  # chart's appVersion and may be overridden here when the deployed version
+  # differs. All other chart-managed labels (app.kubernetes.io/name,
+  # app.kubernetes.io/instance, app.kubernetes.io/managed-by,
+  # helm.sh/chart, component, vault-active, vault-internal) must not be set
+  # here: rendering fails with an error if they are, because they would
+  # produce duplicate label keys and conflict with the labels used in
+  # selectors and HA request routing.
+  extraLabels: {}
+
   # TLS for end-to-end encrypted transport
   tlsDisable: true
 


### PR DESCRIPTION
Add a global.extraLabels value that applies a map of custom labels to every resource created by the chart, including the server StatefulSet, injector Deployment, and CSI DaemonSet pod templates, so the labels also appear on the pods themselves. Also add the recommended helm.sh/chart and app.kubernetes.io/version labels to every resource; app.kubernetes.io/version defaults to the chart's appVersion and can be overridden via global.extraLabels.

Labels are never added to selectors or other immutable fields, so they can be added or changed safely on an existing installation. Rendering fails with a clear error if global.extraLabels attempts to override a chart-managed label.

Fixes #1197

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [x] I have documented a clear reason for, and description of, the change I am making.

- [x] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [x] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
