### PR TITLE
Fixes the bats-unit-tests CI failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Unreleased
+
+Bug Fixes:
+
+* Fix `defaultMode` for license secret volume rendered as octal literal `0440` — changed to decimal `288` to ensure compatibility with `python-yq` >= 4.0.0 [GH-1203](https://github.com/hashicorp/vault-helm/pull/1203)
+
 ## 0.34.0 (July 2, 2026)
 
 Changes:

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -211,7 +211,7 @@ extra volumes the user may have specified (such as a secret with TLS).
         - name: vault-license
           secret:
             secretName: {{ .Values.server.enterpriseLicense.secretName }}
-            defaultMode: 0440
+            defaultMode: 288
   {{- end }}
 {{- end -}}
 


### PR DESCRIPTION
Description:

Fixes the bats-unit-tests CI failure

Root cause:

python-yq released version 4.0.0 on July 3, 2026 , which introduced a breaking change in how it handles YAML octal literals. Previously, `python-yq would convert the octal value 0440 in _helpers.tpl to its decimal equivalent 288 when serialising to JSON. Starting with python-yq >= 4.0.0, it no longer performs this conversion — instead outputting the raw value 440 — causing the unit test assertion to fail`.

The fix changes the defaultMode value in templates/_helpers.tpl from the octal literal 0440 to the explicit decimal 288, which is unambiguous across all versions of python-yq.

The bats-unit-tests CI check failing with the following error:

not ok 705 server/StatefulSet: adds volume for license secret when             enterprise license secret name and key are provided  Expected:  {"defaultMode":288} Actual:    {"defaultMode":440} Error: Process completed with exit code 1.

Test cases execution:

```
m.shilpa@MShilpas-MacBook-Pro vault-helm %  bats --tap --timing ./test/unit/server-statefulset.bats 2>&1 | tail -40
ok 107 server/standalone-StatefulSet: vault port name is https, when tlsDisable is false in 101ms
ok 108 server/standalone-StatefulSet: vault replication port name is https-rep, when tlsDisable is false in 99ms
ok 109 server/standalone-StatefulSet: generic annotations string in 100ms
ok 110 server/standalone-StatefulSet: auditStorage volumeClaim annotations string in 100ms
ok 111 server/standalone-StatefulSet: dataStorage volumeClaim annotations string in 97ms
ok 112 server/standalone-StatefulSet: auditStorage volumeClaim annotations yaml in 99ms
ok 113 server/standalone-StatefulSet: dataStorage volumeClaim annotations yaml in 98ms
ok 114 server/ha-standby-Service: generic annotations yaml in 117ms
ok 115 server/standalone-StatefulSet: config checksum annotation defaults to off in 94ms
ok 116 server/standalone-StatefulSet: config checksum annotation off does not set annotations in 103ms
ok 117 server/standalone-StatefulSet: config checksum annotation can be enabled in 96ms
ok 118 server/standalone-StatefulSet: priorityClassName not set by default in 100ms
ok 119 server/standalone-StatefulSet: priorityClassName can be set in 103ms
ok 120 server/standalone-StatefulSet: postStart disabled by default in 108ms
ok 121 server/standalone-StatefulSet: postStart can be set in 96ms
ok 122 server/standalone-StatefulSet: OpenShift - runAsUser disabled in 106ms
ok 123 server/standalone-StatefulSet: OpenShift - runAsGroup disabled in 99ms
ok 124 server/standalone-StatefulSet: serviceAccount.name is set in 188ms
ok 125 server/standalone-StatefulSet: serviceAccount.name is not set in 178ms
ok 126 server/StatefulSet: adds volume for license secret when enterprise license secret name and key are provided in 104ms
ok 127 server/StatefulSet: adds volume mount for license secret when enterprise license secret name and key are provided in 109ms
ok 128 server/StatefulSet: adds env var for license path when enterprise license secret name and key are provided in 109ms
ok 129 server/StatefulSet: blank secretName does not set env var in 197ms
ok 130 server/standalone-StatefulSet: default statefulSet.securityContext.pod in 100ms
ok 131 server/standalone-StatefulSet: default statefulSet.securityContext.container in 108ms
ok 132 server/standalone-StatefulSet: specify statefulSet.securityContext.pod yaml in 101ms
ok 133 server/standalone-StatefulSet: specify statefulSet.securityContext.container yaml in 99ms
ok 134 server/standalone-StatefulSet: specify statefulSet.securityContext.pod yaml string in 103ms
ok 135 server/standalone-StatefulSet: specify statefulSet.securityContext.container yaml string in 98ms
ok 136 server/StatefulSet: server.hostNetwork not set in 94ms
ok 137 server/StatefulSet: server.hostNetwork is set in 96ms
ok 138 server/StatefulSet: server.hostAliases not set in 96ms
ok 139 server/StatefulSet: server.hostAliases is set in 97ms
ok 140 server/standalone-StatefulSet: adds extra ports in 281ms
ok 141 server/StatefulSet: server.readinessProbe.port is set in 97ms
ok 142 server/StatefulSet: server.livenessProbe.port is set in 98ms
ok 143 server/standalone-StatefulSet: auditStorage volumeClaim labels string in 98ms
ok 144 server/standalone-StatefulSet: dataStorage volumeClaim labels string in 106ms
ok 145 server/standalone-StatefulSet: auditStorage volumeClaim labels yaml in 101ms
ok 146 server/standalone-StatefulSet: dataStorage volumeClaim labels yaml in 95ms


m.shilpa@MShilpas-MacBook-Pro vault-helm % yq --version
yq 4.1.2
jq-1.8.1
```
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [x] I have documented a clear reason for, and description of, the change I am making.

- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
