### PR TITLE
Add extraObjects for additional Kubernetes objects in the release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Unreleased
+
+Features:
+
+* Add `extraObjects` for deploying additional Kubernetes objects as part of the chart's release. Accepts a list or a map, whose entries are either YAML maps or templated strings, and renders each entry with `tpl` against the chart's context [#1206](https://github.com/hashicorp/vault-helm/pull/1206)
+
 ## 0.34.1 (August 13, 2026)
 
 Changes:

--- a/templates/extra-objects.yaml
+++ b/templates/extra-objects.yaml
@@ -1,0 +1,38 @@
+{{/*
+Copyright IBM Corp. 2018, 2025
+SPDX-License-Identifier: MPL-2.0
+*/}}
+
+{{- /*
+extraObjects accepts either a list or a map of objects. Both are normalized to
+a list of entries that keeps the list index or the map key, so an entry of an
+unsupported type can be named in the error. Entries that render to nothing are
+skipped rather than emitting an empty document, so an entry may be wrapped in a
+conditional to tie it to a component being enabled.
+*/ -}}
+{{- $entries := list -}}
+{{- $extraObjects := .Values.extraObjects | default (list) -}}
+{{- if kindIs "map" $extraObjects -}}
+{{- range $key, $object := $extraObjects -}}
+{{- $entries = append $entries (dict "id" $key "object" $object) -}}
+{{- end -}}
+{{- else -}}
+{{- range $index, $object := $extraObjects -}}
+{{- $entries = append $entries (dict "id" $index "object" $object) -}}
+{{- end -}}
+{{- end -}}
+{{- range $entry := $entries }}
+{{- $object := $entry.object }}
+{{- $rendered := "" }}
+{{- if kindIs "string" $object }}
+{{- $rendered = tpl $object $ }}
+{{- else if kindIs "map" $object }}
+{{- $rendered = tpl (toYaml $object) $ }}
+{{- else }}
+{{- fail (printf "extraObjects[%v]: expected a map or a string, got %s" $entry.id (kindOf $object)) }}
+{{- end }}
+{{- if trim $rendered }}
+---
+{{- $rendered | nindent 0 }}
+{{- end }}
+{{- end }}

--- a/test/unit/extra-objects.bats
+++ b/test/unit/extra-objects.bats
@@ -1,0 +1,239 @@
+#!/usr/bin/env bats
+
+load _helpers
+
+#--------------------------------------------------------------------
+# extraObjects
+
+@test "extraObjects: not rendered by default" {
+  cd `chart_dir`
+  local actual=$( (helm template \
+      --show-only templates/extra-objects.yaml \
+      . || echo "---") | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+}
+
+@test "extraObjects: renders an object given as a map" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/extra-objects.yaml \
+      . \
+      -f - <<EOF \
+      | tee /dev/stderr \
+      | yq -r '.metadata.name' | tee /dev/stderr
+extraObjects:
+  - apiVersion: v1
+    kind: ConfigMap
+    metadata:
+      name: from-a-map
+    data:
+      key: value
+EOF
+)
+  [ "${actual}" = "from-a-map" ]
+}
+
+@test "extraObjects: renders an object given as a string" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/extra-objects.yaml \
+      . \
+      -f - <<EOF \
+      | tee /dev/stderr \
+      | yq -r '.data.key' | tee /dev/stderr
+extraObjects:
+  - |
+    apiVersion: v1
+    kind: ConfigMap
+    metadata:
+      name: from-a-string
+    data:
+      key: value
+EOF
+)
+  [ "${actual}" = "value" ]
+}
+
+@test "extraObjects: renders every object in the list" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/extra-objects.yaml \
+      . \
+      -f - <<EOF \
+      | tee /dev/stderr \
+      | yq -s -r 'map(.metadata.name) | join(",")' | tee /dev/stderr
+extraObjects:
+  - apiVersion: v1
+    kind: ConfigMap
+    metadata:
+      name: first
+  - |
+    apiVersion: v1
+    kind: ConfigMap
+    metadata:
+      name: second
+EOF
+)
+  [ "${actual}" = "first,second" ]
+}
+
+@test "extraObjects: accepts a map of objects" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/extra-objects.yaml \
+      . \
+      -f - <<EOF \
+      | tee /dev/stderr \
+      | yq -s -r 'map(.metadata.name) | sort | join(",")' | tee /dev/stderr
+extraObjects:
+  alpha:
+    apiVersion: v1
+    kind: ConfigMap
+    metadata:
+      name: first
+  beta: |
+    apiVersion: v1
+    kind: ConfigMap
+    metadata:
+      name: second
+EOF
+)
+  [ "${actual}" = "first,second" ]
+}
+
+@test "extraObjects: objects are templated against the chart context" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/extra-objects.yaml \
+      --namespace vault-namespace \
+      . \
+      -f - <<EOF \
+      | tee /dev/stderr \
+      | yq -r '[.metadata.name, .metadata.namespace, .metadata.labels["app.kubernetes.io/name"]] | join(",")' | tee /dev/stderr
+extraObjects:
+  - |
+    apiVersion: v1
+    kind: ConfigMap
+    metadata:
+      name: {{ include "vault.fullname" . }}-extra
+      namespace: {{ include "vault.namespace" . }}
+      labels:
+        app.kubernetes.io/name: {{ include "vault.name" . }}
+    data:
+      chart: {{ .Chart.Name }}
+EOF
+)
+  [ "${actual}" = "release-name-vault-extra,vault-namespace,vault" ]
+}
+
+@test "extraObjects: templated values are resolved in the map form too" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/extra-objects.yaml \
+      . \
+      -f - <<EOF \
+      | tee /dev/stderr \
+      | yq -r '.metadata.name' | tee /dev/stderr
+extraObjects:
+  - apiVersion: v1
+    kind: ConfigMap
+    metadata:
+      name: '{{ include "vault.fullname" . }}-extra'
+EOF
+)
+  [ "${actual}" = "release-name-vault-extra" ]
+}
+
+@test "extraObjects: rendered when global.enabled is false" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/extra-objects.yaml \
+      --set 'global.enabled=false' \
+      . \
+      -f - <<EOF \
+      | tee /dev/stderr \
+      | yq -r '.metadata.name' | tee /dev/stderr
+extraObjects:
+  - apiVersion: v1
+    kind: ConfigMap
+    metadata:
+      name: still-here
+EOF
+)
+  [ "${actual}" = "still-here" ]
+}
+
+@test "extraObjects: an entry that renders to nothing is skipped" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/extra-objects.yaml \
+      --set 'csi.enabled=false' \
+      . \
+      -f - <<EOF \
+      | tee /dev/stderr \
+      | yq -s -r 'map(.metadata.name) | join(",")' | tee /dev/stderr
+extraObjects:
+  server: |
+    apiVersion: v1
+    kind: ConfigMap
+    metadata:
+      name: always-here
+  csi: |
+    {{- if .Values.csi.enabled }}
+    apiVersion: v1
+    kind: ConfigMap
+    metadata:
+      name: only-with-csi
+    {{- end }}
+EOF
+)
+  [ "${actual}" = "always-here" ]
+}
+
+@test "extraObjects: objects for the server and the CSI provider can be deployed together" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/extra-objects.yaml \
+      --set 'csi.enabled=true' \
+      . \
+      -f - <<EOF \
+      | tee /dev/stderr \
+      | yq -s -r 'map(.metadata.name) | sort | join(",")' | tee /dev/stderr
+extraObjects:
+  server: |
+    apiVersion: v1
+    kind: ConfigMap
+    metadata:
+      name: {{ include "vault.fullname" . }}-server-tls
+  csi: |
+    {{- if .Values.csi.enabled }}
+    apiVersion: v1
+    kind: ConfigMap
+    metadata:
+      name: {{ include "vault.fullname" . }}-csi-tls
+    {{- end }}
+EOF
+)
+  [ "${actual}" = "release-name-vault-csi-tls,release-name-vault-server-tls" ]
+}
+
+@test "extraObjects: an entry that is neither a map nor a string fails" {
+  cd `chart_dir`
+  run helm template \
+      --show-only templates/extra-objects.yaml \
+      --set 'extraObjects[0]=42' \
+      .
+  [ "$status" -eq 1 ]
+  [[ "$output" =~ "extraObjects[0]: expected a map or a string" ]]
+}
+
+@test "extraObjects: a failing entry in the map form is named by its key" {
+  cd `chart_dir`
+  run helm template \
+      --show-only templates/extra-objects.yaml \
+      --set 'extraObjects.serverCert=42' \
+      .
+  [ "$status" -eq 1 ]
+  [[ "$output" =~ "extraObjects[serverCert]: expected a map or a string" ]]
+}

