### PR TITLE
Workloads revisionHistoryLimit support

### DIFF
--- a/templates/csi-daemonset.yaml
+++ b/templates/csi-daemonset.yaml
@@ -19,6 +19,9 @@ metadata:
     {{- end -}}
   {{ template "csi.daemonSet.annotations" . }}
 spec:
+  {{- if .Values.csi.daemonSet.revisionHistoryLimit }}
+  revisionHistoryLimit: {{ .Values.csi.daemonSet.revisionHistoryLimit }}
+  {{- end }}
   updateStrategy:
     type: {{ .Values.csi.daemonSet.updateStrategy.type }}
     {{- if .Values.csi.daemonSet.updateStrategy.maxUnavailable }}

--- a/templates/injector-deployment.yaml
+++ b/templates/injector-deployment.yaml
@@ -18,6 +18,9 @@ metadata:
     component: webhook
 spec:
   replicas: {{ .Values.injector.replicas }}
+  {{- if .Values.injector.revisionHistoryLimit }}
+  revisionHistoryLimit: {{ .Values.injector.revisionHistoryLimit }}
+  {{- end }}
   selector:
     matchLabels:
       app.kubernetes.io/name: {{ template "vault.name" . }}-agent-injector

--- a/templates/server-statefulset.yaml
+++ b/templates/server-statefulset.yaml
@@ -23,6 +23,9 @@ spec:
   serviceName: {{ template "vault.fullname" . }}-internal
   podManagementPolicy: Parallel
   replicas: {{ template "vault.replicas" . }}
+  {{- if .Values.server.revisionHistoryLimit }}
+  revisionHistoryLimit: {{ .Values.server.revisionHistoryLimit }}
+  {{- end }}
   updateStrategy:
     type: {{ .Values.server.updateStrategyType }}
   {{- if and (semverCompare ">= 1.23-0" .Capabilities.KubeVersion.Version) (.Values.server.persistentVolumeClaimRetentionPolicy) }}

--- a/test/unit/csi-daemonset.bats
+++ b/test/unit/csi-daemonset.bats
@@ -294,6 +294,29 @@ load _helpers
 }
 
 #--------------------------------------------------------------------
+# revisionHistoryLimit
+@test "csi/daemonset: revisionHistoryLimit not set by default" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/csi-daemonset.yaml \
+      --set "csi.enabled=true" \
+      . | tee /dev/stderr |
+      yq -r '.spec.revisionHistoryLimit' | tee /dev/stderr)
+  [ "${actual}" = "null" ]
+}
+
+@test "csi/daemonset: revisionHistoryLimit can be set" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/csi-daemonset.yaml \
+      --set "csi.enabled=true" \
+      --set "csi.daemonSet.revisionHistoryLimit=5" \
+      . | tee /dev/stderr |
+      yq -r '.spec.revisionHistoryLimit' | tee /dev/stderr)
+  [ "${actual}" = "5" ]
+}
+
+#--------------------------------------------------------------------
 # Extra annotations
 @test "csi/daemonset: default csi.daemonSet.annotations" {
   cd `chart_dir`

--- a/test/unit/injector-deployment.bats
+++ b/test/unit/injector-deployment.bats
@@ -1126,3 +1126,22 @@ EOF
       yq -r '.spec.strategy.rollingUpdate.maxUnavailable' | tee /dev/stderr)
   [ "${actual}" = "1" ]
 }
+
+@test "injector/deployment: revisionHistoryLimit not set by default" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/injector-deployment.yaml  \
+      . | tee /dev/stderr |
+      yq -r '.spec.revisionHistoryLimit' | tee /dev/stderr)
+  [ "${actual}" = "null" ]
+}
+
+@test "injector/deployment: revisionHistoryLimit can be set" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/injector-deployment.yaml  \
+      --set 'injector.revisionHistoryLimit=5' \
+      . | tee /dev/stderr |
+      yq -r '.spec.revisionHistoryLimit' | tee /dev/stderr)
+  [ "${actual}" = "5" ]
+}

--- a/test/unit/server-statefulset.bats
+++ b/test/unit/server-statefulset.bats
@@ -222,6 +222,28 @@ load _helpers
 }
 
 #--------------------------------------------------------------------
+# revisionHistoryLimit
+
+@test "server/standalone-StatefulSet: revisionHistoryLimit not set by default" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/server-statefulset.yaml  \
+      . | tee /dev/stderr |
+      yq -r '.spec.revisionHistoryLimit' | tee /dev/stderr)
+  [ "${actual}" = "null" ]
+}
+
+@test "server/standalone-StatefulSet: revisionHistoryLimit can be set" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/server-statefulset.yaml  \
+      --set 'server.revisionHistoryLimit=5' \
+      . | tee /dev/stderr |
+      yq -r '.spec.revisionHistoryLimit' | tee /dev/stderr)
+  [ "${actual}" = "5" ]
+}
+
+#--------------------------------------------------------------------
 # persistentVolumeClaimRetentionPolicy
 
 @test "server/standalone-StatefulSet: persistentVolumeClaimRetentionPolicy not set by default when kubernetes < 1.23" {

--- a/values.yaml
+++ b/values.yaml
@@ -50,6 +50,10 @@ injector:
 
   replicas: 1
 
+  # Configures the number of old ReplicaSets to retain to allow rollback.
+  # If unset, the Kubernetes default (10) is used.
+  revisionHistoryLimit: null
+
   # Configures the port the injector should listen on
   port: 8080
 
@@ -424,6 +428,10 @@ server:
   # Configure the Update Strategy Type for the StatefulSet
   # See https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#update-strategies
   updateStrategyType: "OnDelete"
+
+  # Configures the number of old ControllerRevisions to retain to allow rollback.
+  # If unset, the Kubernetes default (10) is used.
+  revisionHistoryLimit: null
 
   # Configure the logging verbosity for the Vault server.
   # Supported log levels include: trace, debug, info, warn, error
@@ -1225,6 +1233,9 @@ csi:
 
   # Settings for the daemonSet used to run the provider.
   daemonSet:
+    # Configures the number of old ControllerRevisions to retain to allow
+    # rollback. If unset, the Kubernetes default (10) is used.
+    revisionHistoryLimit: null
     updateStrategy:
       type: RollingUpdate
       maxUnavailable: ""


### PR DESCRIPTION
This PR adds support for setting revisionHistoryLimit on the workloads, ref - https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#managing-revision-history

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [x] I have documented a clear reason for, and description of, the change I am making.

- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
