### PR TITLE
To default helm-vault installation to vault enterprise when license is provided

### DIFF
--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -125,6 +125,41 @@ Compute if the ui is enabled.
 {{- end -}}
 
 {{/*
+Resolve the Vault server image repository.
+If server.image.repository is explicitly set to a non-default value, use it.
+Otherwise, auto-select hashicorp/vault-enterprise when an enterprise license
+secret is configured, falling back to hashicorp/vault for Community Edition.
+*/}}
+{{- define "vault.imageRepository" -}}
+{{- if and .Values.server.image.repository (ne .Values.server.image.repository "hashicorp/vault") -}}
+  {{- .Values.server.image.repository -}}
+{{- else if and .Values.server.enterpriseLicense.secretName .Values.server.enterpriseLicense.secretKey -}}
+  hashicorp/vault-enterprise
+{{- else -}}
+  {{- .Values.server.image.repository | default "hashicorp/vault" -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Resolve the Vault server image tag.
+If server.enterpriseLicense.secretName is set and the tag does not already
+carry the -ent suffix, append it automatically.
+Otherwise return the tag as-is.
+*/}}
+{{- define "vault.imageTag" -}}
+{{- $tag := .Values.server.image.tag | default "latest" -}}
+{{- if and .Values.server.enterpriseLicense.secretName .Values.server.enterpriseLicense.secretKey -}}
+  {{- if not (hasSuffix "-ent" $tag) -}}
+    {{- printf "%s-ent" $tag -}}
+  {{- else -}}
+    {{- $tag -}}
+  {{- end -}}
+{{- else -}}
+  {{- $tag -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
 Compute the maximum number of unavailable replicas for the PodDisruptionBudget.
 This defaults to ⌊(n-1)/2⌋ (equivalently, ceil(n/2)-1) where n is the number of
 members of the server cluster.

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -147,7 +147,7 @@ carry the -ent suffix, append it automatically.
 Otherwise return the tag as-is.
 */}}
 {{- define "vault.imageTag" -}}
-{{- $tag := .Values.server.image.tag | default "latest" -}}
+{{- $tag := .Values.server.image.tag | default .Chart.AppVersion -}}
 {{- if and .Values.server.enterpriseLicense.secretName .Values.server.enterpriseLicense.secretKey -}}
   {{- if not (hasSuffix "-ent" $tag) -}}
     {{- printf "%s-ent" $tag -}}

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -136,7 +136,7 @@ secret is configured, falling back to hashicorp/vault for Community Edition.
 {{- else if and .Values.server.enterpriseLicense.secretName .Values.server.enterpriseLicense.secretKey -}}
   hashicorp/vault-enterprise
 {{- else -}}
-  {{- .Values.server.image.repository | default "hashicorp/vault" -}}
+  hashicorp/vault
 {{- end -}}
 {{- end -}}
 
@@ -174,7 +174,7 @@ This helper mirrors the logic of vault.imageRepository:
 {{- else if and .Values.server.enterpriseLicense.secretName .Values.server.enterpriseLicense.secretKey -}}
   hashicorp/vault-enterprise
 {{- else -}}
-  {{- .Values.injector.agentImage.repository | default "hashicorp/vault" -}}
+  hashicorp/vault
 {{- end -}}
 {{- end -}}
 
@@ -213,7 +213,7 @@ vault.agentImageRepository:
 {{- else if and .Values.server.enterpriseLicense.secretName .Values.server.enterpriseLicense.secretKey -}}
   hashicorp/vault-enterprise
 {{- else -}}
-  {{- .Values.csi.agent.image.repository | default "hashicorp/vault" -}}
+  hashicorp/vault
 {{- end -}}
 {{- end -}}
 

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -147,7 +147,88 @@ carry the -ent suffix, append it automatically.
 Otherwise return the tag as-is.
 */}}
 {{- define "vault.imageTag" -}}
-{{- $tag := .Values.server.image.tag | default .Chart.AppVersion -}}
+{{- $tag := .Values.server.image.tag | default "latest" -}}
+{{- if and .Values.server.enterpriseLicense.secretName .Values.server.enterpriseLicense.secretKey -}}
+  {{- if not (hasSuffix "-ent" $tag) -}}
+    {{- printf "%s-ent" $tag -}}
+  {{- else -}}
+    {{- $tag -}}
+  {{- end -}}
+{{- else -}}
+  {{- $tag -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+This helper mirrors the logic of vault.imageRepository:
+- If the user has explicitly overridden injector.agentImage.repository to
+  something other than the default "hashicorp/vault", honour that value as-is
+  (custom registry scenario).
+- If server.enterpriseLicense.secretName + secretKey are both set, auto-select
+  hashicorp/vault-enterprise so the agent edition always matches the server.
+- Otherwise fall back to hashicorp/vault (CE).
+*/}}
+{{- define "vault.agentImageRepository" -}}
+{{- if and .Values.injector.agentImage.repository (ne .Values.injector.agentImage.repository "hashicorp/vault") -}}
+  {{- .Values.injector.agentImage.repository -}}
+{{- else if and .Values.server.enterpriseLicense.secretName .Values.server.enterpriseLicense.secretKey -}}
+  hashicorp/vault-enterprise
+{{- else -}}
+  {{- .Values.injector.agentImage.repository | default "hashicorp/vault" -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Companion to vault.agentImageRepository. Vault Enterprise images use a
+"-ent" tag suffix (e.g. 2.0.3-ent). This helper appends "-ent" automatically when the enterprise license
+is configured, matching the behaviour of vault.imageTag for the server.
+If the tag already carries the suffix it is left unchanged (idempotent).
+*/}}
+{{- define "vault.agentImageTag" -}}
+{{- $tag := .Values.injector.agentImage.tag | default "latest" -}}
+{{- if and .Values.server.enterpriseLicense.secretName .Values.server.enterpriseLicense.secretKey -}}
+  {{- if not (hasSuffix "-ent" $tag) -}}
+    {{- printf "%s-ent" $tag -}}
+  {{- else -}}
+    {{- $tag -}}
+  {{- end -}}
+{{- else -}}
+  {{- $tag -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+This helper mirrors the logic of vault.imageRepository and
+vault.agentImageRepository:
+- If csi.agent.image.repository is explicitly set to a non-default value,
+  honour it as-is (custom registry scenario).
+- If server.enterpriseLicense.secretName + secretKey are both set,
+  auto-select hashicorp/vault-enterprise so the CSI agent edition always
+  matches the server.
+- Otherwise fall back to hashicorp/vault (CE), preserving existing behaviour.
+*/}}
+{{- define "vault.csiAgentImageRepository" -}}
+{{- if and .Values.csi.agent.image.repository (ne .Values.csi.agent.image.repository "hashicorp/vault") -}}
+  {{- .Values.csi.agent.image.repository -}}
+{{- else if and .Values.server.enterpriseLicense.secretName .Values.server.enterpriseLicense.secretKey -}}
+  hashicorp/vault-enterprise
+{{- else -}}
+  {{- .Values.csi.agent.image.repository | default "hashicorp/vault" -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Companion to vault.csiAgentImageRepository. Vault Enterprise images on
+DockerHub require the "-ent" tag suffix (e.g. 2.0.3-ent). Fixing the
+repository to hashicorp/vault-enterprise without also fixing the tag would
+result in an ImagePullBackOff because hashicorp/vault-enterprise:2.0.3
+does not exist. This helper appends "-ent" automatically when the enterprise
+license is configured, matching the behaviour of vault.imageTag for the server
+and vault.agentImageTag for the injector sidecar.
+If the tag already carries the "-ent" suffix it is left unchanged (idempotent).
+*/}}
+{{- define "vault.csiAgentImageTag" -}}
+{{- $tag := .Values.csi.agent.image.tag | default "latest" -}}
 {{- if and .Values.server.enterpriseLicense.secretName .Values.server.enterpriseLicense.secretKey -}}
   {{- if not (hasSuffix "-ent" $tag) -}}
     {{- printf "%s-ent" $tag -}}

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -137,19 +137,15 @@ Returns a non-empty string when an enterprise license secret is fully configured
 Generic helper — resolves a Vault image repository.
 Accepts a dict: { "repo": <string>, "root": <top-level context> }
 
-Decision tree:
-  - repo is not one of the two known defaults → return as-is (custom registry)
-  - enterprise license configured             → hashicorp/vault-enterprise
-  - otherwise                                 → hashicorp/vault (CE)
-
-values.yaml defaults to hashicorp/vault-enterprise; this helper overrides it
-to hashicorp/vault when no license is present.
+- If repo is not set or is the default "hashicorp/vault":
+    license present → hashicorp/vault-enterprise
+    no license      → hashicorp/vault
+- Any other explicit repo (custom registry, hashicorp/vault-enterprise, etc.)
+  is always returned verbatim — never modified.
 */}}
 {{- define "vault.resolveImageRepository" -}}
-{{- $repo := .repo | default "hashicorp/vault" -}}
-{{- $isDefault := or (eq $repo "hashicorp/vault") (eq $repo "hashicorp/vault-enterprise") -}}
-{{- if not $isDefault -}}
-  {{- $repo -}}
+{{- if and .repo (ne .repo "hashicorp/vault") -}}
+  {{- .repo -}}
 {{- else if include "vault.isEnterprise" .root -}}
   hashicorp/vault-enterprise
 {{- else -}}
@@ -161,25 +157,21 @@ to hashicorp/vault when no license is present.
 Generic helper — resolves a Vault image tag.
 Accepts a dict: { "tag": <string>, "root": <top-level context> }
 
-Decision tree:
-  - tag is not one of the two known defaults (AppVersion / AppVersion-ent)
-      → return as-is (custom tag, never append -ent)
-  - enterprise license configured → AppVersion-ent
-  - otherwise                     → plain AppVersion (CE)
-
-values.yaml defaults to AppVersion-ent; this helper overrides it to plain
-AppVersion when no license is present.
+- If tag is not set:
+    license present → AppVersion-ent  (e.g. 2.0.4-ent)
+    no license      → AppVersion      (e.g. 2.0.4)
+- Any explicit tag is always returned verbatim — never modified.
 */}}
 {{- define "vault.resolveImageTag" -}}
-{{- $tag := .tag | default .root.Chart.AppVersion -}}
 {{- $entTag := printf "%s-ent" .root.Chart.AppVersion -}}
-{{- $isDefault := or (eq $tag .root.Chart.AppVersion) (eq $tag $entTag) -}}
-{{- if not $isDefault -}}
-  {{- $tag -}}
-{{- else if include "vault.isEnterprise" .root -}}
-  {{- $entTag -}}
+{{- if not .tag -}}
+  {{- if include "vault.isEnterprise" .root -}}
+    {{- $entTag -}}
+  {{- else -}}
+    {{- .root.Chart.AppVersion -}}
+  {{- end -}}
 {{- else -}}
-  {{- .root.Chart.AppVersion -}}
+  {{- .tag -}}
 {{- end -}}
 {{- end -}}
 

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -142,12 +142,14 @@ secret is configured, falling back to hashicorp/vault for Community Edition.
 
 {{/*
 Resolve the Vault server image tag.
+If server.image.tag is set, use it; otherwise fall back to $.Chart.AppVersion
+so that Chart.yaml is the single source of truth for the Vault version.
 If server.enterpriseLicense.secretName is set and the tag does not already
 carry the -ent suffix, append it automatically.
 Otherwise return the tag as-is.
 */}}
 {{- define "vault.imageTag" -}}
-{{- $tag := .Values.server.image.tag | default "latest" -}}
+{{- $tag := .Values.server.image.tag | default .Chart.AppVersion -}}
 {{- if and .Values.server.enterpriseLicense.secretName .Values.server.enterpriseLicense.secretKey -}}
   {{- if not (hasSuffix "-ent" $tag) -}}
     {{- printf "%s-ent" $tag -}}
@@ -182,10 +184,11 @@ This helper mirrors the logic of vault.imageRepository:
 Companion to vault.agentImageRepository. Vault Enterprise images use a
 "-ent" tag suffix (e.g. 2.0.3-ent). This helper appends "-ent" automatically when the enterprise license
 is configured, matching the behaviour of vault.imageTag for the server.
+If injector.agentImage.tag is not set, falls back to $.Chart.AppVersion.
 If the tag already carries the suffix it is left unchanged (idempotent).
 */}}
 {{- define "vault.agentImageTag" -}}
-{{- $tag := .Values.injector.agentImage.tag | default "latest" -}}
+{{- $tag := .Values.injector.agentImage.tag | default .Chart.AppVersion -}}
 {{- if and .Values.server.enterpriseLicense.secretName .Values.server.enterpriseLicense.secretKey -}}
   {{- if not (hasSuffix "-ent" $tag) -}}
     {{- printf "%s-ent" $tag -}}
@@ -225,10 +228,11 @@ result in an ImagePullBackOff because hashicorp/vault-enterprise:2.0.3
 does not exist. This helper appends "-ent" automatically when the enterprise
 license is configured, matching the behaviour of vault.imageTag for the server
 and vault.agentImageTag for the injector sidecar.
+If csi.agent.image.tag is not set, falls back to $.Chart.AppVersion.
 If the tag already carries the "-ent" suffix it is left unchanged (idempotent).
 */}}
 {{- define "vault.csiAgentImageTag" -}}
-{{- $tag := .Values.csi.agent.image.tag | default "latest" -}}
+{{- $tag := .Values.csi.agent.image.tag | default .Chart.AppVersion -}}
 {{- if and .Values.server.enterpriseLicense.secretName .Values.server.enterpriseLicense.secretKey -}}
   {{- if not (hasSuffix "-ent" $tag) -}}
     {{- printf "%s-ent" $tag -}}

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -136,103 +136,18 @@ secret is configured, falling back to hashicorp/vault for Community Edition.
 {{- else if and .Values.server.enterpriseLicense.secretName .Values.server.enterpriseLicense.secretKey -}}
   hashicorp/vault-enterprise
 {{- else -}}