--- a/values.schema.json
+++ b/values.schema.json
@@ -242,6 +242,13 @@
                 }
             }
         },
+        "extraObjects": {
+            "type": [
+                "array",
+                "object",
+                "null"
+            ]
+        },
         "global": {
             "type": "object",
             "properties": {

--- a/values.yaml
+++ b/values.yaml
@@ -1479,3 +1479,85 @@ serverTelemetry:
       #    for: 5m
       #    labels:
       #      severity: critical
+
+# Additional Kubernetes objects to deploy alongside the chart's own resources.
+# Use this for objects the chart does not model, such as a cert-manager
+# Certificate that issues the Secret referenced by server.volumes, or a
+# NetworkPolicy for the CSI provider. Managing them here keeps them in the same
+# Helm release, so they share its lifecycle instead of being applied separately.
+#
+# Each entry is either a YAML map or a string. Both forms are rendered with
+# `tpl` against the chart's context, so they can call the chart's own templates
+# and values. Referencing helpers such as `vault.fullname`, `vault.name` and
+# `vault.namespace` keeps names, selectors and labels in step with the
+# resources the chart generates. An entry that is neither a map nor a string
+# fails rendering with an error naming its list index or its map key.
+#
+# extraObjects may also be given as a map of named entries instead of a list.
+# Helm replaces lists wholesale when merging values files but merges maps
+# key by key, so the map form lets a layered values file add or override a
+# single object without restating the others.
+#
+# These objects are not gated on global.enabled or on any component being
+# enabled. An entry that renders to nothing is skipped rather than emitting an
+# empty document, so an entry can be wrapped in a conditional to tie it to a
+# component: see the server and CSI provider example below. This matters when
+# one release enables more than one component, since each component needs its
+# own object under its own name.
+#
+# example, as a list of maps:
+# extraObjects:
+#   - apiVersion: cert-manager.io/v1
+#     kind: Certificate
+#     metadata:
+#       name: '{{ include "vault.fullname" . }}-tls'
+#       namespace: '{{ include "vault.namespace" . }}'
+#     spec:
+#       secretName: vault-tls
+#       issuerRef:
+#         name: internal-issuer
+#         kind: ClusterIssuer
+#       dnsNames:
+#         - vault.example.com
+#
+# example, as a map of templated strings, giving the server and the CSI
+# provider a certificate each. The CSI entry renders to nothing when the CSI
+# provider is disabled, so the same values file serves a release with either or
+# both:
+# extraObjects:
+#   serverCertificate: |
+#     apiVersion: cert-manager.io/v1
+#     kind: Certificate
+#     metadata:
+#       name: {{ include "vault.fullname" . }}-server-tls
+#       namespace: {{ include "vault.namespace" . }}
+#       labels:
+#         app.kubernetes.io/name: {{ include "vault.name" . }}
+#     spec:
+#       secretName: vault-server-tls
+#       issuerRef:
+#         name: internal-issuer
+#         kind: ClusterIssuer
+#       dnsNames:
+#         - vault.example.com
+#   csiCertificate: |
+#     {{- if .Values.csi.enabled }}
+#     apiVersion: cert-manager.io/v1
+#     kind: Certificate
+#     metadata:
+#       name: {{ include "vault.fullname" . }}-csi-tls
+#       namespace: {{ include "vault.namespace" . }}
+#       labels:
+#         app.kubernetes.io/name: {{ include "vault.name" . }}
+#     spec:
+#       secretName: vault-csi-tls
+#       issuerRef:
+#         name: internal-issuer
+#         kind: ClusterIssuer
+#       dnsNames:
+#         - vault-csi.example.com
+#     {{- end }}
+#
+# The default is null rather than an empty list so that neither the list nor
+# the map form conflicts with the default's type when values files are merged.
+extraObjects: null


### PR DESCRIPTION
## Summary

Adds an `extraObjects` value for deploying additional Kubernetes objects as part of the chart's release, so objects the chart does not model share the release's lifecycle instead of being applied separately.

Closes #1146. Builds on the approach proposed in #1143 by @giuliocalzo, who is credited as co-author. See "Relationship to #1143" below.

## Problem

Objects the chart does not model, such as a cert-manager `Certificate` issuing the Secret referenced by `server.volumes`, or a `NetworkPolicy` scoped to the chart's workloads, currently need a separate `kubectl apply` or a separate wrapper chart. That splits them from the release that depends on them: they are not tracked by Helm, not removed on `helm uninstall`, and can drift out of step with the resources the chart generates.

## Solution

A new top-level `extraObjects` value, rendered by `templates/extra-objects.yaml`.

**Entries may be a list or a map.** Helm replaces lists wholesale when merging values files but merges maps key by key, so the map form lets a layered values file (a base plus a per-environment overlay) add or override a single object without restating the others.

**Each entry may be a YAML map or a string.** The map form keeps values-file syntax highlighting and schema tooling working; the string form is convenient for manifests copied verbatim.

**Every entry is rendered with `tpl` against the chart's context,** so entries can call the chart's own helpers (`vault.fullname`, `vault.name`, `vault.namespace`) and stay in step with the names and labels the chart generates.

**An entry that renders to nothing is skipped** rather than emitting an empty document. This lets an entry be wrapped in a conditional and tied to a component being enabled, so a single values file can serve releases running any combination of components.

**An entry that is neither a map nor a string fails rendering** with an error naming its list index or map key, rather than producing invalid YAML further down.

`extraObjects` is deliberately not gated on `global.enabled` or on any component being enabled.

## Examples

As a list of maps:

```yaml
extraObjects:
  - apiVersion: cert-manager.io/v1
    kind: Certificate
    metadata:
      name: '{{ include "vault.fullname" . }}-tls'
      namespace: '{{ include "vault.namespace" . }}'
    spec:
      secretName: vault-tls
      issuerRef:
        name: internal-issuer
        kind: ClusterIssuer
      dnsNames:
        - vault.example.com
```

As a map of templated strings, where the second entry renders to nothing unless the CSI provider is enabled:

```yaml
extraObjects:
  serverCertificate: |
    apiVersion: v1
    kind: ConfigMap
    metadata:
      name: {{ include "vault.fullname" . }}-server-tls
      namespace: {{ include "vault.namespace" . }}
  csiCertificate: |
    {{- if .Values.csi.enabled }}
    apiVersion: v1
    kind: ConfigMap
    metadata:
      name: {{ include "vault.fullname" . }}-csi-tls
      namespace: {{ include "vault.namespace" . }}
    {{- end }}
```

## Relationship to #1143

#1143 proposed the same feature with a minimal four-line template. This PR keeps that idea and its `extraObjects` name and string-entry form, and adds map entries, the map-of-named-entries form, conditional skipping, type validation, a `values.schema.json` entry, unit tests, and a CHANGELOG entry.

I am happy for the maintainers to take whichever they prefer, or for this to be applied onto #1143's branch instead if @giuliocalzo would rather carry it there. I have commented on #1143 to say the same.

## Backwards compatibility

Additive only. The default is `null`, so nothing renders unless the value is set. `null` rather than `[]` so that neither the list nor the map form conflicts with the default's type when values files are merged.

## Testing

`test/unit/extra-objects.bats` adds 11 cases covering: not rendered by default; map entries; string entries; multiple entries in a list; the map-of-entries form; templating against the chart context; templating inside the map form; rendering when `global.enabled=false`; skipping an entry that renders to nothing; two component-scoped objects in one release; and the two failure modes, in both the list and map forms.

```
bats test/unit/extra-objects.bats
```

`helm lint` passes.

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [x] I have documented a clear reason for, and description of, the change I am making.

- [x] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

  The change is additive and defaults to `null`. Reverting the pull request is sufficient.

- [x] If applicable, I've documented the impact of any changes to security controls.

  No change to the chart's own security controls. `extraObjects` renders operator-supplied manifests already under the operator's control, with the same privileges as any other manifest they apply to the cluster.