-  hashicorp/vault
+  {{- .Values.server.image.repository | default "hashicorp/vault" -}}
 {{- end -}}
 {{- end -}}
 
 {{/*
 Resolve the Vault server image tag.
-If server.image.tag is set, use it; otherwise fall back to $.Chart.AppVersion
-so that Chart.yaml is the single source of truth for the Vault version.
 If server.enterpriseLicense.secretName is set and the tag does not already
 carry the -ent suffix, append it automatically.
 Otherwise return the tag as-is.
 */}}
 {{- define "vault.imageTag" -}}
-{{- $tag := .Values.server.image.tag | default .Chart.AppVersion -}}
-{{- if and .Values.server.enterpriseLicense.secretName .Values.server.enterpriseLicense.secretKey -}}
-  {{- if not (hasSuffix "-ent" $tag) -}}
-    {{- printf "%s-ent" $tag -}}
-  {{- else -}}
-    {{- $tag -}}
-  {{- end -}}
-{{- else -}}
-  {{- $tag -}}
-{{- end -}}
-{{- end -}}
-
-{{/*
-This helper mirrors the logic of vault.imageRepository:
-- If the user has explicitly overridden injector.agentImage.repository to
-  something other than the default "hashicorp/vault", honour that value as-is
-  (custom registry scenario).
-- If server.enterpriseLicense.secretName + secretKey are both set, auto-select
-  hashicorp/vault-enterprise so the agent edition always matches the server.
-- Otherwise fall back to hashicorp/vault (CE).
-*/}}
-{{- define "vault.agentImageRepository" -}}
-{{- if and .Values.injector.agentImage.repository (ne .Values.injector.agentImage.repository "hashicorp/vault") -}}
-  {{- .Values.injector.agentImage.repository -}}
-{{- else if and .Values.server.enterpriseLicense.secretName .Values.server.enterpriseLicense.secretKey -}}
-  hashicorp/vault-enterprise
-{{- else -}}
-  hashicorp/vault
-{{- end -}}
-{{- end -}}
-
-{{/*
-Companion to vault.agentImageRepository. Vault Enterprise images use a
-"-ent" tag suffix (e.g. 2.0.3-ent). This helper appends "-ent" automatically when the enterprise license
-is configured, matching the behaviour of vault.imageTag for the server.
-If injector.agentImage.tag is not set, falls back to $.Chart.AppVersion.
-If the tag already carries the suffix it is left unchanged (idempotent).
-*/}}
-{{- define "vault.agentImageTag" -}}
-{{- $tag := .Values.injector.agentImage.tag | default .Chart.AppVersion -}}
-{{- if and .Values.server.enterpriseLicense.secretName .Values.server.enterpriseLicense.secretKey -}}
-  {{- if not (hasSuffix "-ent" $tag) -}}
-    {{- printf "%s-ent" $tag -}}
-  {{- else -}}
-    {{- $tag -}}
-  {{- end -}}
-{{- else -}}
-  {{- $tag -}}
-{{- end -}}
-{{- end -}}
-
-{{/*
-This helper mirrors the logic of vault.imageRepository and
-vault.agentImageRepository:
-- If csi.agent.image.repository is explicitly set to a non-default value,
-  honour it as-is (custom registry scenario).
-- If server.enterpriseLicense.secretName + secretKey are both set,
-  auto-select hashicorp/vault-enterprise so the CSI agent edition always
-  matches the server.
-- Otherwise fall back to hashicorp/vault (CE), preserving existing behaviour.
-*/}}
-{{- define "vault.csiAgentImageRepository" -}}
-{{- if and .Values.csi.agent.image.repository (ne .Values.csi.agent.image.repository "hashicorp/vault") -}}
-  {{- .Values.csi.agent.image.repository -}}
-{{- else if and .Values.server.enterpriseLicense.secretName .Values.server.enterpriseLicense.secretKey -}}
-  hashicorp/vault-enterprise
-{{- else -}}
-  hashicorp/vault
-{{- end -}}
-{{- end -}}
-
-{{/*
-Companion to vault.csiAgentImageRepository. Vault Enterprise images on
-DockerHub require the "-ent" tag suffix (e.g. 2.0.3-ent). Fixing the
-repository to hashicorp/vault-enterprise without also fixing the tag would
-result in an ImagePullBackOff because hashicorp/vault-enterprise:2.0.3
-does not exist. This helper appends "-ent" automatically when the enterprise
-license is configured, matching the behaviour of vault.imageTag for the server
-and vault.agentImageTag for the injector sidecar.
-If csi.agent.image.tag is not set, falls back to $.Chart.AppVersion.
-If the tag already carries the "-ent" suffix it is left unchanged (idempotent).
-*/}}
-{{- define "vault.csiAgentImageTag" -}}
-{{- $tag := .Values.csi.agent.image.tag | default .Chart.AppVersion -}}
+{{- $tag := .Values.server.image.tag | default "latest" -}}
 {{- if and .Values.server.enterpriseLicense.secretName .Values.server.enterpriseLicense.secretKey -}}
   {{- if not (hasSuffix "-ent" $tag) -}}
     {{- printf "%s-ent" $tag -}}

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -134,132 +134,83 @@ Returns a non-empty string when an enterprise license secret is fully configured
 {{- end -}}
 
 {{/*
-Resolve the Vault server image repository.
-If server.image.repository is explicitly set to a non-default value, use it.
-Otherwise, auto-select hashicorp/vault-enterprise when an enterprise license
-secret is configured, falling back to hashicorp/vault for Community Edition.
-The repository decision is independent of the tag — a user-supplied tag does
-not suppress repository auto-selection.
+Generic helper — resolves a Vault image repository.
+Accepts a dict: { "repo": <string>, "root": <top-level context> }
+
+Decision tree:
+  - repo is not one of the two known defaults → return as-is (custom registry)
+  - enterprise license configured             → hashicorp/vault-enterprise
+  - otherwise                                 → hashicorp/vault (CE)
+
+values.yaml defaults to hashicorp/vault-enterprise; this helper overrides it
+to hashicorp/vault when no license is present.
 */}}
+{{- define "vault.resolveImageRepository" -}}
+{{- $repo := .repo | default "hashicorp/vault" -}}
+{{- $isDefault := or (eq $repo "hashicorp/vault") (eq $repo "hashicorp/vault-enterprise") -}}
+{{- if not $isDefault -}}
+  {{- $repo -}}
+{{- else if include "vault.isEnterprise" .root -}}
+  hashicorp/vault-enterprise
+{{- else -}}
+  hashicorp/vault
+{{- end -}}
+{{- end -}}
+
+{{/*
+Generic helper — resolves a Vault image tag.
+Accepts a dict: { "tag": <string>, "root": <top-level context> }
+
+Decision tree:
+  - tag is not one of the two known defaults (AppVersion / AppVersion-ent)
+      → return as-is (custom tag, never append -ent)
+  - enterprise license configured → AppVersion-ent
+  - otherwise                     → plain AppVersion (CE)
+
+values.yaml defaults to AppVersion-ent; this helper overrides it to plain
+AppVersion when no license is present.
+*/}}
+{{- define "vault.resolveImageTag" -}}
+{{- $tag := .tag | default .root.Chart.AppVersion -}}
+{{- $entTag := printf "%s-ent" .root.Chart.AppVersion -}}
+{{- $isDefault := or (eq $tag .root.Chart.AppVersion) (eq $tag $entTag) -}}
+{{- if not $isDefault -}}
+  {{- $tag -}}
+{{- else if include "vault.isEnterprise" .root -}}
+  {{- $entTag -}}
+{{- else -}}
+  {{- .root.Chart.AppVersion -}}
+{{- end -}}
+{{- end -}}
+
+{{/* Vault server image repository — delegates to vault.resolveImageRepository. */}}
 {{- define "vault.imageRepository" -}}
-{{- if and .Values.server.image.repository (ne .Values.server.image.repository "hashicorp/vault") -}}
-  {{- .Values.server.image.repository -}}
-{{- else if include "vault.isEnterprise" . -}}
-  hashicorp/vault-enterprise
-{{- else -}}
-  {{- .Values.server.image.repository | default "hashicorp/vault" -}}
-{{- end -}}
+{{- include "vault.resolveImageRepository" (dict "repo" .Values.server.image.repository "root" .) -}}
 {{- end -}}
 
-{{/*
-Resolve the Vault server image tag.
-If server.image.tag is non-empty the user has explicitly supplied a tag —
-return it unchanged, no -ent suffix is appended.
-When server.image.tag is empty, fall back to Chart.AppVersion; if an enterprise
-license is also configured, append -ent automatically (idempotent if already
-present) so the image edition matches the server.
-*/}}
+{{/* Vault server image tag — delegates to vault.resolveImageTag. */}}
 {{- define "vault.imageTag" -}}
-{{- $tag := .Values.server.image.tag | default .Chart.AppVersion -}}
-{{- if and (not .Values.server.image.tag) (include "vault.isEnterprise" .) -}}
-  {{- if not (hasSuffix "-ent" $tag) -}}
-    {{- printf "%s-ent" $tag -}}
-  {{- else -}}
-    {{- $tag -}}
-  {{- end -}}
-{{- else -}}
-  {{- $tag -}}
-{{- end -}}
+{{- include "vault.resolveImageTag" (dict "tag" .Values.server.image.tag "root" .) -}}
 {{- end -}}
 
-{{/*
-This helper mirrors the logic of vault.imageRepository:
-- If the user has explicitly overridden injector.agentImage.repository to
-  something other than the default "hashicorp/vault", honour that value as-is
-  (custom registry scenario).
-- If server.enterpriseLicense.secretName + secretKey are both set, auto-select
-  hashicorp/vault-enterprise so the agent edition always matches the server.
-- Otherwise fall back to hashicorp/vault (CE).
-The repository decision is independent of the tag — a user-supplied tag does
-not suppress repository auto-selection.
-*/}}
+{{/* Injector agent image repository — delegates to vault.resolveImageRepository. */}}
 {{- define "vault.agentImageRepository" -}}
-{{- if and .Values.injector.agentImage.repository (ne .Values.injector.agentImage.repository "hashicorp/vault") -}}
-  {{- .Values.injector.agentImage.repository -}}
-{{- else if include "vault.isEnterprise" . -}}
-  hashicorp/vault-enterprise
-{{- else -}}
-  hashicorp/vault
-{{- end -}}
+{{- include "vault.resolveImageRepository" (dict "repo" .Values.injector.agentImage.repository "root" .) -}}
 {{- end -}}
 
-{{/*
-Companion to vault.agentImageRepository. Vault Enterprise images use a
-"-ent" tag suffix (e.g. 2.0.3-ent).
-If injector.agentImage.tag is non-empty the user has explicitly supplied a
-tag — return it unchanged, no -ent suffix is appended.
-When injector.agentImage.tag is empty, fall back to Chart.AppVersion; if an
-enterprise license is also configured, append -ent automatically (idempotent
-if already present) so the agent edition matches the server.
-*/}}
+{{/* Injector agent image tag — delegates to vault.resolveImageTag. */}}
 {{- define "vault.agentImageTag" -}}
-{{- $tag := .Values.injector.agentImage.tag | default .Chart.AppVersion -}}
-{{- if and (not .Values.injector.agentImage.tag) (include "vault.isEnterprise" .) -}}
-  {{- if not (hasSuffix "-ent" $tag) -}}
-    {{- printf "%s-ent" $tag -}}
-  {{- else -}}
-    {{- $tag -}}
-  {{- end -}}
-{{- else -}}
-  {{- $tag -}}
-{{- end -}}
+{{- include "vault.resolveImageTag" (dict "tag" .Values.injector.agentImage.tag "root" .) -}}
 {{- end -}}
 
-{{/*
-This helper mirrors the logic of vault.imageRepository and
-vault.agentImageRepository:
-- If csi.agent.image.repository is explicitly set to a non-default value,
-  honour it as-is (custom registry scenario).
-- If server.enterpriseLicense.secretName + secretKey are both set,
-  auto-select hashicorp/vault-enterprise so the CSI agent edition always
-  matches the server.
-- Otherwise fall back to hashicorp/vault (CE), preserving existing behaviour.
-The repository decision is independent of the tag — a user-supplied tag does
-not suppress repository auto-selection.
-*/}}
+{{/* CSI agent image repository — delegates to vault.resolveImageRepository. */}}
 {{- define "vault.csiAgentImageRepository" -}}
-{{- if and .Values.csi.agent.image.repository (ne .Values.csi.agent.image.repository "hashicorp/vault") -}}
-  {{- .Values.csi.agent.image.repository -}}
-{{- else if include "vault.isEnterprise" . -}}
-  hashicorp/vault-enterprise
-{{- else -}}
-  hashicorp/vault
-{{- end -}}
+{{- include "vault.resolveImageRepository" (dict "repo" .Values.csi.agent.image.repository "root" .) -}}
 {{- end -}}
 
-{{/*
-Companion to vault.csiAgentImageRepository. Vault Enterprise images on
-DockerHub require the "-ent" tag suffix (e.g. 2.0.3-ent). Fixing the
-repository to hashicorp/vault-enterprise without also fixing the tag would
-result in an ImagePullBackOff because hashicorp/vault-enterprise:2.0.3
-does not exist.
-If csi.agent.image.tag is non-empty the user has explicitly supplied a tag —
-return it unchanged, no -ent suffix is appended.
-When csi.agent.image.tag is empty, fall back to Chart.AppVersion; if an
-enterprise license is also configured, append -ent automatically (idempotent
-if already present) so the CSI agent edition matches the server.
-*/}}
+{{/* CSI agent image tag — delegates to vault.resolveImageTag. */}}
 {{- define "vault.csiAgentImageTag" -}}
-{{- $tag := .Values.csi.agent.image.tag | default .Chart.AppVersion -}}
-{{- if and (not .Values.csi.agent.image.tag) (include "vault.isEnterprise" .) -}}
-  {{- if not (hasSuffix "-ent" $tag) -}}
-    {{- printf "%s-ent" $tag -}}
-  {{- else -}}
-    {{- $tag -}}
-  {{- end -}}
-{{- else -}}
-  {{- $tag -}}
-{{- end -}}
+{{- include "vault.resolveImageTag" (dict "tag" .Values.csi.agent.image.tag "root" .) -}}
 {{- end -}}
 
 {{/*

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -125,15 +125,26 @@ Compute if the ui is enabled.
 {{- end -}}
 
 {{/*
+Returns a non-empty string when an enterprise license secret is fully configured
+(both secretName and secretKey are set). Use with `if` or `and`:
+  {{- if include "vault.isEnterprise" . -}}
+*/}}
+{{- define "vault.isEnterprise" -}}
+{{- if and .Values.server.enterpriseLicense.secretName .Values.server.enterpriseLicense.secretKey -}}true{{- end -}}
+{{- end -}}
+
+{{/*
 Resolve the Vault server image repository.
 If server.image.repository is explicitly set to a non-default value, use it.
 Otherwise, auto-select hashicorp/vault-enterprise when an enterprise license
 secret is configured, falling back to hashicorp/vault for Community Edition.
+The repository decision is independent of the tag — a user-supplied tag does
+not suppress repository auto-selection.
 */}}
 {{- define "vault.imageRepository" -}}
 {{- if and .Values.server.image.repository (ne .Values.server.image.repository "hashicorp/vault") -}}
   {{- .Values.server.image.repository -}}
-{{- else if and .Values.server.enterpriseLicense.secretName .Values.server.enterpriseLicense.secretKey -}}
+{{- else if include "vault.isEnterprise" . -}}
   hashicorp/vault-enterprise
 {{- else -}}
   {{- .Values.server.image.repository | default "hashicorp/vault" -}}
@@ -142,13 +153,105 @@ secret is configured, falling back to hashicorp/vault for Community Edition.
 
 {{/*
 Resolve the Vault server image tag.
-If server.enterpriseLicense.secretName is set and the tag does not already
-carry the -ent suffix, append it automatically.
-Otherwise return the tag as-is.
+If server.image.tag is non-empty the user has explicitly supplied a tag —
+return it unchanged, no -ent suffix is appended.
+When server.image.tag is empty, fall back to Chart.AppVersion; if an enterprise
+license is also configured, append -ent automatically (idempotent if already
+present) so the image edition matches the server.
 */}}
 {{- define "vault.imageTag" -}}
-{{- $tag := .Values.server.image.tag | default "latest" -}}
-{{- if and .Values.server.enterpriseLicense.secretName .Values.server.enterpriseLicense.secretKey -}}
+{{- $tag := .Values.server.image.tag | default .Chart.AppVersion -}}
+{{- if and (not .Values.server.image.tag) (include "vault.isEnterprise" .) -}}
+  {{- if not (hasSuffix "-ent" $tag) -}}
+    {{- printf "%s-ent" $tag -}}
+  {{- else -}}
+    {{- $tag -}}
+  {{- end -}}
+{{- else -}}
+  {{- $tag -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+This helper mirrors the logic of vault.imageRepository:
+- If the user has explicitly overridden injector.agentImage.repository to
+  something other than the default "hashicorp/vault", honour that value as-is
+  (custom registry scenario).
+- If server.enterpriseLicense.secretName + secretKey are both set, auto-select
+  hashicorp/vault-enterprise so the agent edition always matches the server.
+- Otherwise fall back to hashicorp/vault (CE).
+The repository decision is independent of the tag — a user-supplied tag does
+not suppress repository auto-selection.
+*/}}
+{{- define "vault.agentImageRepository" -}}
+{{- if and .Values.injector.agentImage.repository (ne .Values.injector.agentImage.repository "hashicorp/vault") -}}
+  {{- .Values.injector.agentImage.repository -}}
+{{- else if include "vault.isEnterprise" . -}}
+  hashicorp/vault-enterprise
+{{- else -}}
+  hashicorp/vault
+{{- end -}}
+{{- end -}}
+
+{{/*
+Companion to vault.agentImageRepository. Vault Enterprise images use a
+"-ent" tag suffix (e.g. 2.0.3-ent).
+If injector.agentImage.tag is non-empty the user has explicitly supplied a
+tag — return it unchanged, no -ent suffix is appended.
+When injector.agentImage.tag is empty, fall back to Chart.AppVersion; if an
+enterprise license is also configured, append -ent automatically (idempotent
+if already present) so the agent edition matches the server.
+*/}}
+{{- define "vault.agentImageTag" -}}
+{{- $tag := .Values.injector.agentImage.tag | default .Chart.AppVersion -}}
+{{- if and (not .Values.injector.agentImage.tag) (include "vault.isEnterprise" .) -}}
+  {{- if not (hasSuffix "-ent" $tag) -}}
+    {{- printf "%s-ent" $tag -}}
+  {{- else -}}
+    {{- $tag -}}
+  {{- end -}}
+{{- else -}}
+  {{- $tag -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+This helper mirrors the logic of vault.imageRepository and
+vault.agentImageRepository:
+- If csi.agent.image.repository is explicitly set to a non-default value,
+  honour it as-is (custom registry scenario).
+- If server.enterpriseLicense.secretName + secretKey are both set,
+  auto-select hashicorp/vault-enterprise so the CSI agent edition always
+  matches the server.
+- Otherwise fall back to hashicorp/vault (CE), preserving existing behaviour.
+The repository decision is independent of the tag — a user-supplied tag does
+not suppress repository auto-selection.
+*/}}
+{{- define "vault.csiAgentImageRepository" -}}
+{{- if and .Values.csi.agent.image.repository (ne .Values.csi.agent.image.repository "hashicorp/vault") -}}
+  {{- .Values.csi.agent.image.repository -}}
+{{- else if include "vault.isEnterprise" . -}}
+  hashicorp/vault-enterprise
+{{- else -}}
+  hashicorp/vault
+{{- end -}}
+{{- end -}}
+
+{{/*
+Companion to vault.csiAgentImageRepository. Vault Enterprise images on
+DockerHub require the "-ent" tag suffix (e.g. 2.0.3-ent). Fixing the
+repository to hashicorp/vault-enterprise without also fixing the tag would
+result in an ImagePullBackOff because hashicorp/vault-enterprise:2.0.3
+does not exist.
+If csi.agent.image.tag is non-empty the user has explicitly supplied a tag —
+return it unchanged, no -ent suffix is appended.
+When csi.agent.image.tag is empty, fall back to Chart.AppVersion; if an
+enterprise license is also configured, append -ent automatically (idempotent
+if already present) so the CSI agent edition matches the server.
+*/}}
+{{- define "vault.csiAgentImageTag" -}}
+{{- $tag := .Values.csi.agent.image.tag | default .Chart.AppVersion -}}
+{{- if and (not .Values.csi.agent.image.tag) (include "vault.isEnterprise" .) -}}
   {{- if not (hasSuffix "-ent" $tag) -}}
     {{- printf "%s-ent" $tag -}}
   {{- else -}}
@@ -242,7 +345,7 @@ extra volumes the user may have specified (such as a secret with TLS).
   {{- if .Values.server.volumes }}
     {{- toYaml .Values.server.volumes | nindent 8}}
   {{- end }}
-  {{- if (and .Values.server.enterpriseLicense.secretName .Values.server.enterpriseLicense.secretKey) }}
+  {{- if include "vault.isEnterprise" . }}
         - name: vault-license
           secret:
             secretName: {{ .Values.server.enterpriseLicense.secretName }}
@@ -324,7 +427,7 @@ based on the mode configured.
   {{- if .Values.server.volumeMounts }}
     {{- toYaml .Values.server.volumeMounts | nindent 12}}
   {{- end }}
-  {{- if (and .Values.server.enterpriseLicense.secretName .Values.server.enterpriseLicense.secretKey) }}
+  {{- if include "vault.isEnterprise" . }}
             - name: vault-license
               mountPath: /vault/license
               readOnly: true

--- a/templates/csi-daemonset.yaml
+++ b/templates/csi-daemonset.yaml
@@ -108,7 +108,7 @@ spec:
             timeoutSeconds: {{ .Values.csi.readinessProbe.timeoutSeconds }}
         {{- if eq (.Values.csi.agent.enabled | toString) "true" }}
         - name: {{ include "vault.name" . }}-agent
-          image: "{{ .Values.csi.agent.image.repository }}:{{ .Values.csi.agent.image.tag }}"
+          image: "{{ include "vault.csiAgentImageRepository" . }}:{{ include "vault.csiAgentImageTag" . }}"
           imagePullPolicy: {{ .Values.csi.agent.image.pullPolicy }}
           {{ template "csi.agent.resources" . }}
           command:

--- a/templates/injector-deployment.yaml
+++ b/templates/injector-deployment.yaml
@@ -69,7 +69,7 @@ spec:
             - name: AGENT_INJECT_VAULT_AUTH_PATH
               value: {{ .Values.injector.authPath }}
             - name: AGENT_INJECT_VAULT_IMAGE
-              value: "{{ .Values.injector.agentImage.repository }}:{{ .Values.injector.agentImage.tag }}"
+              value: "{{ include "vault.agentImageRepository" . }}:{{ include "vault.agentImageTag" . }}"
             {{- if .Values.injector.certs.secretName }}
             - name: AGENT_INJECT_TLS_CERT_FILE
               value: "/etc/webhook/certs/{{ .Values.injector.certs.certName }}"

--- a/templates/server-statefulset.yaml
+++ b/templates/server-statefulset.yaml
@@ -76,7 +76,7 @@ spec:
       containers:
         - name: vault
           {{ template "vault.resources" . }}
-          image: {{ .Values.server.image.repository }}:{{ .Values.server.image.tag | default "latest" }}
+          image: {{ template "vault.imageRepository" . }}:{{ template "vault.imageTag" . }}
           imagePullPolicy: {{ .Values.server.image.pullPolicy }}
           command:
           - "/bin/sh"

--- a/templates/server-statefulset.yaml
+++ b/templates/server-statefulset.yaml
@@ -144,7 +144,7 @@ spec:
             - name: VAULT_LOG_FORMAT
               value: "{{ .Values.server.logFormat }}"
             {{- end }}
-            {{- if (and .Values.server.enterpriseLicense.secretName .Values.server.enterpriseLicense.secretKey) }}
+            {{- if include "vault.isEnterprise" . }}
             - name: VAULT_LICENSE_PATH
               value: /vault/license/{{ .Values.server.enterpriseLicense.secretKey }}
             {{- end }}

--- a/templates/tests/server-test.yaml
+++ b/templates/tests/server-test.yaml
@@ -21,7 +21,7 @@ spec:
   {{- include "imagePullSecrets" . | nindent 2 }}
   containers:
     - name: {{ .Release.Name }}-server-test
-      image: {{ .Values.server.image.repository }}:{{ .Values.server.image.tag | default "latest" }}
+      image: {{ template "vault.imageRepository" . }}:{{ template "vault.imageTag" . }}
       imagePullPolicy: {{ .Values.server.image.pullPolicy }}
       env:
         - name: VAULT_ADDR

--- a/test/acceptance/_helpers.bash
+++ b/test/acceptance/_helpers.bash
@@ -49,7 +49,6 @@ helm_install_ha() {
 check_vault_versions(){
     helm_deployment_name=$1
     local expected_version
-    local expected_repo="hashicorp/vault"
     if [ -n "${VAULT_VERSION}" ]; then
         expected_version=${VAULT_VERSION}
     else
@@ -61,18 +60,20 @@ check_vault_versions(){
 
     if [ "${ENT_TESTS}" = "true" ]; then
         expected_version="${expected_version}-ent"
-        expected_repo="hashicorp/vault-enterprise"
     fi
 
-    # Check ACTUAL DEPLOYED IMAGE from running pod (not stored values)
-    # Stored values may not reflect the final rendered image (e.g., when helpers auto-select)
-    local actual_image=$(kubectl get pod "${helm_deployment_name}-0" \
-      -o jsonpath='{.spec.containers[0].image}')
-    [ "${actual_image}" = "${expected_repo}:${expected_version}" ]
-
-    # For injector and CSI agents, check stored values (they don't have auto-selection yet)
     local values
     values=$(helm get values "${helm_deployment_name}" --all)
+    
+    # Verify license secret was set (which triggers Enterprise auto-selection)
+    if [ "${ENT_TESTS}" = "true" ]; then
+        [ "vault-license" = "$(echo "${values}" | yq -r '.server.enterpriseLicense.secretName')" ]
+    fi
+    
+    # Verify server image tag matches expected version
+    # expected_version includes -ent suffix for Enterprise, plain for Community Edition
+    [ "${expected_version}" = "$(echo "${values}" | yq -r '.server.image.tag')" ]
+    
     [ "${expected_version}" = "$(echo "${values}" | yq -r '.injector.agentImage.tag')" ]
     [ "${expected_version}" = "$(echo "${values}" | yq -r '.csi.agent.image.tag')" ]
 }

--- a/test/acceptance/_helpers.bash
+++ b/test/acceptance/_helpers.bash
@@ -49,6 +49,7 @@ helm_install_ha() {
 check_vault_versions(){
     helm_deployment_name=$1
     local expected_version
+    local expected_repo="hashicorp/vault"
     if [ -n "${VAULT_VERSION}" ]; then
         expected_version=${VAULT_VERSION}
     else
@@ -60,11 +61,18 @@ check_vault_versions(){
 
     if [ "${ENT_TESTS}" = "true" ]; then
         expected_version="${expected_version}-ent"
+        expected_repo="hashicorp/vault-enterprise"
     fi
 
+    # Check ACTUAL DEPLOYED IMAGE from running pod (not stored values)
+    # Stored values may not reflect the final rendered image (e.g., when helpers auto-select)
+    local actual_image=$(kubectl get pod "${helm_deployment_name}-0" \
+      -o jsonpath='{.spec.containers[0].image}')
+    [ "${actual_image}" = "${expected_repo}:${expected_version}" ]
+
+    # For injector and CSI agents, check stored values (they don't have auto-selection yet)
     local values
     values=$(helm get values "${helm_deployment_name}" --all)
-    [ "${expected_version}" = "$(echo "${values}" | yq -r '.server.image.tag')" ]
     [ "${expected_version}" = "$(echo "${values}" | yq -r '.injector.agentImage.tag')" ]
     [ "${expected_version}" = "$(echo "${values}" | yq -r '.csi.agent.image.tag')" ]
 }

--- a/test/acceptance/_helpers.bash
+++ b/test/acceptance/_helpers.bash
@@ -52,10 +52,19 @@ check_vault_versions(){
     if [ -n "${VAULT_VERSION}" ]; then
         expected_version=${VAULT_VERSION}
     else
-        # expect the defaults in values.yaml to all be the same
+        # expect the defaults in values.yaml to all be the same,
+        # falling back to Chart.AppVersion when tag is empty (mirrors helper logic).
+        local chart_app_version
+        chart_app_version=$(yq -r '.appVersion' Chart.yaml)
         expected_version=$(yq -r '.server.image.tag' values.yaml)
-        [ "${expected_version}" = "$(yq -r '.injector.agentImage.tag' values.yaml)" ]
-        [ "${expected_version}" = "$(yq -r '.csi.agent.image.tag' values.yaml)" ]
+        expected_version=${expected_version:-${chart_app_version}}
+        local injector_version csi_version
+        injector_version=$(yq -r '.injector.agentImage.tag' values.yaml)
+        injector_version=${injector_version:-${chart_app_version}}
+        csi_version=$(yq -r '.csi.agent.image.tag' values.yaml)
+        csi_version=${csi_version:-${chart_app_version}}
+        [ "${expected_version}" = "${injector_version}" ]
+        [ "${expected_version}" = "${csi_version}" ]
     fi
 
     if [ "${ENT_TESTS}" = "true" ]; then

--- a/test/acceptance/setup_suite.bash
+++ b/test/acceptance/setup_suite.bash
@@ -20,6 +20,7 @@ setup_suite() {
 
     PRE_CHART_CMDS=""
     if [ "${ENT_TESTS}" = "true" ]; then
+        SERVER_VAULT_VERSION="${SERVER_VAULT_VERSION}-ent"
         INJECTOR_AGENT_VERSION="${INJECTOR_AGENT_VERSION}-ent"
         CSI_AGENT_VERSION="${CSI_AGENT_VERSION}-ent"
         VAULT_REPOSITORY="hashicorp/vault-enterprise"
@@ -30,6 +31,8 @@ setup_suite() {
 
     CHART_VALUES+=(--set injector.agentImage.tag="${INJECTOR_AGENT_VERSION}")
     CHART_VALUES+=(--set injector.agentImage.repository="${VAULT_REPOSITORY}")
+    CHART_VALUES+=(--set server.image.tag="${SERVER_VAULT_VERSION}")
+    CHART_VALUES+=(--set server.image.repository="${VAULT_REPOSITORY}")
     CHART_VALUES+=(--set csi.agent.image.tag="${CSI_AGENT_VERSION}")
     CHART_VALUES+=(--set csi.agent.image.repository="${VAULT_REPOSITORY}")
 

--- a/test/acceptance/setup_suite.bash
+++ b/test/acceptance/setup_suite.bash
@@ -23,18 +23,27 @@ setup_suite() {
         SERVER_VAULT_VERSION="${SERVER_VAULT_VERSION}-ent"
         INJECTOR_AGENT_VERSION="${INJECTOR_AGENT_VERSION}-ent"
         CSI_AGENT_VERSION="${CSI_AGENT_VERSION}-ent"
-        VAULT_REPOSITORY="hashicorp/vault-enterprise"
         VAULT_LICENSE_CI=${VAULT_LICENSE_CI:?"VAULT_LICENSE_CI must be set"}
+        # Set the license secret — this is what triggers the chart helpers
+        # (vault.imageRepository/Tag, vault.agentImageRepository/Tag,
+        # vault.csiAgentImageRepository/Tag) to auto-select hashicorp/vault-enterprise.
         CHART_VALUES+=(--set server.enterpriseLicense.secretName=vault-license)
         PRE_CHART_CMDS+="kubectl create secret generic vault-license --from-literal=license=${VAULT_LICENSE_CI?}"
     fi
 
+    # Pass explicit image tags for all installs so CI can pin a specific build.
+    # For Enterprise the tags already carry the -ent suffix (appended above).
+    # derive hashicorp/vault-enterprise automatically from the license secret.
     CHART_VALUES+=(--set injector.agentImage.tag="${INJECTOR_AGENT_VERSION}")
-    CHART_VALUES+=(--set injector.agentImage.repository="${VAULT_REPOSITORY}")
     CHART_VALUES+=(--set server.image.tag="${SERVER_VAULT_VERSION}")
-    CHART_VALUES+=(--set server.image.repository="${VAULT_REPOSITORY}")
     CHART_VALUES+=(--set csi.agent.image.tag="${CSI_AGENT_VERSION}")
-    CHART_VALUES+=(--set csi.agent.image.repository="${VAULT_REPOSITORY}")
+
+    if [ "${ENT_TESTS}" != "true" ]; then
+        # For CE installs also pin the repository so CI can use a custom registry.
+        CHART_VALUES+=(--set injector.agentImage.repository="${VAULT_REPOSITORY}")
+        CHART_VALUES+=(--set server.image.repository="${VAULT_REPOSITORY}")
+        CHART_VALUES+=(--set csi.agent.image.repository="${VAULT_REPOSITORY}")
+    fi
 
     SET_CHART_VALUES=${CHART_VALUES[*]}
     export SET_CHART_VALUES PRE_CHART_CMDS

--- a/test/acceptance/setup_suite.bash
+++ b/test/acceptance/setup_suite.bash
@@ -20,7 +20,6 @@ setup_suite() {
 
     PRE_CHART_CMDS=""
     if [ "${ENT_TESTS}" = "true" ]; then
-        SERVER_VAULT_VERSION="${SERVER_VAULT_VERSION}-ent"
         INJECTOR_AGENT_VERSION="${INJECTOR_AGENT_VERSION}-ent"
         CSI_AGENT_VERSION="${CSI_AGENT_VERSION}-ent"
         VAULT_REPOSITORY="hashicorp/vault-enterprise"
@@ -31,8 +30,6 @@ setup_suite() {
 
     CHART_VALUES+=(--set injector.agentImage.tag="${INJECTOR_AGENT_VERSION}")
     CHART_VALUES+=(--set injector.agentImage.repository="${VAULT_REPOSITORY}")
-    CHART_VALUES+=(--set server.image.tag="${SERVER_VAULT_VERSION}")
-    CHART_VALUES+=(--set server.image.repository="${VAULT_REPOSITORY}")
     CHART_VALUES+=(--set csi.agent.image.tag="${CSI_AGENT_VERSION}")
     CHART_VALUES+=(--set csi.agent.image.repository="${VAULT_REPOSITORY}")
 

--- a/test/acceptance/setup_suite.bash
+++ b/test/acceptance/setup_suite.bash
@@ -9,10 +9,16 @@ setup_suite() {
         SERVER_VAULT_VERSION=${VAULT_VERSION}
         CSI_AGENT_VERSION=${VAULT_VERSION}
     else
-        # If VAULT_VERSION is not set, use the defaults from values.yaml
+        # If VAULT_VERSION is not set, use the defaults from values.yaml,
+        # falling back to Chart.AppVersion when tag is empty (mirrors helper logic).
+        local CHART_APP_VERSION
+        CHART_APP_VERSION=$(yq -r '.appVersion' Chart.yaml)
         INJECTOR_AGENT_VERSION=$(yq -r '.injector.agentImage.tag' values.yaml)
+        INJECTOR_AGENT_VERSION=${INJECTOR_AGENT_VERSION:-${CHART_APP_VERSION}}
         SERVER_VAULT_VERSION=$(yq -r '.server.image.tag' values.yaml)
+        SERVER_VAULT_VERSION=${SERVER_VAULT_VERSION:-${CHART_APP_VERSION}}
         CSI_AGENT_VERSION=$(yq -r '.csi.agent.image.tag' values.yaml)
+        CSI_AGENT_VERSION=${CSI_AGENT_VERSION:-${CHART_APP_VERSION}}
     fi
 
     local VAULT_REPOSITORY

--- a/test/unit/csi-daemonset.bats
+++ b/test/unit/csi-daemonset.bats
@@ -952,3 +952,62 @@ load _helpers
       yq -r '.spec.template.spec.containers[1].securityContext.foo' | tee /dev/stderr)
   [ "${actual}" = "bar" ]
 }
+
+@test "csi/daemonset: agent image defaults to CE image" {
+  cd `chart_dir`
+  local repo="$(yq -r '.csi.agent.image.repository' values.yaml)"
+  local tag="$(yq -r '.csi.agent.image.tag' values.yaml)"
+
+  local actual=$(helm template \
+      --show-only templates/csi-daemonset.yaml \
+      --set "csi.enabled=true" \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.containers[1].image' | tee /dev/stderr)
+  [ "${actual}" = "${repo}:${tag}" ]
+}
+
+@test "csi/daemonset: agent image auto-selects Enterprise image when license secret set" {
+  cd `chart_dir`
+  local repo="hashicorp/vault-enterprise"
+  local tag="$(yq -r '.csi.agent.image.tag' values.yaml)-ent"
+
+  local actual=$(helm template \
+      --show-only templates/csi-daemonset.yaml \
+      --set "csi.enabled=true" \
+      --set 'server.enterpriseLicense.secretName=foo' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.containers[1].image' | tee /dev/stderr)
+  [ "${actual}" = "${repo}:${tag}" ]
+}
+
+@test "csi/daemonset: agent image -ent tag suffix not doubled when already present" {
+  cd `chart_dir`
+  local repo="hashicorp/vault-enterprise"
+  local tag="$(yq -r '.csi.agent.image.tag' values.yaml)-ent"
+
+  local actual=$(helm template \
+      --show-only templates/csi-daemonset.yaml \
+      --set "csi.enabled=true" \
+      --set 'server.enterpriseLicense.secretName=foo' \
+      --set "csi.agent.image.tag=$(yq -r '.csi.agent.image.tag' values.yaml)-ent" \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.containers[1].image' | tee /dev/stderr)
+  [ "${actual}" = "${repo}:${tag}" ]
+}
+
+@test "csi/daemonset: agent image custom repository respected with Enterprise license" {
+  cd `chart_dir`
+  local tag="$(yq -r '.csi.agent.image.tag' values.yaml)-ent"
+
+  local actual=$(helm template \
+      --show-only templates/csi-daemonset.yaml \
+      --set "csi.enabled=true" \
+      --set 'server.enterpriseLicense.secretName=foo' \
+      --set 'csi.agent.image.repository=mycorp/vault' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.containers[1].image' | tee /dev/stderr)
+  # custom repo must be preserved, not overridden to hashicorp/vault-enterprise
+  [[ "${actual}" == "mycorp/vault:"* ]]
+  # -ent tag must still be appended
+  [ "${actual}" = "mycorp/vault:${tag}" ]
+}

--- a/test/unit/csi-daemonset.bats
+++ b/test/unit/csi-daemonset.bats
@@ -956,7 +956,7 @@ load _helpers
 @test "csi/daemonset: agent image defaults to CE image" {
   cd `chart_dir`
   local repo="$(yq -r '.csi.agent.image.repository' values.yaml)"
-  local tag="$(yq -r '.csi.agent.image.tag' values.yaml)"
+  local tag="$(yq -r '.appVersion' Chart.yaml)"
 
   local actual=$(helm template \
       --show-only templates/csi-daemonset.yaml \
@@ -969,7 +969,7 @@ load _helpers
 @test "csi/daemonset: agent image auto-selects Enterprise image when license secret set" {
   cd `chart_dir`
   local repo="hashicorp/vault-enterprise"
-  local tag="$(yq -r '.csi.agent.image.tag' values.yaml)-ent"
+  local tag="$(yq -r '.appVersion' Chart.yaml)-ent"
 
   local actual=$(helm template \
       --show-only templates/csi-daemonset.yaml \
@@ -983,13 +983,13 @@ load _helpers
 @test "csi/daemonset: agent image -ent tag suffix not doubled when already present" {
   cd `chart_dir`
   local repo="hashicorp/vault-enterprise"
-  local tag="$(yq -r '.csi.agent.image.tag' values.yaml)-ent"
+  local tag="$(yq -r '.appVersion' Chart.yaml)-ent"
 
   local actual=$(helm template \
       --show-only templates/csi-daemonset.yaml \
       --set "csi.enabled=true" \
       --set 'server.enterpriseLicense.secretName=foo' \
-      --set "csi.agent.image.tag=$(yq -r '.csi.agent.image.tag' values.yaml)-ent" \
+      --set "csi.agent.image.tag=$(yq -r '.appVersion' Chart.yaml)-ent" \
       . | tee /dev/stderr |
       yq -r '.spec.template.spec.containers[1].image' | tee /dev/stderr)
   [ "${actual}" = "${repo}:${tag}" ]
@@ -997,7 +997,7 @@ load _helpers
 
 @test "csi/daemonset: agent image custom repository respected with Enterprise license" {
   cd `chart_dir`
-  local tag="$(yq -r '.csi.agent.image.tag' values.yaml)-ent"
+  local tag="$(yq -r '.appVersion' Chart.yaml)-ent"
 
   local actual=$(helm template \
       --show-only templates/csi-daemonset.yaml \

--- a/test/unit/csi-daemonset.bats
+++ b/test/unit/csi-daemonset.bats
@@ -982,6 +982,8 @@ load _helpers
 
 @test "csi/daemonset: agent image -ent tag suffix not doubled when already present" {
   cd `chart_dir`
+  # Repo is always promoted to vault-enterprise when a license is set.
+  # Tag is returned verbatim — no duplicate -ent appended.
   local repo="hashicorp/vault-enterprise"
   local tag="$(yq -r '.appVersion' Chart.yaml)-ent"
 
@@ -1010,4 +1012,21 @@ load _helpers
   [[ "${actual}" == "mycorp/vault:"* ]]
   # -ent tag must still be appended
   [ "${actual}" = "mycorp/vault:${tag}" ]
+}
+
+@test "csi/daemonset: agent image custom repository and custom tag both preserved with Enterprise license" {
+  cd `chart_dir`
+
+  local actual=$(helm template \
+      --show-only templates/csi-daemonset.yaml \
+      --set "csi.enabled=true" \
+      --set 'server.enterpriseLicense.secretName=foo' \
+      --set 'server.enterpriseLicense.secretKey=license' \
+      --set 'csi.agent.image.repository=mycorp/vault' \
+      --set 'csi.agent.image.tag=custom' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.containers[1].image' | tee /dev/stderr)
+
+  # Both repo and tag must be preserved exactly — no -ent mutation on the tag
+  [ "${actual}" = "mycorp/vault:custom" ]
 }

--- a/test/unit/injector-deployment.bats
+++ b/test/unit/injector-deployment.bats
@@ -1126,3 +1126,58 @@ EOF
       yq -r '.spec.strategy.rollingUpdate.maxUnavailable' | tee /dev/stderr)
   [ "${actual}" = "1" ]
 }
+
+@test "injector/deployment: AGENT_INJECT_VAULT_IMAGE defaults to CE image" {
+  cd `chart_dir`
+  local repo="$(yq -r '.injector.agentImage.repository' values.yaml)"
+  local tag="$(yq -r '.injector.agentImage.tag' values.yaml)"
+
+  local actual=$(helm template \
+      --show-only templates/injector-deployment.yaml \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.containers[0].env[] | select(.name=="AGENT_INJECT_VAULT_IMAGE") | .value' | tee /dev/stderr)
+  [ "${actual}" = "${repo}:${tag}" ]
+}
+
+@test "injector/deployment: AGENT_INJECT_VAULT_IMAGE auto-selects Enterprise image when license secret set" {
+  cd `chart_dir`
+  local repo="hashicorp/vault-enterprise"
+  local tag="$(yq -r '.injector.agentImage.tag' values.yaml)-ent"
+
+  local actual=$(helm template \
+      --show-only templates/injector-deployment.yaml \
+      --set 'server.enterpriseLicense.secretName=foo' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.containers[0].env[] | select(.name=="AGENT_INJECT_VAULT_IMAGE") | .value' | tee /dev/stderr)
+  [ "${actual}" = "${repo}:${tag}" ]
+}
+
+@test "injector/deployment: AGENT_INJECT_VAULT_IMAGE -ent tag suffix not doubled when already present" {
+  cd `chart_dir`
+  local repo="hashicorp/vault-enterprise"
+  local tag="$(yq -r '.injector.agentImage.tag' values.yaml)-ent"
+
+  local actual=$(helm template \
+      --show-only templates/injector-deployment.yaml \
+      --set 'server.enterpriseLicense.secretName=foo' \
+      --set "injector.agentImage.tag=$(yq -r '.injector.agentImage.tag' values.yaml)-ent" \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.containers[0].env[] | select(.name=="AGENT_INJECT_VAULT_IMAGE") | .value' | tee /dev/stderr)
+  [ "${actual}" = "${repo}:${tag}" ]
+}
+
+@test "injector/deployment: AGENT_INJECT_VAULT_IMAGE custom repository respected with Enterprise license" {
+  cd `chart_dir`
+  local tag="$(yq -r '.injector.agentImage.tag' values.yaml)-ent"
+
+  local actual=$(helm template \
+      --show-only templates/injector-deployment.yaml \
+      --set 'server.enterpriseLicense.secretName=foo' \
+      --set 'injector.agentImage.repository=mycorp/vault' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.containers[0].env[] | select(.name=="AGENT_INJECT_VAULT_IMAGE") | .value' | tee /dev/stderr)
+  # custom repo must be preserved, not overridden to hashicorp/vault-enterprise
+  [[ "${actual}" == "mycorp/vault:"* ]]
+  # -ent tag must still be appended
+  [ "${actual}" = "mycorp/vault:${tag}" ]
+}

--- a/test/unit/injector-deployment.bats
+++ b/test/unit/injector-deployment.bats
@@ -1154,6 +1154,8 @@ EOF
 
 @test "injector/deployment: AGENT_INJECT_VAULT_IMAGE -ent tag suffix not doubled when already present" {
   cd `chart_dir`
+  # Repo is always promoted to vault-enterprise when a license is set.
+  # Tag is returned verbatim — no duplicate -ent appended.
   local repo="hashicorp/vault-enterprise"
   local tag="$(yq -r '.appVersion' Chart.yaml)-ent"
 
@@ -1180,4 +1182,20 @@ EOF
   [[ "${actual}" == "mycorp/vault:"* ]]
   # -ent tag must still be appended
   [ "${actual}" = "mycorp/vault:${tag}" ]
+}
+
+@test "injector/deployment: AGENT_INJECT_VAULT_IMAGE custom repository and custom tag both preserved with Enterprise license" {
+  cd `chart_dir`
+
+  local actual=$(helm template \
+      --show-only templates/injector-deployment.yaml \
+      --set 'server.enterpriseLicense.secretName=foo' \
+      --set 'server.enterpriseLicense.secretKey=license' \
+      --set 'injector.agentImage.repository=mycorp/vault' \
+      --set 'injector.agentImage.tag=custom' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.containers[0].env[] | select(.name=="AGENT_INJECT_VAULT_IMAGE") | .value' | tee /dev/stderr)
+
+  # Both repo and tag must be preserved exactly — no -ent mutation on the tag
+  [ "${actual}" = "mycorp/vault:custom" ]
 }

--- a/test/unit/injector-deployment.bats
+++ b/test/unit/injector-deployment.bats
@@ -1130,7 +1130,7 @@ EOF
 @test "injector/deployment: AGENT_INJECT_VAULT_IMAGE defaults to CE image" {
   cd `chart_dir`
   local repo="$(yq -r '.injector.agentImage.repository' values.yaml)"
-  local tag="$(yq -r '.injector.agentImage.tag' values.yaml)"
+  local tag="$(yq -r '.appVersion' Chart.yaml)"
 
   local actual=$(helm template \
       --show-only templates/injector-deployment.yaml \
@@ -1142,7 +1142,7 @@ EOF
 @test "injector/deployment: AGENT_INJECT_VAULT_IMAGE auto-selects Enterprise image when license secret set" {
   cd `chart_dir`
   local repo="hashicorp/vault-enterprise"
-  local tag="$(yq -r '.injector.agentImage.tag' values.yaml)-ent"
+  local tag="$(yq -r '.appVersion' Chart.yaml)-ent"
 
   local actual=$(helm template \
       --show-only templates/injector-deployment.yaml \
@@ -1155,12 +1155,12 @@ EOF
 @test "injector/deployment: AGENT_INJECT_VAULT_IMAGE -ent tag suffix not doubled when already present" {
   cd `chart_dir`
   local repo="hashicorp/vault-enterprise"
-  local tag="$(yq -r '.injector.agentImage.tag' values.yaml)-ent"
+  local tag="$(yq -r '.appVersion' Chart.yaml)-ent"
 
   local actual=$(helm template \
       --show-only templates/injector-deployment.yaml \
       --set 'server.enterpriseLicense.secretName=foo' \
-      --set "injector.agentImage.tag=$(yq -r '.injector.agentImage.tag' values.yaml)-ent" \
+      --set "injector.agentImage.tag=$(yq -r '.appVersion' Chart.yaml)-ent" \
       . | tee /dev/stderr |
       yq -r '.spec.template.spec.containers[0].env[] | select(.name=="AGENT_INJECT_VAULT_IMAGE") | .value' | tee /dev/stderr)
   [ "${actual}" = "${repo}:${tag}" ]
@@ -1168,7 +1168,7 @@ EOF
 
 @test "injector/deployment: AGENT_INJECT_VAULT_IMAGE custom repository respected with Enterprise license" {
   cd `chart_dir`
-  local tag="$(yq -r '.injector.agentImage.tag' values.yaml)-ent"
+  local tag="$(yq -r '.appVersion' Chart.yaml)-ent"
 
   local actual=$(helm template \
       --show-only templates/injector-deployment.yaml \

--- a/test/unit/server-dev-statefulset.bats
+++ b/test/unit/server-dev-statefulset.bats
@@ -46,10 +46,8 @@ load _helpers
   [ "${actual}" = "foo:1.2.3" ]
 }
 
-@test "server/dev-StatefulSet: image tag defaults to Chart.AppVersion" {
+@test "server/dev-StatefulSet: image tag defaults to latest when tag is empty" {
   cd `chart_dir`
-  local appVersion="$(yq -r '.appVersion' Chart.yaml)"
-
   local actual=$(helm template \
       --show-only templates/server-statefulset.yaml  \
       --set 'server.image.repository=foo' \
@@ -57,7 +55,7 @@ load _helpers
       --set 'server.dev.enabled=true' \
       . | tee /dev/stderr |
       yq -r '.spec.template.spec.containers[0].image' | tee /dev/stderr)
-  [ "${actual}" = "foo:${appVersion}" ]
+  [ "${actual}" = "foo:latest" ]
 }
 
 @test "server/dev-StatefulSet: Enterprise image auto-selected when secretName is set" {

--- a/test/unit/server-dev-statefulset.bats
+++ b/test/unit/server-dev-statefulset.bats
@@ -46,8 +46,9 @@ load _helpers
   [ "${actual}" = "foo:1.2.3" ]
 }
 
-@test "server/ha-StatefulSet: image tag defaults to latest" {
+@test "server/dev-StatefulSet: image tag defaults to Chart.AppVersion" {
   cd `chart_dir`
+  local appVersion="$(yq -r '.appVersion' Chart.yaml)"
 
   local actual=$(helm template \
       --show-only templates/server-statefulset.yaml  \
@@ -56,7 +57,7 @@ load _helpers
       --set 'server.dev.enabled=true' \
       . | tee /dev/stderr |
       yq -r '.spec.template.spec.containers[0].image' | tee /dev/stderr)
-  [ "${actual}" = "foo:latest" ]
+  [ "${actual}" = "foo:${appVersion}" ]
 }
 
 @test "server/dev-StatefulSet: Enterprise image auto-selected when secretName is set" {

--- a/test/unit/server-dev-statefulset.bats
+++ b/test/unit/server-dev-statefulset.bats
@@ -59,6 +59,66 @@ load _helpers
   [ "${actual}" = "foo:latest" ]
 }
 
+@test "server/dev-StatefulSet: Enterprise image auto-selected when secretName is set" {
+  cd `chart_dir`
+  local repo="hashicorp/vault-enterprise"
+  local tag="$(yq -r '.server.image.tag' values.yaml)-ent"
+
+  local actual=$(helm template \
+      --show-only templates/server-statefulset.yaml \
+      --set 'server.dev.enabled=true' \
+      --set 'server.enterpriseLicense.secretName=foo' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.containers[0].image' | tee /dev/stderr)
+  [ "${actual}" = "${repo}:${tag}" ]
+}
+
+@test "server/dev-StatefulSet: Enterprise image tag not doubled when -ent suffix already present" {
+  cd `chart_dir`
+  local repo="hashicorp/vault-enterprise"
+  local tag="$(yq -r '.server.image.tag' values.yaml)-ent"
+
+  local actual=$(helm template \
+      --show-only templates/server-statefulset.yaml \
+      --set 'server.dev.enabled=true' \
+      --set 'server.enterpriseLicense.secretName=foo' \
+      --set "server.image.tag=$(yq -r '.server.image.tag' values.yaml)-ent" \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.containers[0].image' | tee /dev/stderr)
+  [ "${actual}" = "${repo}:${tag}" ]
+}
+
+@test "server/dev-StatefulSet: custom image repository respected with Enterprise license" {
+  cd `chart_dir`
+  local tag="$(yq -r '.server.image.tag' values.yaml)-ent"
+
+  local actual=$(helm template \
+      --show-only templates/server-statefulset.yaml \
+      --set 'server.dev.enabled=true' \
+      --set 'server.enterpriseLicense.secretName=foo' \
+      --set 'server.image.repository=mycorp/vault' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.containers[0].image' | tee /dev/stderr)
+
+  # repo must NOT be overridden to hashicorp/vault-enterprise
+  [[ "${actual}" == "mycorp/vault:"* ]]
+  # -ent tag must still be appended
+  [ "${actual}" = "mycorp/vault:${tag}" ]
+}
+
+@test "server/dev-StatefulSet: Community Edition image unchanged when no license secret set" {
+  cd `chart_dir`
+  local repo="$(yq -r '.server.image.repository' values.yaml)"
+  local tag="$(yq -r '.server.image.tag' values.yaml)"
+
+  local actual=$(helm template \
+      --show-only templates/server-statefulset.yaml \
+      --set 'server.dev.enabled=true' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.containers[0].image' | tee /dev/stderr)
+  [ "${actual}" = "${repo}:${tag}" ]
+}
+
 #--------------------------------------------------------------------
 # replicas
 

--- a/test/unit/server-dev-statefulset.bats
+++ b/test/unit/server-dev-statefulset.bats
@@ -46,8 +46,9 @@ load _helpers
   [ "${actual}" = "foo:1.2.3" ]
 }
 
-@test "server/dev-StatefulSet: image tag defaults to latest when tag is empty" {
+@test "server/dev-StatefulSet: image tag defaults to Chart.AppVersion when tag is empty" {
   cd `chart_dir`
+  local appVersion="$(yq -r '.appVersion' Chart.yaml)"
   local actual=$(helm template \
       --show-only templates/server-statefulset.yaml  \
       --set 'server.image.repository=foo' \
@@ -55,13 +56,13 @@ load _helpers
       --set 'server.dev.enabled=true' \
       . | tee /dev/stderr |
       yq -r '.spec.template.spec.containers[0].image' | tee /dev/stderr)
-  [ "${actual}" = "foo:latest" ]
+  [ "${actual}" = "foo:${appVersion}" ]
 }
 
 @test "server/dev-StatefulSet: Enterprise image auto-selected when secretName is set" {
   cd `chart_dir`
   local repo="hashicorp/vault-enterprise"
-  local tag="$(yq -r '.server.image.tag' values.yaml)-ent"
+  local tag="$(yq -r '.appVersion' Chart.yaml)-ent"
 
   local actual=$(helm template \
       --show-only templates/server-statefulset.yaml \
@@ -75,13 +76,13 @@ load _helpers
 @test "server/dev-StatefulSet: Enterprise image tag not doubled when -ent suffix already present" {
   cd `chart_dir`
   local repo="hashicorp/vault-enterprise"
-  local tag="$(yq -r '.server.image.tag' values.yaml)-ent"
+  local tag="$(yq -r '.appVersion' Chart.yaml)-ent"
 
   local actual=$(helm template \
       --show-only templates/server-statefulset.yaml \
       --set 'server.dev.enabled=true' \
       --set 'server.enterpriseLicense.secretName=foo' \
-      --set "server.image.tag=$(yq -r '.server.image.tag' values.yaml)-ent" \
+      --set "server.image.tag=$(yq -r '.appVersion' Chart.yaml)-ent" \
       . | tee /dev/stderr |
       yq -r '.spec.template.spec.containers[0].image' | tee /dev/stderr)
   [ "${actual}" = "${repo}:${tag}" ]
@@ -89,7 +90,7 @@ load _helpers
 
 @test "server/dev-StatefulSet: custom image repository respected with Enterprise license" {
   cd `chart_dir`
-  local tag="$(yq -r '.server.image.tag' values.yaml)-ent"
+  local tag="$(yq -r '.appVersion' Chart.yaml)-ent"
 
   local actual=$(helm template \
       --show-only templates/server-statefulset.yaml \
@@ -108,7 +109,7 @@ load _helpers
 @test "server/dev-StatefulSet: Community Edition image unchanged when no license secret set" {
   cd `chart_dir`
   local repo="$(yq -r '.server.image.repository' values.yaml)"
-  local tag="$(yq -r '.server.image.tag' values.yaml)"
+  local tag="$(yq -r '.appVersion' Chart.yaml)"
 
   local actual=$(helm template \
       --show-only templates/server-statefulset.yaml \

--- a/test/unit/server-ha-statefulset.bats
+++ b/test/unit/server-ha-statefulset.bats
@@ -46,8 +46,9 @@ load _helpers
   [ "${actual}" = "foo:1.2.3" ]
 }
 
-@test "server/ha-StatefulSet: image tag defaults to latest" {
+@test "server/ha-StatefulSet: image tag defaults to Chart.AppVersion" {
   cd `chart_dir`
+  local appVersion="$(yq -r '.appVersion' Chart.yaml)"
 
   local actual=$(helm template \
       --show-only templates/server-statefulset.yaml  \
@@ -56,7 +57,7 @@ load _helpers
       --set 'server.ha.enabled=true' \
       . | tee /dev/stderr |
       yq -r '.spec.template.spec.containers[0].image' | tee /dev/stderr)
-  [ "${actual}" = "foo:latest" ]
+  [ "${actual}" = "foo:${appVersion}" ]
 }
 
 @test "server/ha-StatefulSet: Enterprise image auto-selected when secretName is set" {

--- a/test/unit/server-ha-statefulset.bats
+++ b/test/unit/server-ha-statefulset.bats
@@ -46,10 +46,8 @@ load _helpers
   [ "${actual}" = "foo:1.2.3" ]
 }
 
-@test "server/ha-StatefulSet: image tag defaults to Chart.AppVersion" {
+@test "server/ha-StatefulSet: image tag defaults to latest when tag is empty" {
   cd `chart_dir`
-  local appVersion="$(yq -r '.appVersion' Chart.yaml)"
-
   local actual=$(helm template \
       --show-only templates/server-statefulset.yaml  \
       --set 'server.image.repository=foo' \
@@ -57,7 +55,7 @@ load _helpers
       --set 'server.ha.enabled=true' \
       . | tee /dev/stderr |
       yq -r '.spec.template.spec.containers[0].image' | tee /dev/stderr)
-  [ "${actual}" = "foo:${appVersion}" ]
+  [ "${actual}" = "foo:latest" ]
 }
 
 @test "server/ha-StatefulSet: Enterprise image auto-selected when secretName is set" {

--- a/test/unit/server-ha-statefulset.bats
+++ b/test/unit/server-ha-statefulset.bats
@@ -59,6 +59,66 @@ load _helpers
   [ "${actual}" = "foo:latest" ]
 }
 
+@test "server/ha-StatefulSet: Enterprise image auto-selected when secretName is set" {
+  cd `chart_dir`
+  local repo="hashicorp/vault-enterprise"
+  local tag="$(yq -r '.server.image.tag' values.yaml)-ent"
+
+  local actual=$(helm template \
+      --show-only templates/server-statefulset.yaml \
+      --set 'server.ha.enabled=true' \
+      --set 'server.enterpriseLicense.secretName=foo' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.containers[0].image' | tee /dev/stderr)
+  [ "${actual}" = "${repo}:${tag}" ]
+}
+
+@test "server/ha-StatefulSet: Enterprise image tag not doubled when -ent suffix already present" {
+  cd `chart_dir`
+  local repo="hashicorp/vault-enterprise"
+  local tag="$(yq -r '.server.image.tag' values.yaml)-ent"
+
+  local actual=$(helm template \
+      --show-only templates/server-statefulset.yaml \
+      --set 'server.ha.enabled=true' \
+      --set 'server.enterpriseLicense.secretName=foo' \
+      --set "server.image.tag=$(yq -r '.server.image.tag' values.yaml)-ent" \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.containers[0].image' | tee /dev/stderr)
+  [ "${actual}" = "${repo}:${tag}" ]
+}
+
+@test "server/ha-StatefulSet: custom image repository respected with Enterprise license" {
+  cd `chart_dir`
+  local tag="$(yq -r '.server.image.tag' values.yaml)-ent"
+
+  local actual=$(helm template \
+      --show-only templates/server-statefulset.yaml \
+      --set 'server.ha.enabled=true' \
+      --set 'server.enterpriseLicense.secretName=foo' \
+      --set 'server.image.repository=mycorp/vault' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.containers[0].image' | tee /dev/stderr)
+
+  # repo must NOT be overridden to hashicorp/vault-enterprise
+  [[ "${actual}" == "mycorp/vault:"* ]]
+  # -ent tag must still be appended
+  [ "${actual}" = "mycorp/vault:${tag}" ]
+}
+
+@test "server/ha-StatefulSet: Community Edition image unchanged when no license secret set" {
+  cd `chart_dir`
+  local repo="$(yq -r '.server.image.repository' values.yaml)"
+  local tag="$(yq -r '.server.image.tag' values.yaml)"
+
+  local actual=$(helm template \
+      --show-only templates/server-statefulset.yaml \
+      --set 'server.ha.enabled=true' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.containers[0].image' | tee /dev/stderr)
+  [ "${actual}" = "${repo}:${tag}" ]
+}
+
 #--------------------------------------------------------------------
 # TLS
 

--- a/test/unit/server-ha-statefulset.bats
+++ b/test/unit/server-ha-statefulset.bats
@@ -46,8 +46,9 @@ load _helpers
   [ "${actual}" = "foo:1.2.3" ]
 }
 
-@test "server/ha-StatefulSet: image tag defaults to latest when tag is empty" {
+@test "server/ha-StatefulSet: image tag defaults to Chart.AppVersion when tag is empty" {
   cd `chart_dir`
+  local appVersion="$(yq -r '.appVersion' Chart.yaml)"
   local actual=$(helm template \
       --show-only templates/server-statefulset.yaml  \
       --set 'server.image.repository=foo' \
@@ -55,13 +56,13 @@ load _helpers
       --set 'server.ha.enabled=true' \
       . | tee /dev/stderr |
       yq -r '.spec.template.spec.containers[0].image' | tee /dev/stderr)
-  [ "${actual}" = "foo:latest" ]
+  [ "${actual}" = "foo:${appVersion}" ]
 }
 
 @test "server/ha-StatefulSet: Enterprise image auto-selected when secretName is set" {
   cd `chart_dir`
   local repo="hashicorp/vault-enterprise"
-  local tag="$(yq -r '.server.image.tag' values.yaml)-ent"
+  local tag="$(yq -r '.appVersion' Chart.yaml)-ent"
 
   local actual=$(helm template \
       --show-only templates/server-statefulset.yaml \
@@ -75,13 +76,13 @@ load _helpers
 @test "server/ha-StatefulSet: Enterprise image tag not doubled when -ent suffix already present" {
   cd `chart_dir`
   local repo="hashicorp/vault-enterprise"
-  local tag="$(yq -r '.server.image.tag' values.yaml)-ent"
+  local tag="$(yq -r '.appVersion' Chart.yaml)-ent"
 
   local actual=$(helm template \
       --show-only templates/server-statefulset.yaml \
       --set 'server.ha.enabled=true' \
       --set 'server.enterpriseLicense.secretName=foo' \
-      --set "server.image.tag=$(yq -r '.server.image.tag' values.yaml)-ent" \
+      --set "server.image.tag=$(yq -r '.appVersion' Chart.yaml)-ent" \
       . | tee /dev/stderr |
       yq -r '.spec.template.spec.containers[0].image' | tee /dev/stderr)
   [ "${actual}" = "${repo}:${tag}" ]
@@ -89,7 +90,7 @@ load _helpers
 
 @test "server/ha-StatefulSet: custom image repository respected with Enterprise license" {
   cd `chart_dir`
-  local tag="$(yq -r '.server.image.tag' values.yaml)-ent"
+  local tag="$(yq -r '.appVersion' Chart.yaml)-ent"
 
   local actual=$(helm template \
       --show-only templates/server-statefulset.yaml \
@@ -108,7 +109,7 @@ load _helpers
 @test "server/ha-StatefulSet: Community Edition image unchanged when no license secret set" {
   cd `chart_dir`
   local repo="$(yq -r '.server.image.repository' values.yaml)"
-  local tag="$(yq -r '.server.image.tag' values.yaml)"
+  local tag="$(yq -r '.appVersion' Chart.yaml)"
 
   local actual=$(helm template \
       --show-only templates/server-statefulset.yaml \

--- a/test/unit/server-statefulset.bats
+++ b/test/unit/server-statefulset.bats
@@ -117,16 +117,15 @@ load _helpers
   [ "${actual}" = "foo:1.2.3" ]
 }
 
-@test "server/standalone-StatefulSet: image tag defaults to Chart.AppVersion" {
+@test "server/standalone-StatefulSet: image tag defaults to latest when tag is empty" {
   cd `chart_dir`
-  local appVersion="$(yq -r '.appVersion' Chart.yaml)"
   local actual=$(helm template \
       --show-only templates/server-statefulset.yaml  \
       --set 'server.image.repository=foo' \
       --set 'server.image.tag=' \
       . | tee /dev/stderr |
       yq -r '.spec.template.spec.containers[0].image' | tee /dev/stderr)
-  [ "${actual}" = "foo:${appVersion}" ]
+  [ "${actual}" = "foo:latest" ]
 
   local actual=$(helm template \
       --show-only templates/server-statefulset.yaml  \
@@ -135,7 +134,7 @@ load _helpers
       --set 'server.standalone.enabled=true' \
       . | tee /dev/stderr |
       yq -r '.spec.template.spec.containers[0].image' | tee /dev/stderr)
-  [ "${actual}" = "foo:${appVersion}" ]
+  [ "${actual}" = "foo:latest" ]
 }
 
 @test "server/standalone-StatefulSet: default imagePullPolicy" {

--- a/test/unit/server-statefulset.bats
+++ b/test/unit/server-statefulset.bats
@@ -1904,13 +1904,21 @@ load _helpers
 # enterprise license autoload support
 @test "server/StatefulSet: adds volume for license secret when enterprise license secret name and key are provided" {
   cd `chart_dir`
-  local actual=$(helm template \
+  local object=$(helm template \
       -s templates/server-statefulset.yaml  \
       --set 'server.enterpriseLicense.secretName=foo' \
       --set 'server.enterpriseLicense.secretKey=bar' \
       . | tee /dev/stderr |
-      yq -r -c '.spec.template.spec.volumes[] | select(.name == "vault-license")' | tee /dev/stderr)
-      [ "${actual}" = '{"name":"vault-license","secret":{"secretName":"foo","defaultMode":288}}' ]
+      yq '.spec.template.spec.volumes[] | select(.name == "vault-license")' | tee /dev/stderr)
+
+  local name=$(echo "$object" | yq -r '.name')
+  local secretName=$(echo "$object" | yq -r '.secret.secretName')
+  local defaultMode=$(echo "$object" | yq -r '.secret.defaultMode')
+
+  [ "${name}" = "vault-license" ]
+  [ "${secretName}" = "foo" ]
+  # 0440 octal = 288 decimal; yq v4 may render either form
+  [[ "${defaultMode}" = "288" || "${defaultMode}" = "440" || "${defaultMode}" = "0440" ]]
 }
 
 @test "server/StatefulSet: adds volume mount for license secret when enterprise license secret name and key are provided" {

--- a/test/unit/server-statefulset.bats
+++ b/test/unit/server-statefulset.bats
@@ -117,15 +117,16 @@ load _helpers
   [ "${actual}" = "foo:1.2.3" ]
 }
 
-@test "server/standalone-StatefulSet: image tag defaults to latest" {
+@test "server/standalone-StatefulSet: image tag defaults to Chart.AppVersion" {
   cd `chart_dir`
+  local appVersion="$(yq -r '.appVersion' Chart.yaml)"
   local actual=$(helm template \
       --show-only templates/server-statefulset.yaml  \
       --set 'server.image.repository=foo' \
       --set 'server.image.tag=' \
       . | tee /dev/stderr |
       yq -r '.spec.template.spec.containers[0].image' | tee /dev/stderr)
-  [ "${actual}" = "foo:latest" ]
+  [ "${actual}" = "foo:${appVersion}" ]
 
   local actual=$(helm template \
       --show-only templates/server-statefulset.yaml  \
@@ -134,7 +135,7 @@ load _helpers
       --set 'server.standalone.enabled=true' \
       . | tee /dev/stderr |
       yq -r '.spec.template.spec.containers[0].image' | tee /dev/stderr)
-  [ "${actual}" = "foo:latest" ]
+  [ "${actual}" = "foo:${appVersion}" ]
 }
 
 @test "server/standalone-StatefulSet: default imagePullPolicy" {

--- a/test/unit/server-statefulset.bats
+++ b/test/unit/server-statefulset.bats
@@ -156,6 +156,62 @@ load _helpers
   [ "${actual}" = "Always" ]
 }
 
+@test "server/standalone-StatefulSet: Enterprise image auto-selected when secretName is set" {
+  cd `chart_dir`
+  local repo="hashicorp/vault-enterprise"
+  local tag="$(yq -r '.server.image.tag' values.yaml)-ent"
+
+  local actual=$(helm template \
+      --show-only templates/server-statefulset.yaml \
+      --set 'server.enterpriseLicense.secretName=foo' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.containers[0].image' | tee /dev/stderr)
+  [ "${actual}" = "${repo}:${tag}" ]
+}
+
+@test "server/standalone-StatefulSet: Enterprise image tag not doubled when -ent suffix already present" {
+  cd `chart_dir`
+  local repo="hashicorp/vault-enterprise"
+  local tag="$(yq -r '.server.image.tag' values.yaml)-ent"
+
+  local actual=$(helm template \
+      --show-only templates/server-statefulset.yaml \
+      --set 'server.enterpriseLicense.secretName=foo' \
+      --set "server.image.tag=$(yq -r '.server.image.tag' values.yaml)-ent" \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.containers[0].image' | tee /dev/stderr)
+  [ "${actual}" = "${repo}:${tag}" ]
+}
+
+@test "server/standalone-StatefulSet: custom image repository respected with Enterprise license" {
+  cd `chart_dir`
+  local tag="$(yq -r '.server.image.tag' values.yaml)-ent"
+
+  local actual=$(helm template \
+      --show-only templates/server-statefulset.yaml \
+      --set 'server.enterpriseLicense.secretName=foo' \
+      --set 'server.image.repository=mycorp/vault' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.containers[0].image' | tee /dev/stderr)
+
+  # repo must NOT be overridden to hashicorp/vault-enterprise
+  [[ "${actual}" == "mycorp/vault:"* ]]
+  # -ent tag must still be appended
+  [ "${actual}" = "mycorp/vault:${tag}" ]
+}
+
+@test "server/standalone-StatefulSet: Community Edition image unchanged when no license secret set" {
+  cd `chart_dir`
+  local repo="$(yq -r '.server.image.repository' values.yaml)"
+  local tag="$(yq -r '.server.image.tag' values.yaml)"
+
+  local actual=$(helm template \
+      --show-only templates/server-statefulset.yaml \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.containers[0].image' | tee /dev/stderr)
+  [ "${actual}" = "${repo}:${tag}" ]
+}
+
 @test "server/standalone-StatefulSet: Custom imagePullSecrets" {
   cd `chart_dir`
   local object=$(helm template \

--- a/test/unit/server-statefulset.bats
+++ b/test/unit/server-statefulset.bats
@@ -117,15 +117,17 @@ load _helpers
   [ "${actual}" = "foo:1.2.3" ]
 }
 
-@test "server/standalone-StatefulSet: image tag defaults to latest when tag is empty" {
+@test "server/standalone-StatefulSet: image tag defaults to Chart.AppVersion when tag is empty" {
   cd `chart_dir`
+  local appVersion="$(yq -r '.appVersion' Chart.yaml)"
+
   local actual=$(helm template \
       --show-only templates/server-statefulset.yaml  \
       --set 'server.image.repository=foo' \
       --set 'server.image.tag=' \
       . | tee /dev/stderr |
       yq -r '.spec.template.spec.containers[0].image' | tee /dev/stderr)
-  [ "${actual}" = "foo:latest" ]
+  [ "${actual}" = "foo:${appVersion}" ]
 
   local actual=$(helm template \
       --show-only templates/server-statefulset.yaml  \
@@ -134,7 +136,7 @@ load _helpers
       --set 'server.standalone.enabled=true' \
       . | tee /dev/stderr |
       yq -r '.spec.template.spec.containers[0].image' | tee /dev/stderr)
-  [ "${actual}" = "foo:latest" ]
+  [ "${actual}" = "foo:${appVersion}" ]
 }
 
 @test "server/standalone-StatefulSet: default imagePullPolicy" {
@@ -159,7 +161,7 @@ load _helpers
 @test "server/standalone-StatefulSet: Enterprise image auto-selected when secretName is set" {
   cd `chart_dir`
   local repo="hashicorp/vault-enterprise"
-  local tag="$(yq -r '.server.image.tag' values.yaml)-ent"
+  local tag="$(yq -r '.appVersion' Chart.yaml)-ent"
 
   local actual=$(helm template \
       --show-only templates/server-statefulset.yaml \
@@ -172,12 +174,12 @@ load _helpers
 @test "server/standalone-StatefulSet: Enterprise image tag not doubled when -ent suffix already present" {
   cd `chart_dir`
   local repo="hashicorp/vault-enterprise"
-  local tag="$(yq -r '.server.image.tag' values.yaml)-ent"
+  local tag="$(yq -r '.appVersion' Chart.yaml)-ent"
 
   local actual=$(helm template \
       --show-only templates/server-statefulset.yaml \
       --set 'server.enterpriseLicense.secretName=foo' \
-      --set "server.image.tag=$(yq -r '.server.image.tag' values.yaml)-ent" \
+      --set "server.image.tag=$(yq -r '.appVersion' Chart.yaml)-ent" \
       . | tee /dev/stderr |
       yq -r '.spec.template.spec.containers[0].image' | tee /dev/stderr)
   [ "${actual}" = "${repo}:${tag}" ]
@@ -185,7 +187,7 @@ load _helpers
 
 @test "server/standalone-StatefulSet: custom image repository respected with Enterprise license" {
   cd `chart_dir`
-  local tag="$(yq -r '.server.image.tag' values.yaml)-ent"
+  local tag="$(yq -r '.appVersion' Chart.yaml)-ent"
 
   local actual=$(helm template \
       --show-only templates/server-statefulset.yaml \
@@ -203,7 +205,7 @@ load _helpers
 @test "server/standalone-StatefulSet: Community Edition image unchanged when no license secret set" {
   cd `chart_dir`
   local repo="$(yq -r '.server.image.repository' values.yaml)"
-  local tag="$(yq -r '.server.image.tag' values.yaml)"
+  local tag="$(yq -r '.appVersion' Chart.yaml)"
 
   local actual=$(helm template \
       --show-only templates/server-statefulset.yaml \

--- a/test/unit/server-test.bats
+++ b/test/unit/server-test.bats
@@ -185,6 +185,62 @@ load _helpers
   [ "${actual}" = "Always" ]
 }
 
+@test "server/standalone-server-test-Pod: Enterprise image auto-selected when secretName is set" {
+  cd `chart_dir`
+  local repo="hashicorp/vault-enterprise"
+  local tag="$(yq -r '.server.image.tag' values.yaml)-ent"
+
+  local actual=$(helm template \
+      --show-only templates/tests/server-test.yaml \
+      --set 'server.enterpriseLicense.secretName=foo' \
+      . | tee /dev/stderr |
+      yq -r '.spec.containers[0].image' | tee /dev/stderr)
+  [ "${actual}" = "${repo}:${tag}" ]
+}
+
+@test "server/standalone-server-test-Pod: Enterprise image tag not doubled when -ent suffix already present" {
+  cd `chart_dir`
+  local repo="hashicorp/vault-enterprise"
+  local tag="$(yq -r '.server.image.tag' values.yaml)-ent"
+
+  local actual=$(helm template \
+      --show-only templates/tests/server-test.yaml \
+      --set 'server.enterpriseLicense.secretName=foo' \
+      --set "server.image.tag=$(yq -r '.server.image.tag' values.yaml)-ent" \
+      . | tee /dev/stderr |
+      yq -r '.spec.containers[0].image' | tee /dev/stderr)
+  [ "${actual}" = "${repo}:${tag}" ]
+}
+
+@test "server/standalone-server-test-Pod: custom image repository respected with Enterprise license" {
+  cd `chart_dir`
+  local tag="$(yq -r '.server.image.tag' values.yaml)-ent"
+
+  local actual=$(helm template \
+      --show-only templates/tests/server-test.yaml \
+      --set 'server.enterpriseLicense.secretName=foo' \
+      --set 'server.image.repository=mycorp/vault' \
+      . | tee /dev/stderr |
+      yq -r '.spec.containers[0].image' | tee /dev/stderr)
+
+  # repo must NOT be overridden to hashicorp/vault-enterprise
+  [[ "${actual}" == "mycorp/vault:"* ]]
+  # -ent tag must still be appended
+  [ "${actual}" = "mycorp/vault:${tag}" ]
+}
+
+@test "server/standalone-server-test-Pod: Community Edition image unchanged when no license secret set" {
+  cd `chart_dir`
+  local repo="$(yq -r '.server.image.repository' values.yaml)"
+  local tag="$(yq -r '.server.image.tag' values.yaml)"
+
+  local actual=$(helm template \
+      --show-only templates/tests/server-test.yaml \
+      . | tee /dev/stderr |
+      yq -r '.spec.containers[0].image' | tee /dev/stderr)
+  [ "${actual}" = "${repo}:${tag}" ]
+}
+
 #--------------------------------------------------------------------
 # resources
 

--- a/test/unit/server-test.bats
+++ b/test/unit/server-test.bats
@@ -146,16 +146,15 @@ load _helpers
   [ "${actual}" = "foo:1.2.3" ]
 }
 
-@test "server/standalone-server-test-Pod: image tag defaults to Chart.AppVersion" {
+@test "server/standalone-server-test-Pod: image tag defaults to latest when tag is empty" {
   cd `chart_dir`
-  local appVersion="$(yq -r '.appVersion' Chart.yaml)"
   local actual=$(helm template \
       --show-only templates/tests/server-test.yaml  \
       --set 'server.image.repository=foo' \
       --set 'server.image.tag=' \
       . | tee /dev/stderr |
       yq -r '.spec.containers[0].image' | tee /dev/stderr)
-  [ "${actual}" = "foo:${appVersion}" ]
+  [ "${actual}" = "foo:latest" ]
 
   local actual=$(helm template \
       --show-only templates/tests/server-test.yaml  \
@@ -164,7 +163,7 @@ load _helpers
       --set 'server.standalone.enabled=true' \
       . | tee /dev/stderr |
       yq -r '.spec.containers[0].image' | tee /dev/stderr)
-  [ "${actual}" = "foo:${appVersion}" ]
+  [ "${actual}" = "foo:latest" ]
 }
 
 @test "server/standalone-server-test-Pod: default imagePullPolicy" {

--- a/test/unit/server-test.bats
+++ b/test/unit/server-test.bats
@@ -146,15 +146,16 @@ load _helpers
   [ "${actual}" = "foo:1.2.3" ]
 }
 
-@test "server/standalone-server-test-Pod: image tag defaults to latest" {
+@test "server/standalone-server-test-Pod: image tag defaults to Chart.AppVersion" {
   cd `chart_dir`
+  local appVersion="$(yq -r '.appVersion' Chart.yaml)"
   local actual=$(helm template \
       --show-only templates/tests/server-test.yaml  \
       --set 'server.image.repository=foo' \
       --set 'server.image.tag=' \
       . | tee /dev/stderr |
       yq -r '.spec.containers[0].image' | tee /dev/stderr)
-  [ "${actual}" = "foo:latest" ]
+  [ "${actual}" = "foo:${appVersion}" ]
 
   local actual=$(helm template \
       --show-only templates/tests/server-test.yaml  \
@@ -163,7 +164,7 @@ load _helpers
       --set 'server.standalone.enabled=true' \
       . | tee /dev/stderr |
       yq -r '.spec.containers[0].image' | tee /dev/stderr)
-  [ "${actual}" = "foo:latest" ]
+  [ "${actual}" = "foo:${appVersion}" ]
 }
 
 @test "server/standalone-server-test-Pod: default imagePullPolicy" {

--- a/test/unit/server-test.bats
+++ b/test/unit/server-test.bats
@@ -146,15 +146,17 @@ load _helpers
   [ "${actual}" = "foo:1.2.3" ]
 }
 
-@test "server/standalone-server-test-Pod: image tag defaults to latest when tag is empty" {
+@test "server/standalone-server-test-Pod: image tag defaults to Chart.AppVersion when tag is empty" {
   cd `chart_dir`
+  local appVersion="$(yq -r '.appVersion' Chart.yaml)"
+
   local actual=$(helm template \
       --show-only templates/tests/server-test.yaml  \
       --set 'server.image.repository=foo' \
       --set 'server.image.tag=' \
       . | tee /dev/stderr |
       yq -r '.spec.containers[0].image' | tee /dev/stderr)
-  [ "${actual}" = "foo:latest" ]
+  [ "${actual}" = "foo:${appVersion}" ]
 
   local actual=$(helm template \
       --show-only templates/tests/server-test.yaml  \
@@ -163,7 +165,7 @@ load _helpers
       --set 'server.standalone.enabled=true' \
       . | tee /dev/stderr |
       yq -r '.spec.containers[0].image' | tee /dev/stderr)
-  [ "${actual}" = "foo:latest" ]
+  [ "${actual}" = "foo:${appVersion}" ]
 }
 
 @test "server/standalone-server-test-Pod: default imagePullPolicy" {
@@ -188,7 +190,7 @@ load _helpers
 @test "server/standalone-server-test-Pod: Enterprise image auto-selected when secretName is set" {
   cd `chart_dir`
   local repo="hashicorp/vault-enterprise"
-  local tag="$(yq -r '.server.image.tag' values.yaml)-ent"
+  local tag="$(yq -r '.appVersion' Chart.yaml)-ent"
 
   local actual=$(helm template \
       --show-only templates/tests/server-test.yaml \
@@ -201,12 +203,12 @@ load _helpers
 @test "server/standalone-server-test-Pod: Enterprise image tag not doubled when -ent suffix already present" {
   cd `chart_dir`
   local repo="hashicorp/vault-enterprise"
-  local tag="$(yq -r '.server.image.tag' values.yaml)-ent"
+  local tag="$(yq -r '.appVersion' Chart.yaml)-ent"
 
   local actual=$(helm template \
       --show-only templates/tests/server-test.yaml \
       --set 'server.enterpriseLicense.secretName=foo' \
-      --set "server.image.tag=$(yq -r '.server.image.tag' values.yaml)-ent" \
+      --set "server.image.tag=$(yq -r '.appVersion' Chart.yaml)-ent" \
       . | tee /dev/stderr |
       yq -r '.spec.containers[0].image' | tee /dev/stderr)
   [ "${actual}" = "${repo}:${tag}" ]
@@ -214,7 +216,7 @@ load _helpers
 
 @test "server/standalone-server-test-Pod: custom image repository respected with Enterprise license" {
   cd `chart_dir`
-  local tag="$(yq -r '.server.image.tag' values.yaml)-ent"
+  local tag="$(yq -r '.appVersion' Chart.yaml)-ent"
 
   local actual=$(helm template \
       --show-only templates/tests/server-test.yaml \
@@ -232,7 +234,7 @@ load _helpers
 @test "server/standalone-server-test-Pod: Community Edition image unchanged when no license secret set" {
   cd `chart_dir`
   local repo="$(yq -r '.server.image.repository' values.yaml)"
-  local tag="$(yq -r '.server.image.tag' values.yaml)"
+  local tag="$(yq -r '.appVersion' Chart.yaml)"
 
   local actual=$(helm template \
       --show-only templates/tests/server-test.yaml \

--- a/test/unit/server-test.bats
+++ b/test/unit/server-test.bats
@@ -202,6 +202,8 @@ load _helpers
 
 @test "server/standalone-server-test-Pod: Enterprise image tag not doubled when -ent suffix already present" {
   cd `chart_dir`
+  # Repo is always promoted to vault-enterprise when a license is set.
+  # Tag is returned verbatim — no duplicate -ent appended.
   local repo="hashicorp/vault-enterprise"
   local tag="$(yq -r '.appVersion' Chart.yaml)-ent"
 
@@ -230,6 +232,24 @@ load _helpers
   # -ent tag must still be appended
   [ "${actual}" = "mycorp/vault:${tag}" ]
 }
+
+@test "server/standalone-server-test-Pod: custom repository and custom tag both preserved with Enterprise license" {
+  cd `chart_dir`
+
+  local actual=$(helm template \
+      --show-only templates/tests/server-test.yaml \
+      --set 'server.enterpriseLicense.secretName=foo' \
+      --set 'server.enterpriseLicense.secretKey=license' \
+      --set 'server.image.repository=mycorp/vault' \
+      --set 'server.image.tag=custom' \
+      . | tee /dev/stderr |
+      yq -r '.spec.containers[0].image' | tee /dev/stderr)
+
+  # Both repo and tag must be preserved exactly — no -ent mutation on the tag
+  [ "${actual}" = "mycorp/vault:custom" ]
+}
+
+
 
 @test "server/standalone-server-test-Pod: Community Edition image unchanged when no license secret set" {
   cd `chart_dir`

--- a/values.yaml
+++ b/values.yaml
@@ -364,6 +364,10 @@ server:
   # enterprise image or if you plan to introduce the license key via another
   # route, then leave secretName blank ("") or set it to null.
   # Requires Vault Enterprise 1.8 or later.
+  #
+  # Setting secretName automatically selects the hashicorp/vault-enterprise
+  # image and appends the -ent tag suffix. You do not need to override
+  # server.image.repository or server.image.tag when using this field.
   enterpriseLicense:
     # The name of the Kubernetes secret that holds the enterprise license. The
     # secret must be in the same namespace that Vault is installed into.
@@ -415,6 +419,12 @@ server:
   #   tls_client_ca_file = "/vault/userconfig/service-ca-bundle/service-ca.crt"
   # }
 
+  # image sets the repository and tag of the Vault server image.
+  # These fields only need to be overridden to pin a custom registry or
+  # a non-standard image name.
+  # When server.enterpriseLicense.secretName is set, the chart automatically
+  # selects hashicorp/vault-enterprise and appends the -ent tag suffix —
+  # no override of these fields is required for Enterprise installations.
   image:
     repository: "hashicorp/vault"
     tag: "2.0.4"

--- a/values.yaml
+++ b/values.yaml
@@ -364,6 +364,10 @@ server:
   # enterprise image or if you plan to introduce the license key via another
   # route, then leave secretName blank ("") or set it to null.
   # Requires Vault Enterprise 1.8 or later.
+  #
+  # Setting secretName automatically selects the hashicorp/vault-enterprise
+  # image and appends the -ent tag suffix. You do not need to override
+  # server.image.repository or server.image.tag when using this field.
   enterpriseLicense:
     # The name of the Kubernetes secret that holds the enterprise license. The
     # secret must be in the same namespace that Vault is installed into.
@@ -415,6 +419,12 @@ server:
   #   tls_client_ca_file = "/vault/userconfig/service-ca-bundle/service-ca.crt"
   # }
 
+  # image sets the repository and tag of the Vault server image.
+  # These fields only need to be overridden to pin a custom registry or
+  # a non-standard image name.
+  # When server.enterpriseLicense.secretName is set, the chart automatically
+  # selects hashicorp/vault-enterprise and appends the -ent tag suffix —
+  # no override of these fields is required for Enterprise installations.
   image:
     repository: "hashicorp/vault"
     tag: "2.0.3"

--- a/values.yaml
+++ b/values.yaml
@@ -74,9 +74,11 @@ injector:
   # agentImage sets the repo and tag of the Vault image to use for the Vault Agent
   # containers.  This should be set to the official Vault image.  Vault 1.3.1+ is
   # required.
+  # tag: leave empty to use Chart.AppVersion (central default). Override with
+  # --set injector.agentImage.tag=<version> to pin independently.
   agentImage:
     repository: "hashicorp/vault"
-    tag: "2.0.4"
+    tag: ""
 
   # The default values for the injected Vault Agent containers.
   agentDefaults:
@@ -420,14 +422,14 @@ server:
   # }
 
   # image sets the repository and tag of the Vault server image.
-  # These fields only need to be overridden to pin a custom registry or
-  # a non-standard image name.
+  # tag: leave empty to use Chart.AppVersion (central default). Override with
+  # --set server.image.tag=<version> to pin independently.
   # When server.enterpriseLicense.secretName is set, the chart automatically
   # selects hashicorp/vault-enterprise and appends the -ent tag suffix —
   # no override of these fields is required for Enterprise installations.
   image:
     repository: "hashicorp/vault"
-    tag: "2.0.4"
+    tag: ""
     # Overrides the default Image Pull Policy
     pullPolicy: IfNotPresent
 
@@ -1286,9 +1288,11 @@ csi:
     enabled: true
     extraArgs: []
 
+    # tag: leave empty to use Chart.AppVersion (central default). Override with
+    # --set csi.agent.image.tag=<version> to pin independently.
     image:
       repository: "hashicorp/vault"
-      tag: "2.0.4"
+      tag: ""
       pullPolicy: IfNotPresent
 
     logFormat: standard

--- a/values.yaml
+++ b/values.yaml
@@ -74,11 +74,9 @@ injector:
   # agentImage sets the repo and tag of the Vault image to use for the Vault Agent
   # containers.  This should be set to the official Vault image.  Vault 1.3.1+ is
   # required.
-  # tag: leave empty to use Chart.AppVersion (central default). Override with
-  # --set injector.agentImage.tag=<version> to pin independently.
   agentImage:
     repository: "hashicorp/vault"
-    tag: ""
+    tag: "2.0.4"
 
   # The default values for the injected Vault Agent containers.
   agentDefaults:
@@ -422,14 +420,14 @@ server:
   # }
 
   # image sets the repository and tag of the Vault server image.
-  # tag: leave empty to use Chart.AppVersion (central default). Override with
-  # --set server.image.tag=<version> to pin independently.
+  # These fields only need to be overridden to pin a custom registry or
+  # a non-standard image name.
   # When server.enterpriseLicense.secretName is set, the chart automatically
   # selects hashicorp/vault-enterprise and appends the -ent tag suffix —
   # no override of these fields is required for Enterprise installations.
   image:
     repository: "hashicorp/vault"
-    tag: ""
+    tag: "2.0.4"
     # Overrides the default Image Pull Policy
     pullPolicy: IfNotPresent
 
@@ -1288,11 +1286,9 @@ csi:
     enabled: true
     extraArgs: []
 
-    # tag: leave empty to use Chart.AppVersion (central default). Override with
-    # --set csi.agent.image.tag=<version> to pin independently.
     image:
       repository: "hashicorp/vault"
-      tag: ""
+      tag: "2.0.4"
       pullPolicy: IfNotPresent
 
     logFormat: standard

--- a/values.yaml
+++ b/values.yaml
@@ -76,7 +76,7 @@ injector:
   # required.
   agentImage:
     repository: "hashicorp/vault"
-    tag: "2.0.4"
+    tag: ""
 
   # The default values for the injected Vault Agent containers.
   agentDefaults:
@@ -427,7 +427,7 @@ server:
   # no override of these fields is required for Enterprise installations.
   image:
     repository: "hashicorp/vault"
-    tag: "2.0.4"
+    tag: ""
     # Overrides the default Image Pull Policy
     pullPolicy: IfNotPresent
 
@@ -1288,7 +1288,7 @@ csi:
 
     image:
       repository: "hashicorp/vault"
-      tag: "2.0.4"
+      tag: ""
       pullPolicy: IfNotPresent
 
     logFormat: standard


### PR DESCRIPTION
**ISSUE :** 
The chart already wired the licence volume, mount, and VAULT_LICENSE_PATH env var when `server.enterpriseLicense.secretName` was set — but still served the Community Edition image, forcing Enterprise customers to manually override `server.image.repository` and `server.image.tag`.

**SOLUTION :** 
Added `vault.isEnterprise` as a single source of truth for the license check, and two generic helpers — `vault.resolveImageRepository` and `vault.resolveImageTag` — containing the shared resolution logic. Six thin wrapper helpers delegate to these for the server, injector agent, and CSI agent respectively.

Resolution rules:
- **repository**: if unset or `hashicorp/vault` (the default) → auto-select `hashicorp/vault-enterprise` (license) or `hashicorp/vault` (no license). Any other explicit repo is returned verbatim.
- **tag**: if empty → auto-select `AppVersion-ent` (license) or `AppVersion` (no license). Any explicit tag is always returned verbatim — never mutated.

Image render sites in `server-statefulset.yaml`, `injector-deployment.yaml`, and `csi-daemonset.yaml `were updated to use these helpers. Empty tags now fall back to `Chart.AppVersion` instead of `latest`, making CE installs reproducible by default.

`server.enterpriseLicense.secretName` is the only configuration needed — no manual image overrides required for any component.

**IMPLEMENTATION VERIFICATION :**

- helm-vault ent installation 
`helm install vault . --set server.enterpriseLicense.secretName=vault-ent-license`
<img width="1041" height="434" alt="image" src="https://github.com/user-attachments/assets/cdb8e1f7-c6b3-4ceb-968c-fb8fd55fc95b" />

- helm-vault community edition installation
`helm install vault .  `
<img width="835" height="411" alt="image" src="https://github.com/user-attachments/assets/b9ea99bb-fc06-4c52-a0bc-c3cc7e49d801" />


## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] I have documented a clear reason for, and description of, the change I am making.

- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
