### PR TITLE
Add Vault Proxy as an optional standalone component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 Features:
 
-* Add support for running Vault Proxy as a standalone Deployment via the new `proxy.*` values, providing a cluster-local caching API proxy in front of an in-cluster or external Vault server, with optional auto-auth via the Kubernetes auth method and an optional external Service [#1207](https://github.com/hashicorp/vault-helm/pull/1207)
+* Add support for running Vault Proxy as a standalone Deployment via the new `proxy.*` values, providing a cluster-local caching API proxy in front of an in-cluster or external Vault server, with optional auto-auth via the Kubernetes auth method and optional external Service and Ingress resources for exposing it outside the cluster [#1207](https://github.com/hashicorp/vault-helm/pull/1207)
 
 ## 0.34.1 (August 13, 2026)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Unreleased
+
+Features:
+
+* Add support for running Vault Proxy as a standalone Deployment via the new `proxy.*` values, providing a cluster-local caching API proxy in front of an in-cluster or external Vault server, with optional auto-auth via the Kubernetes auth method and an optional external Service [#1207](https://github.com/hashicorp/vault-helm/pull/1207)
+
 ## 0.34.1 (August 13, 2026)
 
 Changes:

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -62,6 +62,17 @@ Compute if the injector is enabled.
 {{- end -}}
 
 {{/*
+Compute if the proxy is enabled. Unlike the other components, the proxy is
+disabled by default and must be enabled explicitly, but the "-" convention
+is still honored for consistency.
+*/}}
+{{- define "vault.proxyEnabled" -}}
+{{- $_ := set . "proxyEnabled" (or
+  (eq (.Values.proxy.enabled | toString) "true")
+  (and (eq (.Values.proxy.enabled | toString) "-") (eq (.Values.global.enabled | toString) "true"))) -}}
+{{- end -}}
+
+{{/*
 Compute if the server is enabled.
 */}}
 {{- define "vault.serverEnabled" -}}
@@ -1047,6 +1058,240 @@ Sets extra CSI service account annotations
 {{- end -}}
 
 {{/*
+Vault address the proxy uses to reach the Vault server: the value of
+global.externalVaultAddr when set, otherwise the chart's internal Vault
+service. Referenced from the default proxy.config value.
+*/}}
+{{- define "proxy.vaultAddress" -}}
+{{- if .Values.global.externalVaultAddr -}}
+{{- .Values.global.externalVaultAddr -}}
+{{- else -}}
+{{- printf "%s://%s.%s.svc:%v" (include "vault.scheme" .) (include "vault.fullname" .) (include "vault.namespace" .) .Values.server.service.port -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Proxy configuration rendered with templating support, so values like
+proxy.vaultAddress can be referenced from proxy.config.
+*/}}
+{{- define "proxy.config" -}}
+{{- tpl .Values.proxy.config . -}}
+{{- end -}}
+
+{{/*
+Scheme for the proxy listener, used by path-based health probes. Follows
+proxy.tlsDisable, which must match the listener stanza in proxy.config.
+*/}}
+{{- define "proxy.scheme" -}}
+{{- if .Values.proxy.tlsDisable -}}
+{{ "http" }}
+{{- else -}}
+{{ "https" }}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create the name of the proxy service account to use
+*/}}
+{{- define "proxy.serviceAccount.name" -}}
+{{- if .Values.proxy.serviceAccount.create -}}
+    {{ default (printf "%s-proxy" (include "vault.fullname" .)) .Values.proxy.serviceAccount.name }}
+{{- else -}}
+    {{ default "default" .Values.proxy.serviceAccount.name }}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Sets extra proxy pod annotations. The configuration checksum is always
+included so that the stateless proxy pods roll when their configuration
+changes.
+*/}}
+{{- define "proxy.annotations" }}
+      annotations:
+        vault.hashicorp.com/config-checksum: {{ include "proxy.config" . | sha256sum }}
+  {{- if .Values.proxy.annotations }}
+        {{- $tp := typeOf .Values.proxy.annotations }}
+        {{- if eq $tp "string" }}
+          {{- tpl .Values.proxy.annotations . | nindent 8 }}
+        {{- else }}
+          {{- toYaml .Values.proxy.annotations | nindent 8 }}
+        {{- end }}
+  {{- end }}
+{{- end -}}
+
+{{/*
+Sets extra proxy service annotations
+*/}}
+{{- define "proxy.service.annotations" -}}
+  {{- if .Values.proxy.service.annotations }}
+  annotations:
+    {{- $tp := typeOf .Values.proxy.service.annotations }}
+    {{- if eq $tp "string" }}
+      {{- tpl .Values.proxy.service.annotations . | nindent 4 }}
+    {{- else }}
+      {{- toYaml .Values.proxy.service.annotations | nindent 4 }}
+    {{- end }}
+  {{- end }}
+{{- end -}}
+
+{{/*
+Sets extra proxy external service annotations
+*/}}
+{{- define "proxy.externalService.annotations" -}}
+  {{- if .Values.proxy.service.externalService.annotations }}
+  annotations:
+    {{- $tp := typeOf .Values.proxy.service.externalService.annotations }}
+    {{- if eq $tp "string" }}
+      {{- tpl .Values.proxy.service.externalService.annotations . | nindent 4 }}
+    {{- else }}
+      {{- toYaml .Values.proxy.service.externalService.annotations | nindent 4 }}
+    {{- end }}
+  {{- end }}
+{{- end -}}
+
+{{/*
+Sets extra proxy service account annotations
+*/}}
+{{- define "proxy.serviceAccount.annotations" -}}
+  {{- if .Values.proxy.serviceAccount.annotations }}
+  annotations:
+    {{- $tp := typeOf .Values.proxy.serviceAccount.annotations }}
+    {{- if eq $tp "string" }}
+      {{- tpl .Values.proxy.serviceAccount.annotations . | nindent 4 }}
+    {{- else }}
+      {{- toYaml .Values.proxy.serviceAccount.annotations | nindent 4 }}
+    {{- end }}
+  {{- end }}
+{{- end -}}
+
+{{/*
+securityContext for the proxy pod level.
+*/}}
+{{- define "proxy.securityContext.pod" -}}
+  {{- if .Values.proxy.securityContext.pod }}
+      securityContext:
+        {{- $tp := typeOf .Values.proxy.securityContext.pod }}
+        {{- if eq $tp "string" }}
+          {{- tpl .Values.proxy.securityContext.pod . | nindent 8 }}
+        {{- else }}
+          {{- toYaml .Values.proxy.securityContext.pod | nindent 8 }}
+        {{- end }}
+  {{- else if not .Values.global.openshift }}
+      securityContext:
+        runAsNonRoot: true
+        runAsGroup: {{ .Values.proxy.gid | default 1000 }}
+        runAsUser: {{ .Values.proxy.uid | default 100 }}
+        fsGroup: {{ .Values.proxy.gid | default 1000 }}
+  {{- end }}
+{{- end -}}
+
+{{/*
+securityContext for the proxy container level.
+*/}}
+{{- define "proxy.securityContext.container" -}}
+  {{- if .Values.proxy.securityContext.container }}
+          securityContext:
+            {{- $tp := typeOf .Values.proxy.securityContext.container }}
+            {{- if eq $tp "string" }}
+              {{- tpl .Values.proxy.securityContext.container . | nindent 12 }}
+            {{- else }}
+              {{- toYaml .Values.proxy.securityContext.container | nindent 12 }}
+            {{- end }}
+  {{- else if not .Values.global.openshift }}
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+  {{- end }}
+{{- end -}}
+
+{{/*
+Sets the proxy affinity for pod placement
+*/}}
+{{- define "proxy.affinity" -}}
+  {{- if .Values.proxy.affinity }}
+      affinity:
+        {{ $tp := typeOf .Values.proxy.affinity }}
+        {{- if eq $tp "string" }}
+          {{- tpl .Values.proxy.affinity . | nindent 8 | trim }}
+        {{- else }}
+          {{- toYaml .Values.proxy.affinity | nindent 8 }}
+        {{- end }}
+  {{ end }}
+{{- end -}}
+
+{{/*
+Sets the proxy topologySpreadConstraints for pod placement
+*/}}
+{{- define "proxy.topologySpreadConstraints" -}}
+  {{- if .Values.proxy.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{ $tp := typeOf .Values.proxy.topologySpreadConstraints }}
+        {{- if eq $tp "string" }}
+          {{- tpl .Values.proxy.topologySpreadConstraints . | nindent 8 | trim }}
+        {{- else }}
+          {{- toYaml .Values.proxy.topologySpreadConstraints | nindent 8 }}
+        {{- end }}
+  {{ end }}
+{{- end -}}
+
+{{/*
+Sets the proxy toleration for pod placement
+*/}}
+{{- define "proxy.tolerations" -}}
+  {{- if .Values.proxy.tolerations }}
+      tolerations:
+      {{- $tp := typeOf .Values.proxy.tolerations }}
+      {{- if eq $tp "string" }}
+        {{ tpl .Values.proxy.tolerations . | nindent 8 | trim }}
+      {{- else }}
+        {{- toYaml .Values.proxy.tolerations | nindent 8 }}
+      {{- end }}
+  {{- end }}
+{{- end -}}
+
+{{/*
+Sets the proxy node selector for pod placement
+*/}}
+{{- define "proxy.nodeselector" -}}
+  {{- if .Values.proxy.nodeSelector }}
+      nodeSelector:
+      {{- $tp := typeOf .Values.proxy.nodeSelector }}
+      {{- if eq $tp "string" }}
+        {{ tpl .Values.proxy.nodeSelector . | nindent 8 | trim }}
+      {{- else }}
+        {{- toYaml .Values.proxy.nodeSelector | nindent 8 }}
+      {{- end }}
+  {{- end }}
+{{- end -}}
+
+{{/*
+Sets the proxy deployment update strategy
+*/}}
+{{- define "proxy.strategy" -}}
+  {{- if .Values.proxy.strategy }}
+  strategy:
+  {{- $tp := typeOf .Values.proxy.strategy }}
+  {{- if eq $tp "string" }}
+    {{ tpl .Values.proxy.strategy . | nindent 4 | trim }}
+  {{- else }}
+    {{- toYaml .Values.proxy.strategy | nindent 4 }}
+  {{- end }}
+  {{- end }}
+{{- end -}}
+
+{{/*
+Sets the container resources if the user has set any.
+*/}}
+{{- define "proxy.resources" -}}
+  {{- if .Values.proxy.resources -}}
+          resources:
+{{ toYaml .Values.proxy.resources | indent 12}}
+  {{ end }}
+{{- end -}}
+
+{{/*
 Inject extra environment vars in the format key:value, if populated
 */}}
 {{- define "vault.extraEnvironmentVars" -}}
@@ -1121,7 +1366,13 @@ loadBalancer configuration for the the UI service.
 Supported inputs are Values.ui
 */}}
 {{- define "service.loadBalancer" -}}
-{{- if  eq (.serviceType | toString) "LoadBalancer" }}
+{{- $type := "" -}}
+{{- if .serviceType -}}
+{{- $type = .serviceType -}}
+{{- else if .type -}}
+{{- $type = .type -}}
+{{- end -}}
+{{- if eq $type "LoadBalancer" }}
 {{- if .loadBalancerIP }}
   loadBalancerIP: {{ .loadBalancerIP }}
 {{- end }}

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -73,6 +73,15 @@ is still honored for consistency.
 {{- end -}}
 
 {{/*
+Compute if the proxy Service is enabled. The proxy Ingress routes to it, so it
+must exist for the Ingress to have a backend.
+*/}}
+{{- define "vault.proxyServiceEnabled" -}}
+{{- template "vault.proxyEnabled" . -}}
+{{- $_ := set . "proxyServiceEnabled" (and .proxyEnabled (eq (.Values.proxy.service.enabled | toString) "true")) -}}
+{{- end -}}
+
+{{/*
 Compute if the server is enabled.
 */}}
 {{- define "vault.serverEnabled" -}}
@@ -1130,6 +1139,21 @@ Sets extra proxy service annotations
       {{- tpl .Values.proxy.service.annotations . | nindent 4 }}
     {{- else }}
       {{- toYaml .Values.proxy.service.annotations | nindent 4 }}
+    {{- end }}
+  {{- end }}
+{{- end -}}
+
+{{/*
+Sets extra proxy ingress annotations
+*/}}
+{{- define "proxy.ingress.annotations" -}}
+  {{- if .Values.proxy.ingress.annotations }}
+  annotations:
+    {{- $tp := typeOf .Values.proxy.ingress.annotations }}
+    {{- if eq $tp "string" }}
+      {{- tpl .Values.proxy.ingress.annotations . | nindent 4 }}
+    {{- else }}
+      {{- toYaml .Values.proxy.ingress.annotations | nindent 4 }}
     {{- end }}
   {{- end }}
 {{- end -}}

--- a/templates/proxy-configmap.yaml
+++ b/templates/proxy-configmap.yaml
@@ -1,0 +1,21 @@
+{{/*
+Copyright IBM Corp. 2018, 2025
+SPDX-License-Identifier: MPL-2.0
+*/}}
+
+{{- template "vault.proxyEnabled" . -}}
+{{- if .proxyEnabled -}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "vault.fullname" . }}-proxy-config
+  namespace: {{ include "vault.namespace" . }}
+  labels:
+    helm.sh/chart: {{ include "vault.chart" . }}
+    app.kubernetes.io/name: {{ include "vault.name" . }}-proxy
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+data:
+  config.hcl: |
+    {{- include "proxy.config" . | nindent 4 }}
+{{- end }}

--- a/templates/proxy-deployment.yaml
+++ b/templates/proxy-deployment.yaml
@@ -1,0 +1,118 @@
+{{/*
+Copyright IBM Corp. 2018, 2025
+SPDX-License-Identifier: MPL-2.0
+*/}}
+
+{{- template "vault.proxyEnabled" . -}}
+{{- if .proxyEnabled -}}
+# Deployment for Vault Proxy
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ template "vault.fullname" . }}-proxy
+  namespace: {{ include "vault.namespace" . }}
+  labels:
+    helm.sh/chart: {{ include "vault.chart" . }}
+    app.kubernetes.io/name: {{ include "vault.name" . }}-proxy
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    component: proxy
+spec:
+  replicas: {{ .Values.proxy.replicas }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ template "vault.name" . }}-proxy
+      app.kubernetes.io/instance: {{ .Release.Name }}
+      component: proxy
+  {{ template "proxy.strategy" . }}
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: {{ template "vault.name" . }}-proxy
+        app.kubernetes.io/instance: {{ .Release.Name }}
+        component: proxy
+        {{- if  .Values.proxy.extraLabels -}}
+          {{- toYaml .Values.proxy.extraLabels | nindent 8 -}}
+        {{- end -}}
+      {{ template "proxy.annotations" . }}
+    spec:
+      {{ template "proxy.affinity" . }}
+      {{ template "proxy.topologySpreadConstraints" . }}
+      {{ template "proxy.tolerations" . }}
+      {{ template "proxy.nodeselector" . }}
+      {{- if .Values.proxy.priorityClassName }}
+      priorityClassName: {{ .Values.proxy.priorityClassName }}
+      {{- end }}
+      serviceAccountName: {{ template "proxy.serviceAccount.name" . }}
+      {{ template "proxy.securityContext.pod" . }}
+      containers:
+        - name: vault-proxy
+          {{ template "proxy.resources" . }}
+          image: "{{ .Values.proxy.image.repository }}:{{ .Values.proxy.image.tag }}"
+          imagePullPolicy: "{{ .Values.proxy.image.pullPolicy }}"
+          {{- template "proxy.securityContext.container" . }}
+          command:
+            - vault
+          args:
+            - proxy
+            - -config=/etc/vault/config.hcl
+            {{- if .Values.proxy.extraArgs }}
+            {{- toYaml .Values.proxy.extraArgs | nindent 12 }}
+            {{- end }}
+          ports:
+            - name: proxy
+              containerPort: {{ .Values.proxy.port }}
+          env:
+            - name: VAULT_LOG_LEVEL
+              value: "{{ .Values.proxy.logLevel }}"
+            - name: VAULT_LOG_FORMAT
+              value: "{{ .Values.proxy.logFormat }}"
+            {{- include "vault.extraEnvironmentVars" .Values.proxy | nindent 12 }}
+            {{- include "vault.extraSecretEnvironmentVars" .Values.proxy | nindent 12 }}
+          livenessProbe:
+            {{- if .Values.proxy.livenessProbe.path }}
+            httpGet:
+              path: {{ .Values.proxy.livenessProbe.path | quote }}
+              port: {{ default .Values.proxy.port .Values.proxy.livenessProbe.port }}
+              scheme: {{ include "proxy.scheme" . | upper }}
+            {{- else }}
+            tcpSocket:
+              port: {{ default .Values.proxy.port .Values.proxy.livenessProbe.port }}
+            {{- end }}
+            failureThreshold: {{ .Values.proxy.livenessProbe.failureThreshold }}
+            initialDelaySeconds: {{ .Values.proxy.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.proxy.livenessProbe.periodSeconds }}
+            successThreshold: {{ .Values.proxy.livenessProbe.successThreshold }}
+            timeoutSeconds: {{ .Values.proxy.livenessProbe.timeoutSeconds }}
+          readinessProbe:
+            {{- if .Values.proxy.readinessProbe.path }}
+            httpGet:
+              path: {{ .Values.proxy.readinessProbe.path | quote }}
+              port: {{ default .Values.proxy.port .Values.proxy.readinessProbe.port }}
+              scheme: {{ include "proxy.scheme" . | upper }}
+            {{- else }}
+            tcpSocket:
+              port: {{ default .Values.proxy.port .Values.proxy.readinessProbe.port }}
+            {{- end }}
+            failureThreshold: {{ .Values.proxy.readinessProbe.failureThreshold }}
+            initialDelaySeconds: {{ .Values.proxy.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.proxy.readinessProbe.periodSeconds }}
+            successThreshold: {{ .Values.proxy.readinessProbe.successThreshold }}
+            timeoutSeconds: {{ .Values.proxy.readinessProbe.timeoutSeconds }}
+          volumeMounts:
+            - name: config
+              mountPath: /etc/vault/config.hcl
+              subPath: config.hcl
+              readOnly: true
+            {{- if .Values.proxy.volumeMounts }}
+            {{- toYaml .Values.proxy.volumeMounts | nindent 12 }}
+            {{- end }}
+      volumes:
+        - name: config
+          configMap:
+            name: {{ template "vault.fullname" . }}-proxy-config
+        {{- if .Values.proxy.volumes }}
+        {{- toYaml .Values.proxy.volumes | nindent 8 }}
+        {{- end }}
+      {{- include "imagePullSecrets" . | nindent 6 }}
+{{ end }}

--- a/templates/proxy-disruptionbudget.yaml
+++ b/templates/proxy-disruptionbudget.yaml
@@ -1,0 +1,28 @@
+{{/*
+Copyright IBM Corp. 2018, 2025
+SPDX-License-Identifier: MPL-2.0
+*/}}
+
+{{- template "vault.proxyEnabled" . -}}
+{{- if .proxyEnabled -}}
+{{- if .Values.proxy.podDisruptionBudget -}}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ template "vault.fullname" . }}-proxy
+  namespace: {{ include "vault.namespace" . }}
+  labels:
+    helm.sh/chart: {{ include "vault.chart" . }}
+    app.kubernetes.io/name: {{ include "vault.name" . }}-proxy
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    component: proxy
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ template "vault.name" . }}-proxy
+      app.kubernetes.io/instance: {{ .Release.Name }}
+      component: proxy
+  {{- toYaml .Values.proxy.podDisruptionBudget | nindent 2 }}
+{{- end }}
+{{- end }}

--- a/templates/proxy-external-service.yaml
+++ b/templates/proxy-external-service.yaml
@@ -1,0 +1,33 @@
+{{/*
+Copyright IBM Corp. 2018, 2025
+SPDX-License-Identifier: MPL-2.0
+*/}}
+
+{{- template "vault.proxyEnabled" . -}}
+{{- if .proxyEnabled -}}
+{{- if eq (.Values.proxy.service.externalService.enabled | toString) "true" }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "vault.fullname" . }}-proxy-external
+  namespace: {{ include "vault.namespace" . }}
+  labels:
+    helm.sh/chart: {{ include "vault.chart" . }}
+    app.kubernetes.io/name: {{ include "vault.name" . }}-proxy
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+  {{ template "proxy.externalService.annotations" . }}
+spec:
+  type: {{ .Values.proxy.service.externalService.type }}
+{{- template "service.externalTrafficPolicy" .Values.proxy.service.externalService }}
+  {{- include "service.loadBalancer" .Values.proxy.service.externalService }}
+  ports:
+    - name: proxy
+      port: {{ .Values.proxy.service.externalService.port }}
+      targetPort: {{ .Values.proxy.service.externalService.targetPort }}
+  selector:
+    app.kubernetes.io/name: {{ include "vault.name" . }}-proxy
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    component: proxy
+{{- end }}
+{{- end }}

--- a/templates/proxy-ingress.yaml
+++ b/templates/proxy-ingress.yaml
@@ -1,0 +1,60 @@
+{{/*
+Copyright IBM Corp. 2018, 2025
+SPDX-License-Identifier: MPL-2.0
+*/}}
+
+{{- template "vault.proxyServiceEnabled" . -}}
+{{- if .proxyServiceEnabled -}}
+{{- if .Values.proxy.ingress.enabled -}}
+{{- $extraPaths := .Values.proxy.ingress.extraPaths -}}
+{{- $serviceName := printf "%s-proxy" (include "vault.fullname" .) -}}
+{{- $servicePort := .Values.proxy.service.port -}}
+{{- $pathType := .Values.proxy.ingress.pathType -}}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ template "vault.fullname" . }}-proxy
+  namespace: {{ include "vault.namespace" . }}
+  labels:
+    helm.sh/chart: {{ include "vault.chart" . }}
+    app.kubernetes.io/name: {{ include "vault.name" . }}-proxy
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    {{- with .Values.proxy.ingress.labels }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- template "proxy.ingress.annotations" . }}
+spec:
+{{- if .Values.proxy.ingress.tls }}
+  tls:
+  {{- range .Values.proxy.ingress.tls }}
+    - hosts:
+      {{- range .hosts }}
+        - {{ . | quote }}
+      {{- end }}
+      secretName: {{ .secretName }}
+  {{- end }}
+{{- end }}
+{{- if .Values.proxy.ingress.ingressClassName }}
+  ingressClassName: {{ .Values.proxy.ingress.ingressClassName }}
+{{- end }}
+  rules:
+  {{- range .Values.proxy.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+{{ if $extraPaths }}
+{{ toYaml $extraPaths | indent 10 }}
+{{- end }}
+        {{- range (.paths | default (list "/")) }}
+          - path: {{ . }}
+            pathType: {{ $pathType }}
+            backend:
+              service:
+                name: {{ $serviceName }}
+                port:
+                  number: {{ $servicePort }}
+        {{- end }}
+  {{- end }}
+{{- end }}
+{{- end }}

--- a/templates/proxy-service.yaml
+++ b/templates/proxy-service.yaml
@@ -1,0 +1,35 @@
+{{/*
+Copyright IBM Corp. 2018, 2025
+SPDX-License-Identifier: MPL-2.0
+*/}}
+
+{{- template "vault.proxyEnabled" . -}}
+{{- if .proxyEnabled -}}
+{{- if eq (.Values.proxy.service.enabled | toString) "true" }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "vault.fullname" . }}-proxy
+  namespace: {{ include "vault.namespace" . }}
+  labels:
+    helm.sh/chart: {{ include "vault.chart" . }}
+    app.kubernetes.io/name: {{ include "vault.name" . }}-proxy
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+  {{ template "proxy.service.annotations" . }}
+spec:
+  type: {{ .Values.proxy.service.type }}
+{{- template "service.externalTrafficPolicy" .Values.proxy.service }}
+  ports:
+    - name: proxy
+      port: {{ .Values.proxy.service.port }}
+      targetPort: {{ .Values.proxy.service.targetPort }}
+      {{- if and (.Values.proxy.service.nodePort) (eq (.Values.proxy.service.type | toString) "NodePort") }}
+      nodePort: {{ .Values.proxy.service.nodePort }}
+      {{- end }}
+  selector:
+    app.kubernetes.io/name: {{ include "vault.name" . }}-proxy
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    component: proxy
+{{- end }}
+{{- end }}

--- a/templates/proxy-serviceaccount.yaml
+++ b/templates/proxy-serviceaccount.yaml
@@ -1,0 +1,24 @@
+{{/*
+Copyright IBM Corp. 2018, 2025
+SPDX-License-Identifier: MPL-2.0
+*/}}
+
+{{- template "vault.proxyEnabled" . -}}
+{{- if .proxyEnabled -}}
+{{- if .Values.proxy.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ template "proxy.serviceAccount.name" . }}
+  namespace: {{ include "vault.namespace" . }}
+  labels:
+    helm.sh/chart: {{ include "vault.chart" . }}
+    app.kubernetes.io/name: {{ include "vault.name" . }}-proxy
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    {{- if  .Values.proxy.serviceAccount.extraLabels -}}
+      {{- toYaml .Values.proxy.serviceAccount.extraLabels | nindent 4 -}}
+    {{- end -}}
+  {{ template "proxy.serviceAccount.annotations" . }}
+{{- end }}
+{{- end }}

--- a/test/acceptance/proxy-ingress.bats
+++ b/test/acceptance/proxy-ingress.bats
@@ -1,0 +1,115 @@
+#!/usr/bin/env bats
+#
+# Acceptance tests for templates/proxy-ingress.yaml
+#
+# Tests install the chart on a k8s cluster and assert the Ingress object is
+# created with the correct spec. No ingress controller is required: the API
+# server admits an Ingress with no matching IngressClass, so these tests
+# verify that what the chart renders survives real API server validation,
+# which helm template alone cannot show.
+
+load _helpers
+
+# ---- helpers ----------------------------------------------------------------
+
+ingress_field() {
+  kubectl get ingress "$(name_prefix)-proxy" --output json | jq -r "$1"
+}
+
+install_with_ingress() {
+  kubectl delete namespace acceptance --ignore-not-found=true
+  kubectl create namespace acceptance
+  kubectl config set-context --current --namespace=acceptance
+
+  eval "${PRE_CHART_CMDS}"
+  helm install "$(name_prefix)" . ${SET_CHART_VALUES} \
+    --set='server.dev.enabled=true' \
+    --set='injector.enabled=false' \
+    --set='proxy.enabled=true' \
+    --set='proxy.ingress.enabled=true' \
+    "$@"
+}
+
+# ---- tests ------------------------------------------------------------------
+
+@test "proxy/ingress: Ingress resource is created in the correct namespace" {
+  cd `chart_dir`
+
+  install_with_ingress
+
+  local namespace=$(ingress_field '.metadata.namespace')
+  [ "${namespace}" == "acceptance" ]
+}
+
+@test "proxy/ingress: backend points at the proxy service and port" {
+  cd `chart_dir`
+
+  install_with_ingress \
+    --set 'proxy.ingress.hosts[0].host=proxy.example.com' \
+    --set 'proxy.ingress.hosts[0].paths[0]=/v1'
+
+  local host=$(ingress_field '.spec.rules[0].host')
+  [ "${host}" == "proxy.example.com" ]
+
+  local path=$(ingress_field '.spec.rules[0].http.paths[0].path')
+  [ "${path}" == "/v1" ]
+
+  local backend=$(ingress_field '.spec.rules[0].http.paths[0].backend.service.name')
+  [ "${backend}" == "$(name_prefix)-proxy" ]
+
+  local port=$(ingress_field '.spec.rules[0].http.paths[0].backend.service.port.number')
+  [ "${port}" == "8100" ]
+
+  # The backend must resolve to a Service that actually exists, otherwise the
+  # Ingress is admitted but can never route
+  local service=$(kubectl get service "$(name_prefix)-proxy" --output json | jq -r '.metadata.name')
+  [ "${service}" == "$(name_prefix)-proxy" ]
+}
+
+@test "proxy/ingress: ingressClassName and tls are set on the Ingress" {
+  cd `chart_dir`
+
+  install_with_ingress \
+    --set 'proxy.ingress.ingressClassName=nginx' \
+    --set 'proxy.ingress.hosts[0].host=proxy.example.com' \
+    --set 'proxy.ingress.tls[0].secretName=proxy-tls' \
+    --set 'proxy.ingress.tls[0].hosts[0]=proxy.example.com'
+
+  local class=$(ingress_field '.spec.ingressClassName')
+  [ "${class}" == "nginx" ]
+
+  local secret=$(ingress_field '.spec.tls[0].secretName')
+  [ "${secret}" == "proxy-tls" ]
+
+  local tlsHost=$(ingress_field '.spec.tls[0].hosts[0]')
+  [ "${tlsHost}" == "proxy.example.com" ]
+}
+
+@test "proxy/ingress: Ingress is not created when the proxy is enabled but the ingress is not" {
+  cd `chart_dir`
+
+  kubectl delete namespace acceptance --ignore-not-found=true
+  kubectl create namespace acceptance
+  kubectl config set-context --current --namespace=acceptance
+
+  eval "${PRE_CHART_CMDS}"
+  helm install "$(name_prefix)" . ${SET_CHART_VALUES} \
+    --set='server.dev.enabled=true' \
+    --set='injector.enabled=false' \
+    --set='proxy.enabled=true'
+
+  local count=$(kubectl get ingress --output json | jq '.items | length')
+  [ "${count}" == "0" ]
+}
+
+# ---- teardown ---------------------------------------------------------------
+
+teardown() {
+  if [[ ${CLEANUP:-true} == "true" ]]; then
+    echo "proxy/ingress teardown"
+    helm delete "$(name_prefix)" --ignore-not-found
+    kubectl delete --all pvc
+    kubectl delete namespace acceptance --ignore-not-found=true
+    kubectl config unset contexts."$(kubectl config current-context)".namespace
+  fi
+}

--- a/test/acceptance/proxy.bats
+++ b/test/acceptance/proxy.bats
@@ -1,0 +1,173 @@
+#!/usr/bin/env bats
+
+load _helpers
+
+@test "proxy: testing deployment" {
+  cd "$(chart_dir)"
+  kubectl delete namespace acceptance --ignore-not-found=true
+  kubectl create namespace acceptance
+  kubectl config set-context --current --namespace=acceptance
+
+  echo "Using chart vars: ${SET_CHART_VALUES}"
+
+  eval "${PRE_CHART_CMDS}"
+  # The injector is not needed here; leaving it enabled also breaks the
+  # helm upgrade below, because the injector patches the mutating webhook's
+  # caBundle at runtime and server-side apply refuses to upgrade over the
+  # resulting field-ownership conflict.
+  helm install "$(name_prefix)" . \
+    --set='server.dev.enabled=true' \
+    --set='injector.enabled=false' \
+    --set='proxy.enabled=true' \
+    --set='proxy.logLevel=debug' \
+    ${SET_CHART_VALUES}
+  check_vault_versions "$(name_prefix)"
+  wait_for_running "$(name_prefix)-0"
+  wait_for_ready "$(kubectl get pod -l component=proxy -o jsonpath='{.items[0].metadata.name}')"
+
+  # Replicas
+  local replicas=$(kubectl get deployment "$(name_prefix)-proxy" --output json |
+    jq -r '.spec.replicas')
+  [ "${replicas}" == "1" ]
+
+  # Probes default to TCP socket checks on the listener port: an HTTP probe
+  # would forward to Vault, so a Vault outage would restart the proxy and
+  # destroy its cache, the one thing still serving requests during an outage
+  local liveness=$(kubectl get deployment "$(name_prefix)-proxy" --output json |
+    jq -r '.spec.template.spec.containers[0].livenessProbe.tcpSocket.port')
+  [ "${liveness}" == "8100" ]
+
+  local readiness=$(kubectl get deployment "$(name_prefix)-proxy" --output json |
+    jq -r '.spec.template.spec.containers[0].readinessProbe.tcpSocket.port')
+  [ "${readiness}" == "8100" ]
+
+  # Config checksum pod annotation
+  local checksum=$(kubectl get deployment "$(name_prefix)-proxy" --output json |
+    jq -r '.spec.template.metadata.annotations["vault.hashicorp.com/config-checksum"]')
+  [ "${checksum}" != "null" ]
+
+  # Service
+  local service=$(kubectl get service "$(name_prefix)-proxy" --output json |
+    jq -r '.spec.type')
+  [ "${service}" == "ClusterIP" ]
+
+  local port=$(kubectl get service "$(name_prefix)-proxy" --output json |
+    jq -r '.spec.ports[0].port')
+  [ "${port}" == "8100" ]
+
+  # Provision a test user, policy and secret on the dev server
+  kubectl exec "$(name_prefix)-0" -- sh -c '
+    export VAULT_TOKEN=root VAULT_ADDR=http://127.0.0.1:8200
+    vault auth enable userpass
+    echo "path \"secret/data/*\" { capabilities = [\"read\"] }" | vault policy write proxy-acceptance -
+    vault write auth/userpass/users/proxy-acceptance password=testpassword policies=proxy-acceptance'
+
+  # Pass-through: write and read a KV secret through the proxy service
+  kubectl exec "$(name_prefix)-0" -- sh -c "
+    export VAULT_TOKEN=root VAULT_ADDR=http://$(name_prefix)-proxy:8100
+    vault kv put secret/proxy-acceptance message=proxy-pass-through"
+
+  local passthrough=$(kubectl exec "$(name_prefix)-0" -- sh -c "
+    export VAULT_TOKEN=root VAULT_ADDR=http://$(name_prefix)-proxy:8100
+    vault kv get -field=message secret/proxy-acceptance")
+  [ "${passthrough}" == "proxy-pass-through" ]
+
+  # Caching: identical login requests are served from the cache, so the
+  # second login must return the same token rather than a new one. The cache
+  # index includes the client token, so both requests must come from the same
+  # client: vault-0's CLI silently attaches the dev root token from
+  # ~/.vault-token.
+  local token1=$(kubectl exec "$(name_prefix)-0" -- sh -c "
+    VAULT_ADDR=http://$(name_prefix)-proxy:8100 vault write -field=token auth/userpass/login/proxy-acceptance password=testpassword")
+  local token2=$(kubectl exec "$(name_prefix)-0" -- sh -c "
+    VAULT_ADDR=http://$(name_prefix)-proxy:8100 vault write -field=token auth/userpass/login/proxy-acceptance password=testpassword")
+  [ -n "${token1}" ]
+  [ "${token1}" == "${token2}" ]
+
+  kubectl logs deployment/"$(name_prefix)-proxy" | grep -q "returning cached dynamic secret response"
+
+  # Auto-auth: configure the Kubernetes auth method with a role bound to the
+  # proxy's service account. The chart's ClusterRoleBinding already grants the
+  # server's service account the TokenReview permission this requires.
+  kubectl exec "$(name_prefix)-0" -- sh -c "
+    export VAULT_TOKEN=root VAULT_ADDR=http://127.0.0.1:8200
+    vault auth enable kubernetes
+    vault write auth/kubernetes/config kubernetes_host=https://kubernetes.default.svc
+    vault write auth/kubernetes/role/vault-proxy \
+      bound_service_account_names=$(name_prefix)-proxy \
+      bound_service_account_namespaces=acceptance \
+      policies=proxy-acceptance ttl=10m"
+
+  # Switch proxy.config to the auto_auth/api_proxy example shipped in
+  # values.yaml. This must roll the deployment via the config-checksum
+  # pod annotation.
+  local checksum_before=$(kubectl get deployment "$(name_prefix)-proxy" --output json |
+    jq -r '.spec.template.metadata.annotations["vault.hashicorp.com/config-checksum"]')
+
+  cat <<'EOF' > "${BATS_TEST_TMPDIR}/proxy-auto-auth-values.yaml"
+proxy:
+  config: |
+    vault {
+      address = "{{ include "proxy.vaultAddress" . }}"
+      retry {
+        num_retries = 5
+      }
+    }
+
+    listener "tcp" {
+      address = "[::]:8100"
+      tls_disable = true
+    }
+
+    auto_auth {
+      method "kubernetes" {
+        mount_path = "auth/kubernetes"
+        config = {
+          role = "vault-proxy"
+        }
+      }
+    }
+
+    api_proxy {
+      use_auto_auth_token = true
+    }
+
+    cache {
+    }
+EOF
+  helm upgrade "$(name_prefix)" . --reuse-values \
+    -f "${BATS_TEST_TMPDIR}/proxy-auto-auth-values.yaml"
+  kubectl rollout status deployment "$(name_prefix)-proxy" --timeout=2m
+
+  local checksum_after=$(kubectl get deployment "$(name_prefix)-proxy" --output json |
+    jq -r '.spec.template.metadata.annotations["vault.hashicorp.com/config-checksum"]')
+  [ "${checksum_after}" != "null" ]
+  [ "${checksum_before}" != "${checksum_after}" ]
+
+  # A tokenless request through the proxy succeeds: the proxy attaches its
+  # auto-auth token on behalf of the client. Retry briefly to allow the fresh
+  # pod's auth handler to complete its first login.
+  local tokenless=""
+  for _ in $(seq 15); do
+    tokenless=$(kubectl exec "$(name_prefix)-0" -- \
+      wget -qO- "http://$(name_prefix)-proxy:8100/v1/secret/data/proxy-acceptance" 2>/dev/null |
+      jq -r '.data.data.message')
+    if [ "${tokenless}" == "proxy-pass-through" ]; then
+      break
+    fi
+    sleep 2
+  done
+  [ "${tokenless}" == "proxy-pass-through" ]
+}
+
+# Clean up
+teardown() {
+  if [[ ${CLEANUP:-true} == "true" ]]
+  then
+      echo "helm/pvc teardown"
+      helm delete vault
+      kubectl delete --all pvc
+      kubectl delete namespace acceptance --ignore-not-found=true
+      kubectl config unset contexts."$(kubectl config current-context)".namespace
+  fi
+}

--- a/test/unit/proxy-configmap.bats
+++ b/test/unit/proxy-configmap.bats
@@ -1,0 +1,116 @@
+#!/usr/bin/env bats
+
+load _helpers
+
+@test "proxy/ConfigMap: disabled by default" {
+  cd `chart_dir`
+  local actual=$( (helm template \
+      --show-only templates/proxy-configmap.yaml \
+      . || echo "---") | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+}
+
+@test "proxy/ConfigMap: enabled with proxy.enabled=true" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/proxy-configmap.yaml \
+      --set 'proxy.enabled=true' \
+      . | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}
+
+@test "proxy/ConfigMap: disabled with global.enabled=false and proxy.enabled=-" {
+  cd `chart_dir`
+  local actual=$( (helm template \
+      --show-only templates/proxy-configmap.yaml \
+      --set 'global.enabled=false' \
+      --set 'proxy.enabled=-' \
+      . || echo "---") | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+}
+
+@test "proxy/ConfigMap: enabled with global.enabled=false and proxy.enabled=true" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/proxy-configmap.yaml \
+      --set 'global.enabled=false' \
+      --set 'proxy.enabled=true' \
+      . | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}
+
+@test "proxy/ConfigMap: default vault address is the internal service" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/proxy-configmap.yaml \
+      --set 'proxy.enabled=true' \
+      . | tee /dev/stderr |
+      yq -r '.data["config.hcl"]' | tee /dev/stderr)
+  echo "${actual}" | grep 'address = "http://release-name-vault.default.svc:8200"'
+}
+
+@test "proxy/ConfigMap: vault address respects global.tlsDisable=false" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/proxy-configmap.yaml \
+      --set 'proxy.enabled=true' \
+      --set 'global.tlsDisable=false' \
+      . | tee /dev/stderr |
+      yq -r '.data["config.hcl"]' | tee /dev/stderr)
+  echo "${actual}" | grep 'address = "https://release-name-vault.default.svc:8200"'
+}
+
+@test "proxy/ConfigMap: vault address uses global.externalVaultAddr" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/proxy-configmap.yaml \
+      --set 'proxy.enabled=true' \
+      --set 'global.externalVaultAddr=https://vault.example.com:8200' \
+      . | tee /dev/stderr |
+      yq -r '.data["config.hcl"]' | tee /dev/stderr)
+  echo "${actual}" | grep 'address = "https://vault.example.com:8200"'
+}
+
+@test "proxy/ConfigMap: default config includes listener and cache stanzas" {
+  cd `chart_dir`
+  local output=$(helm template \
+      --show-only templates/proxy-configmap.yaml \
+      --set 'proxy.enabled=true' \
+      . | tee /dev/stderr |
+      yq -r '.data["config.hcl"]' | tee /dev/stderr)
+  echo "${output}" | grep 'listener "tcp"'
+  echo "${output}" | grep 'address = "\[::\]:8100"'
+  echo "${output}" | grep 'cache {'
+}
+
+@test "proxy/ConfigMap: custom config is templated" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/proxy-configmap.yaml \
+      --set 'proxy.enabled=true' \
+      --set 'proxy.config=# ns {{ .Release.Namespace }}' \
+      . | tee /dev/stderr |
+      yq -r '.data["config.hcl"]' | tee /dev/stderr)
+  [ "${actual}" = "# ns default" ]
+}
+
+@test "proxy/ConfigMap: namespace" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/proxy-configmap.yaml \
+      --set 'proxy.enabled=true' \
+      . | tee /dev/stderr |
+      yq -r '.metadata.namespace' | tee /dev/stderr)
+  [ "${actual}" = "default" ]
+  local actual=$(helm template \
+      --show-only templates/proxy-configmap.yaml \
+      --set 'proxy.enabled=true' \
+      --set 'global.namespace=bar' \
+      . | tee /dev/stderr |
+      yq -r '.metadata.namespace' | tee /dev/stderr)
+  [ "${actual}" = "bar" ]
+}

--- a/test/unit/proxy-deployment.bats
+++ b/test/unit/proxy-deployment.bats
@@ -1,0 +1,595 @@
+#!/usr/bin/env bats
+
+load _helpers
+
+#--------------------------------------------------------------------
+# disable / enable proxy deployment
+
+@test "proxy/deployment: disabled by default" {
+  cd `chart_dir`
+  local actual=$( (helm template \
+      --show-only templates/proxy-deployment.yaml \
+      . || echo "---") | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+}
+
+@test "proxy/deployment: enable with proxy.enabled=true" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/proxy-deployment.yaml \
+      --set 'proxy.enabled=true' \
+      . | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}
+
+@test "proxy/deployment: enable with global.enabled false and proxy.enabled true" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/proxy-deployment.yaml \
+      --set 'global.enabled=false' \
+      --set 'proxy.enabled=true' \
+      . | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}
+
+@test "proxy/deployment: enable with proxy.enabled dash and global.enabled true" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/proxy-deployment.yaml \
+      --set 'proxy.enabled=-' \
+      --set 'global.enabled=true' \
+      . | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}
+
+@test "proxy/deployment: disable with proxy.enabled dash and global.enabled false" {
+  cd `chart_dir`
+  local actual=$( (helm template \
+      --show-only templates/proxy-deployment.yaml \
+      --set 'proxy.enabled=-' \
+      --set 'global.enabled=false' \
+      . || echo "---") | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+}
+
+#--------------------------------------------------------------------
+# metadata
+
+@test "proxy/deployment: namespace" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/proxy-deployment.yaml \
+      --set 'proxy.enabled=true' \
+      . | tee /dev/stderr |
+      yq -r '.metadata.namespace' | tee /dev/stderr)
+  [ "${actual}" = "default" ]
+  local actual=$(helm template \
+      --show-only templates/proxy-deployment.yaml \
+      --set 'proxy.enabled=true' \
+      --set 'global.namespace=bar' \
+      . | tee /dev/stderr |
+      yq -r '.metadata.namespace' | tee /dev/stderr)
+  [ "${actual}" = "bar" ]
+}
+
+@test "proxy/deployment: selector labels" {
+  cd `chart_dir`
+  local output=$(helm template \
+      --show-only templates/proxy-deployment.yaml \
+      --set 'proxy.enabled=true' \
+      . | tee /dev/stderr)
+  [ "$(echo "$output" | yq -r '.spec.selector.matchLabels["app.kubernetes.io/name"]')" = "vault-proxy" ]
+  [ "$(echo "$output" | yq -r '.spec.selector.matchLabels.component')" = "proxy" ]
+  [ "$(echo "$output" | yq -r '.spec.template.metadata.labels.component')" = "proxy" ]
+}
+
+@test "proxy/deployment: specify extraLabels" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/proxy-deployment.yaml \
+      --set 'proxy.enabled=true' \
+      --set 'proxy.extraLabels.foo=bar' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.metadata.labels.foo' | tee /dev/stderr)
+  [ "${actual}" = "bar" ]
+}
+
+#--------------------------------------------------------------------
+# annotations
+
+@test "proxy/deployment: config checksum annotation is set by default" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/proxy-deployment.yaml \
+      --set 'proxy.enabled=true' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.metadata.annotations["vault.hashicorp.com/config-checksum"]' | tee /dev/stderr)
+  [ "${actual}" != "null" ]
+}
+
+@test "proxy/deployment: config checksum annotation changes with the config" {
+  cd `chart_dir`
+  local default=$(helm template \
+      --show-only templates/proxy-deployment.yaml \
+      --set 'proxy.enabled=true' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.metadata.annotations["vault.hashicorp.com/config-checksum"]' | tee /dev/stderr)
+  local custom=$(helm template \
+      --show-only templates/proxy-deployment.yaml \
+      --set 'proxy.enabled=true' \
+      --set 'proxy.config=cache {}' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.metadata.annotations["vault.hashicorp.com/config-checksum"]' | tee /dev/stderr)
+  [ "${default}" != "${custom}" ]
+}
+
+@test "proxy/deployment: specify annotations yaml" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/proxy-deployment.yaml \
+      --set 'proxy.enabled=true' \
+      --set 'proxy.annotations.foo=bar' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.metadata.annotations.foo' | tee /dev/stderr)
+  [ "${actual}" = "bar" ]
+}
+
+@test "proxy/deployment: specify annotations string" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/proxy-deployment.yaml \
+      --set 'proxy.enabled=true' \
+      --set 'proxy.annotations=foo: bar' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.metadata.annotations.foo' | tee /dev/stderr)
+  [ "${actual}" = "bar" ]
+}
+
+#--------------------------------------------------------------------
+# image, replicas, command
+
+@test "proxy/deployment: default image" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/proxy-deployment.yaml \
+      --set 'proxy.enabled=true' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.containers[0].image' | tee /dev/stderr)
+  [ "${actual}" = "hashicorp/vault:2.0.3" ]
+}
+
+@test "proxy/deployment: specify image and pullPolicy" {
+  cd `chart_dir`
+  local output=$(helm template \
+      --show-only templates/proxy-deployment.yaml \
+      --set 'proxy.enabled=true' \
+      --set 'proxy.image.repository=foo' \
+      --set 'proxy.image.tag=1.2.3' \
+      --set 'proxy.image.pullPolicy=Always' \
+      . | tee /dev/stderr)
+  [ "$(echo "$output" | yq -r '.spec.template.spec.containers[0].image')" = "foo:1.2.3" ]
+  [ "$(echo "$output" | yq -r '.spec.template.spec.containers[0].imagePullPolicy')" = "Always" ]
+}
+
+@test "proxy/deployment: default replicas" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/proxy-deployment.yaml \
+      --set 'proxy.enabled=true' \
+      . | tee /dev/stderr |
+      yq -r '.spec.replicas' | tee /dev/stderr)
+  [ "${actual}" = "1" ]
+}
+
+@test "proxy/deployment: specify replicas" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/proxy-deployment.yaml \
+      --set 'proxy.enabled=true' \
+      --set 'proxy.replicas=3' \
+      . | tee /dev/stderr |
+      yq -r '.spec.replicas' | tee /dev/stderr)
+  [ "${actual}" = "3" ]
+}
+
+@test "proxy/deployment: runs vault proxy with the mounted config" {
+  cd `chart_dir`
+  local output=$(helm template \
+      --show-only templates/proxy-deployment.yaml \
+      --set 'proxy.enabled=true' \
+      . | tee /dev/stderr)
+  [ "$(echo "$output" | yq -r '.spec.template.spec.containers[0].command[0]')" = "vault" ]
+  [ "$(echo "$output" | yq -r '.spec.template.spec.containers[0].args[0]')" = "proxy" ]
+  [ "$(echo "$output" | yq -r '.spec.template.spec.containers[0].args[1]')" = "-config=/etc/vault/config.hcl" ]
+}
+
+@test "proxy/deployment: specify extraArgs" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/proxy-deployment.yaml \
+      --set 'proxy.enabled=true' \
+      --set 'proxy.extraArgs[0]=-log-file=/tmp/proxy.log' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.containers[0].args[2]' | tee /dev/stderr)
+  [ "${actual}" = "-log-file=/tmp/proxy.log" ]
+}
+
+#--------------------------------------------------------------------
+# environment
+
+@test "proxy/deployment: default log level and format" {
+  cd `chart_dir`
+  local output=$(helm template \
+      --show-only templates/proxy-deployment.yaml \
+      --set 'proxy.enabled=true' \
+      . | tee /dev/stderr)
+  [ "$(echo "$output" | yq -r '.spec.template.spec.containers[0].env[] | select(.name == "VAULT_LOG_LEVEL") | .value')" = "info" ]
+  [ "$(echo "$output" | yq -r '.spec.template.spec.containers[0].env[] | select(.name == "VAULT_LOG_FORMAT") | .value')" = "standard" ]
+}
+
+@test "proxy/deployment: specify log level and format" {
+  cd `chart_dir`
+  local output=$(helm template \
+      --show-only templates/proxy-deployment.yaml \
+      --set 'proxy.enabled=true' \
+      --set 'proxy.logLevel=debug' \
+      --set 'proxy.logFormat=json' \
+      . | tee /dev/stderr)
+  [ "$(echo "$output" | yq -r '.spec.template.spec.containers[0].env[] | select(.name == "VAULT_LOG_LEVEL") | .value')" = "debug" ]
+  [ "$(echo "$output" | yq -r '.spec.template.spec.containers[0].env[] | select(.name == "VAULT_LOG_FORMAT") | .value')" = "json" ]
+}
+
+@test "proxy/deployment: specify extraEnvironmentVars" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/proxy-deployment.yaml \
+      --set 'proxy.enabled=true' \
+      --set 'proxy.extraEnvironmentVars.VAULT_CACERT=/vault/tls/ca.crt' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.containers[0].env[] | select(.name == "VAULT_CACERT") | .value' | tee /dev/stderr)
+  [ "${actual}" = "/vault/tls/ca.crt" ]
+}
+
+@test "proxy/deployment: specify extraSecretEnvironmentVars" {
+  cd `chart_dir`
+  local output=$(helm template \
+      --show-only templates/proxy-deployment.yaml \
+      --set 'proxy.enabled=true' \
+      --set 'proxy.extraSecretEnvironmentVars[0].envName=AWS_SECRET_ACCESS_KEY' \
+      --set 'proxy.extraSecretEnvironmentVars[0].secretName=vault' \
+      --set 'proxy.extraSecretEnvironmentVars[0].secretKey=AWS_SECRET_ACCESS_KEY' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.containers[0].env[] | select(.name == "AWS_SECRET_ACCESS_KEY")' | tee /dev/stderr)
+  [ "$(echo "$output" | yq -r '.valueFrom.secretKeyRef.name')" = "vault" ]
+  [ "$(echo "$output" | yq -r '.valueFrom.secretKeyRef.key')" = "AWS_SECRET_ACCESS_KEY" ]
+}
+
+#--------------------------------------------------------------------
+# resources
+
+@test "proxy/deployment: default resources" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/proxy-deployment.yaml \
+      --set 'proxy.enabled=true' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.containers[0].resources' | tee /dev/stderr)
+  [ "${actual}" = "null" ]
+}
+
+@test "proxy/deployment: specify resources" {
+  cd `chart_dir`
+  local output=$(helm template \
+      --show-only templates/proxy-deployment.yaml \
+      --set 'proxy.enabled=true' \
+      --set 'proxy.resources.requests.memory=256Mi' \
+      --set 'proxy.resources.limits.memory=512Mi' \
+      . | tee /dev/stderr)
+  [ "$(echo "$output" | yq -r '.spec.template.spec.containers[0].resources.requests.memory')" = "256Mi" ]
+  [ "$(echo "$output" | yq -r '.spec.template.spec.containers[0].resources.limits.memory')" = "512Mi" ]
+}
+
+#--------------------------------------------------------------------
+# securityContext
+
+@test "proxy/deployment: default pod securityContext" {
+  cd `chart_dir`
+  local output=$(helm template \
+      --show-only templates/proxy-deployment.yaml \
+      --set 'proxy.enabled=true' \
+      . | tee /dev/stderr)
+  [ "$(echo "$output" | yq -r '.spec.template.spec.securityContext.runAsNonRoot')" = "true" ]
+  [ "$(echo "$output" | yq -r '.spec.template.spec.securityContext.runAsUser')" = "100" ]
+  [ "$(echo "$output" | yq -r '.spec.template.spec.securityContext.fsGroup')" = "1000" ]
+}
+
+@test "proxy/deployment: default container securityContext" {
+  cd `chart_dir`
+  local output=$(helm template \
+      --show-only templates/proxy-deployment.yaml \
+      --set 'proxy.enabled=true' \
+      . | tee /dev/stderr)
+  [ "$(echo "$output" | yq -r '.spec.template.spec.containers[0].securityContext.allowPrivilegeEscalation')" = "false" ]
+  [ "$(echo "$output" | yq -r '.spec.template.spec.containers[0].securityContext.capabilities.drop[0]')" = "ALL" ]
+}
+
+@test "proxy/deployment: no default securityContext on OpenShift" {
+  cd `chart_dir`
+  local output=$(helm template \
+      --show-only templates/proxy-deployment.yaml \
+      --set 'proxy.enabled=true' \
+      --set 'global.openshift=true' \
+      . | tee /dev/stderr)
+  [ "$(echo "$output" | yq -r '.spec.template.spec.securityContext')" = "null" ]
+  [ "$(echo "$output" | yq -r '.spec.template.spec.containers[0].securityContext')" = "null" ]
+}
+
+@test "proxy/deployment: specify pod securityContext yaml" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/proxy-deployment.yaml \
+      --set 'proxy.enabled=true' \
+      --set 'proxy.securityContext.pod.runAsUser=200' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.securityContext.runAsUser' | tee /dev/stderr)
+  [ "${actual}" = "200" ]
+}
+
+@test "proxy/deployment: specify container securityContext yaml" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/proxy-deployment.yaml \
+      --set 'proxy.enabled=true' \
+      --set 'proxy.securityContext.container.readOnlyRootFilesystem=true' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.containers[0].securityContext.readOnlyRootFilesystem' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}
+
+#--------------------------------------------------------------------
+# scheduling
+
+@test "proxy/deployment: no affinity by default" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/proxy-deployment.yaml \
+      --set 'proxy.enabled=true' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.affinity' | tee /dev/stderr)
+  [ "${actual}" = "null" ]
+}
+
+@test "proxy/deployment: specify affinity string" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/proxy-deployment.yaml \
+      --set 'proxy.enabled=true' \
+      --set 'proxy.affinity=nodeAffinity: {{ .Release.Name }}' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.affinity.nodeAffinity' | tee /dev/stderr)
+  [ "${actual}" = "release-name" ]
+}
+
+@test "proxy/deployment: specify tolerations" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/proxy-deployment.yaml \
+      --set 'proxy.enabled=true' \
+      --set 'proxy.tolerations[0].key=dedicated' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.tolerations[0].key' | tee /dev/stderr)
+  [ "${actual}" = "dedicated" ]
+}
+
+@test "proxy/deployment: specify nodeSelector" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/proxy-deployment.yaml \
+      --set 'proxy.enabled=true' \
+      --set 'proxy.nodeSelector.disktype=ssd' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.nodeSelector.disktype' | tee /dev/stderr)
+  [ "${actual}" = "ssd" ]
+}
+
+@test "proxy/deployment: specify topologySpreadConstraints" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/proxy-deployment.yaml \
+      --set 'proxy.enabled=true' \
+      --set 'proxy.topologySpreadConstraints[0].maxSkew=1' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.topologySpreadConstraints[0].maxSkew' | tee /dev/stderr)
+  [ "${actual}" = "1" ]
+}
+
+@test "proxy/deployment: specify priorityClassName" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/proxy-deployment.yaml \
+      --set 'proxy.enabled=true' \
+      --set 'proxy.priorityClassName=high-priority' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.priorityClassName' | tee /dev/stderr)
+  [ "${actual}" = "high-priority" ]
+}
+
+@test "proxy/deployment: specify strategy" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/proxy-deployment.yaml \
+      --set 'proxy.enabled=true' \
+      --set 'proxy.strategy.type=Recreate' \
+      . | tee /dev/stderr |
+      yq -r '.spec.strategy.type' | tee /dev/stderr)
+  [ "${actual}" = "Recreate" ]
+}
+
+#--------------------------------------------------------------------
+# probes and ports
+
+@test "proxy/deployment: default probes are tcp checks on the proxy port" {
+  cd `chart_dir`
+  local output=$(helm template \
+      --show-only templates/proxy-deployment.yaml \
+      --set 'proxy.enabled=true' \
+      . | tee /dev/stderr)
+  [ "$(echo "$output" | yq -r '.spec.template.spec.containers[0].livenessProbe.tcpSocket.port')" = "8100" ]
+  [ "$(echo "$output" | yq -r '.spec.template.spec.containers[0].readinessProbe.tcpSocket.port')" = "8100" ]
+}
+
+@test "proxy/deployment: probe with path uses httpGet on the listener" {
+  cd `chart_dir`
+  local output=$(helm template \
+      --show-only templates/proxy-deployment.yaml \
+      --set 'proxy.enabled=true' \
+      --set 'proxy.readinessProbe.path=/v1/sys/health?standbyok=true&perfstandbyok=true' \
+      . | tee /dev/stderr)
+  [ "$(echo "$output" | yq -r '.spec.template.spec.containers[0].readinessProbe.httpGet.path')" = "/v1/sys/health?standbyok=true&perfstandbyok=true" ]
+  [ "$(echo "$output" | yq -r '.spec.template.spec.containers[0].readinessProbe.httpGet.port')" = "8100" ]
+  [ "$(echo "$output" | yq -r '.spec.template.spec.containers[0].readinessProbe.httpGet.scheme')" = "HTTP" ]
+  [ "$(echo "$output" | yq -r '.spec.template.spec.containers[0].readinessProbe.tcpSocket')" = "null" ]
+  [ "$(echo "$output" | yq -r '.spec.template.spec.containers[0].livenessProbe.tcpSocket.port')" = "8100" ]
+}
+
+@test "proxy/deployment: probe scheme follows proxy.tlsDisable" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/proxy-deployment.yaml \
+      --set 'proxy.enabled=true' \
+      --set 'proxy.tlsDisable=false' \
+      --set 'proxy.livenessProbe.path=/v1/sys/health' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.containers[0].livenessProbe.httpGet.scheme' | tee /dev/stderr)
+  [ "${actual}" = "HTTPS" ]
+}
+
+@test "proxy/deployment: specify probe settings" {
+  cd `chart_dir`
+  local output=$(helm template \
+      --show-only templates/proxy-deployment.yaml \
+      --set 'proxy.enabled=true' \
+      --set 'proxy.livenessProbe.failureThreshold=10' \
+      --set 'proxy.readinessProbe.periodSeconds=30' \
+      . | tee /dev/stderr)
+  [ "$(echo "$output" | yq -r '.spec.template.spec.containers[0].livenessProbe.failureThreshold')" = "10" ]
+  [ "$(echo "$output" | yq -r '.spec.template.spec.containers[0].readinessProbe.periodSeconds')" = "30" ]
+}
+
+@test "proxy/deployment: specify port" {
+  cd `chart_dir`
+  local output=$(helm template \
+      --show-only templates/proxy-deployment.yaml \
+      --set 'proxy.enabled=true' \
+      --set 'proxy.port=8300' \
+      . | tee /dev/stderr)
+  [ "$(echo "$output" | yq -r '.spec.template.spec.containers[0].ports[0].containerPort')" = "8300" ]
+  [ "$(echo "$output" | yq -r '.spec.template.spec.containers[0].livenessProbe.tcpSocket.port')" = "8300" ]
+  [ "$(echo "$output" | yq -r '.spec.template.spec.containers[0].readinessProbe.tcpSocket.port')" = "8300" ]
+}
+
+@test "proxy/deployment: probe ports can target a different listener" {
+  cd `chart_dir`
+  local output=$(helm template \
+      --show-only templates/proxy-deployment.yaml \
+      --set 'proxy.enabled=true' \
+      --set 'proxy.livenessProbe.port=8101' \
+      --set 'proxy.readinessProbe.path=/v1/sys/health?standbyok=true&perfstandbyok=true' \
+      --set 'proxy.readinessProbe.port=8102' \
+      . | tee /dev/stderr)
+  [ "$(echo "$output" | yq -r '.spec.template.spec.containers[0].livenessProbe.tcpSocket.port')" = "8101" ]
+  [ "$(echo "$output" | yq -r '.spec.template.spec.containers[0].readinessProbe.httpGet.port')" = "8102" ]
+  [ "$(echo "$output" | yq -r '.spec.template.spec.containers[0].ports[0].containerPort')" = "8100" ]
+}
+
+#--------------------------------------------------------------------
+# volumes
+
+@test "proxy/deployment: config is mounted from the ConfigMap" {
+  cd `chart_dir`
+  local output=$(helm template \
+      --show-only templates/proxy-deployment.yaml \
+      --set 'proxy.enabled=true' \
+      . | tee /dev/stderr)
+  [ "$(echo "$output" | yq -r '.spec.template.spec.volumes[0].configMap.name')" = "release-name-vault-proxy-config" ]
+  [ "$(echo "$output" | yq -r '.spec.template.spec.containers[0].volumeMounts[0].mountPath')" = "/etc/vault/config.hcl" ]
+  [ "$(echo "$output" | yq -r '.spec.template.spec.containers[0].volumeMounts[0].readOnly')" = "true" ]
+}
+
+@test "proxy/deployment: proxy.volumes adds volume" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/proxy-deployment.yaml \
+      --set 'proxy.enabled=true' \
+      --set 'proxy.volumes[0].name=plugins' \
+      --set 'proxy.volumes[0].emptyDir=' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.volumes[] | select(.name == "plugins") | .name' | tee /dev/stderr)
+  [ "${actual}" = "plugins" ]
+}
+
+@test "proxy/deployment: proxy.volumeMounts adds volume mount" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/proxy-deployment.yaml \
+      --set 'proxy.enabled=true' \
+      --set 'proxy.volumeMounts[0].name=plugins' \
+      --set 'proxy.volumeMounts[0].mountPath=/usr/local/libexec/vault' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.containers[0].volumeMounts[] | select(.name == "plugins") | .mountPath' | tee /dev/stderr)
+  [ "${actual}" = "/usr/local/libexec/vault" ]
+}
+
+#--------------------------------------------------------------------
+# serviceAccount
+
+@test "proxy/deployment: default serviceAccountName" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/proxy-deployment.yaml \
+      --set 'proxy.enabled=true' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.serviceAccountName' | tee /dev/stderr)
+  [ "${actual}" = "release-name-vault-proxy" ]
+}
+
+@test "proxy/deployment: specify serviceAccount name" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/proxy-deployment.yaml \
+      --set 'proxy.enabled=true' \
+      --set 'proxy.serviceAccount.name=custom-proxy-sa' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.serviceAccountName' | tee /dev/stderr)
+  [ "${actual}" = "custom-proxy-sa" ]
+}
+
+@test "proxy/deployment: serviceAccountName is default when create is false" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/proxy-deployment.yaml \
+      --set 'proxy.enabled=true' \
+      --set 'proxy.serviceAccount.create=false' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.serviceAccountName' | tee /dev/stderr)
+  [ "${actual}" = "default" ]
+}
+
+#--------------------------------------------------------------------
+# imagePullSecrets
+
+@test "proxy/deployment: specify global.imagePullSecrets" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/proxy-deployment.yaml \
+      --set 'proxy.enabled=true' \
+      --set 'global.imagePullSecrets[0].name=my-secret' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.imagePullSecrets[0].name' | tee /dev/stderr)
+  [ "${actual}" = "my-secret" ]
+}

--- a/test/unit/proxy-deployment.bats
+++ b/test/unit/proxy-deployment.bats
@@ -153,14 +153,18 @@ load _helpers
 #--------------------------------------------------------------------
 # image, replicas, command
 
-@test "proxy/deployment: default image" {
+@test "proxy/deployment: default image is proxy.image.repository:tag" {
   cd `chart_dir`
+  # Read the expected image from values.yaml rather than pinning a version, so
+  # this does not need updating every time the default Vault image is bumped
+  local expected=$(yq -r '.proxy.image | .repository + ":" + .tag' values.yaml | tee /dev/stderr)
+
   local actual=$(helm template \
       --show-only templates/proxy-deployment.yaml \
       --set 'proxy.enabled=true' \
       . | tee /dev/stderr |
       yq -r '.spec.template.spec.containers[0].image' | tee /dev/stderr)
-  [ "${actual}" = "hashicorp/vault:2.0.3" ]
+  [ "${actual}" = "${expected}" ]
 }
 
 @test "proxy/deployment: specify image and pullPolicy" {

--- a/test/unit/proxy-disruptionbudget.bats
+++ b/test/unit/proxy-disruptionbudget.bats
@@ -1,0 +1,56 @@
+#!/usr/bin/env bats
+
+load _helpers
+
+@test "proxy/DisruptionBudget: absent by default" {
+  cd `chart_dir`
+  local actual=$( (helm template \
+      --show-only templates/proxy-disruptionbudget.yaml \
+      --set 'proxy.enabled=true' \
+      . || echo "---") | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+}
+
+@test "proxy/DisruptionBudget: absent when proxy is disabled" {
+  cd `chart_dir`
+  local actual=$( (helm template \
+      --show-only templates/proxy-disruptionbudget.yaml \
+      --set 'proxy.podDisruptionBudget.maxUnavailable=1' \
+      . || echo "---") | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+}
+
+@test "proxy/DisruptionBudget: enabled with podDisruptionBudget set" {
+  cd `chart_dir`
+  local output=$(helm template \
+      --show-only templates/proxy-disruptionbudget.yaml \
+      --set 'proxy.enabled=true' \
+      --set 'proxy.podDisruptionBudget.maxUnavailable=1' \
+      . | tee /dev/stderr)
+  [ "$(echo "$output" | yq -r '.kind')" = "PodDisruptionBudget" ]
+  [ "$(echo "$output" | yq -r '.spec.maxUnavailable')" = "1" ]
+}
+
+@test "proxy/DisruptionBudget: passes through arbitrary spec fields" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/proxy-disruptionbudget.yaml \
+      --set 'proxy.enabled=true' \
+      --set 'proxy.podDisruptionBudget.minAvailable=1' \
+      . | tee /dev/stderr |
+      yq -r '.spec.minAvailable' | tee /dev/stderr)
+  [ "${actual}" = "1" ]
+}
+
+@test "proxy/DisruptionBudget: selector targets the proxy pods" {
+  cd `chart_dir`
+  local output=$(helm template \
+      --show-only templates/proxy-disruptionbudget.yaml \
+      --set 'proxy.enabled=true' \
+      --set 'proxy.podDisruptionBudget.maxUnavailable=1' \
+      . | tee /dev/stderr)
+  [ "$(echo "$output" | yq -r '.spec.selector.matchLabels["app.kubernetes.io/name"]')" = "vault-proxy" ]
+  [ "$(echo "$output" | yq -r '.spec.selector.matchLabels.component')" = "proxy" ]
+}

--- a/test/unit/proxy-external-service.bats
+++ b/test/unit/proxy-external-service.bats
@@ -1,0 +1,184 @@
+#!/usr/bin/env bats
+
+load _helpers
+
+@test "proxy/ExternalService: disabled by default" {
+  cd `chart_dir`
+  local actual=$( (helm template \
+      --show-only templates/proxy-external-service.yaml \
+      . || echo "---") | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+}
+
+@test "proxy/ExternalService: disabled when proxy.enabled=true but externalService.enabled=false" {
+  cd `chart_dir`
+  local actual=$( (helm template \
+      --show-only templates/proxy-external-service.yaml \
+      --set 'proxy.enabled=true' \
+      . || echo "---") | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+}
+
+@test "proxy/ExternalService: enabled with proxy.enabled and externalService.enabled" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/proxy-external-service.yaml \
+      --set 'proxy.enabled=true' \
+      --set 'proxy.service.externalService.enabled=true' \
+      . | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}
+
+@test "proxy/ExternalService: default type is LoadBalancer" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/proxy-external-service.yaml \
+      --set 'proxy.enabled=true' \
+      --set 'proxy.service.externalService.enabled=true' \
+      . | tee /dev/stderr |
+      yq -r '.spec.type' | tee /dev/stderr)
+  [ "${actual}" = "LoadBalancer" ]
+}
+
+@test "proxy/ExternalService: default port and targetPort" {
+  cd `chart_dir`
+  local output=$(helm template \
+      --show-only templates/proxy-external-service.yaml \
+      --set 'proxy.enabled=true' \
+      --set 'proxy.service.externalService.enabled=true' \
+      . | tee /dev/stderr)
+  [ "$(echo "$output" | yq -r '.spec.ports[0].port')" = "8100" ]
+  [ "$(echo "$output" | yq -r '.spec.ports[0].targetPort')" = "8100" ]
+  [ "$(echo "$output" | yq -r '.spec.ports[0].name')" = "proxy" ]
+}
+
+@test "proxy/ExternalService: custom port and targetPort" {
+  cd `chart_dir`
+  local output=$(helm template \
+      --show-only templates/proxy-external-service.yaml \
+      --set 'proxy.enabled=true' \
+      --set 'proxy.service.externalService.enabled=true' \
+      --set 'proxy.service.externalService.port=8200' \
+      --set 'proxy.service.externalService.targetPort=8200' \
+      . | tee /dev/stderr)
+  [ "$(echo "$output" | yq -r '.spec.ports[0].port')" = "8200" ]
+  [ "$(echo "$output" | yq -r '.spec.ports[0].targetPort')" = "8200" ]
+}
+
+@test "proxy/ExternalService: service name is <release>-proxy-external" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/proxy-external-service.yaml \
+      --set 'proxy.enabled=true' \
+      --set 'proxy.service.externalService.enabled=true' \
+      . | tee /dev/stderr |
+      yq -r '.metadata.name' | tee /dev/stderr)
+  [ "${actual}" = "release-name-vault-proxy-external" ]
+}
+
+@test "proxy/ExternalService: selector targets the proxy pods" {
+  cd `chart_dir`
+  local output=$(helm template \
+      --show-only templates/proxy-external-service.yaml \
+      --set 'proxy.enabled=true' \
+      --set 'proxy.service.externalService.enabled=true' \
+      . | tee /dev/stderr)
+  [ "$(echo "$output" | yq -r '.spec.selector["app.kubernetes.io/name"]')" = "vault-proxy" ]
+  [ "$(echo "$output" | yq -r '.spec.selector.component')" = "proxy" ]
+}
+
+@test "proxy/ExternalService: default externalTrafficPolicy is Local" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/proxy-external-service.yaml \
+      --set 'proxy.enabled=true' \
+      --set 'proxy.service.externalService.enabled=true' \
+      . | tee /dev/stderr |
+      yq -r '.spec.externalTrafficPolicy' | tee /dev/stderr)
+  [ "${actual}" = "Local" ]
+}
+
+@test "proxy/ExternalService: externalTrafficPolicy Cluster" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/proxy-external-service.yaml \
+      --set 'proxy.enabled=true' \
+      --set 'proxy.service.externalService.enabled=true' \
+      --set 'proxy.service.externalService.externalTrafficPolicy=Cluster' \
+      . | tee /dev/stderr |
+      yq -r '.spec.externalTrafficPolicy' | tee /dev/stderr)
+  [ "${actual}" = "Cluster" ]
+}
+
+@test "proxy/ExternalService: no externalTrafficPolicy for ClusterIP" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/proxy-external-service.yaml \
+      --set 'proxy.enabled=true' \
+      --set 'proxy.service.externalService.enabled=true' \
+      --set 'proxy.service.externalService.type=ClusterIP' \
+      . | tee /dev/stderr |
+      yq -r '.spec.externalTrafficPolicy' | tee /dev/stderr)
+  [ "${actual}" = "null" ]
+}
+
+@test "proxy/ExternalService: loadBalancerSourceRanges" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/proxy-external-service.yaml \
+      --set 'proxy.enabled=true' \
+      --set 'proxy.service.externalService.enabled=true' \
+      --set 'proxy.service.externalService.loadBalancerSourceRanges={10.0.0.0/8,192.168.0.0/16}' \
+      . | tee /dev/stderr |
+      yq -r '.spec.loadBalancerSourceRanges | length' | tee /dev/stderr)
+  [ "${actual}" = "2" ]
+}
+
+@test "proxy/ExternalService: no loadBalancerSourceRanges by default" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/proxy-external-service.yaml \
+      --set 'proxy.enabled=true' \
+      --set 'proxy.service.externalService.enabled=true' \
+      . | tee /dev/stderr |
+      yq -r '.spec.loadBalancerSourceRanges' | tee /dev/stderr)
+  [ "${actual}" = "null" ]
+}
+
+@test "proxy/ExternalService: no annotations by default" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/proxy-external-service.yaml \
+      --set 'proxy.enabled=true' \
+      --set 'proxy.service.externalService.enabled=true' \
+      . | tee /dev/stderr |
+      yq -r '.metadata.annotations' | tee /dev/stderr)
+  [ "${actual}" = "null" ]
+}
+
+@test "proxy/ExternalService: specify annotations yaml" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/proxy-external-service.yaml \
+      --set 'proxy.enabled=true' \
+      --set 'proxy.service.externalService.enabled=true' \
+      --set 'proxy.service.externalService.annotations.foo=bar' \
+      . | tee /dev/stderr |
+      yq -r '.metadata.annotations.foo' | tee /dev/stderr)
+  [ "${actual}" = "bar" ]
+}
+
+@test "proxy/ExternalService: specify annotations string" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/proxy-external-service.yaml \
+      --set 'proxy.enabled=true' \
+      --set 'proxy.service.externalService.enabled=true' \
+      --set 'proxy.service.externalService.annotations=foo: bar' \
+      . | tee /dev/stderr |
+      yq -r '.metadata.annotations.foo' | tee /dev/stderr)
+  [ "${actual}" = "bar" ]
+}

--- a/test/unit/proxy-ingress.bats
+++ b/test/unit/proxy-ingress.bats
@@ -1,0 +1,340 @@
+#!/usr/bin/env bats
+
+load _helpers
+
+@test "proxy/Ingress: disabled by default" {
+  cd `chart_dir`
+  local actual=$( (helm template \
+      --show-only templates/proxy-ingress.yaml \
+      . || echo "---") | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+}
+
+@test "proxy/Ingress: disabled when proxy.enabled=true but ingress.enabled=false" {
+  cd `chart_dir`
+  local actual=$( (helm template \
+      --show-only templates/proxy-ingress.yaml \
+      --set 'proxy.enabled=true' \
+      . || echo "---") | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+}
+
+@test "proxy/Ingress: disabled when ingress.enabled=true but proxy.enabled=false" {
+  cd `chart_dir`
+  local actual=$( (helm template \
+      --show-only templates/proxy-ingress.yaml \
+      --set 'proxy.ingress.enabled=true' \
+      . || echo "---") | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+}
+
+@test "proxy/Ingress: enabled with proxy.enabled and ingress.enabled" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/proxy-ingress.yaml \
+      --set 'proxy.enabled=true' \
+      --set 'proxy.ingress.enabled=true' \
+      . | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}
+
+@test "proxy/Ingress: disabled when the proxy Service is disabled" {
+  cd `chart_dir`
+  local actual=$( (helm template \
+      --show-only templates/proxy-ingress.yaml \
+      --set 'proxy.enabled=true' \
+      --set 'proxy.ingress.enabled=true' \
+      --set 'proxy.service.enabled=false' \
+      . || echo "---") | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+}
+
+@test "proxy/Ingress: not governed by global.enabled" {
+  cd `chart_dir`
+  local actual=$( (helm template \
+      --show-only templates/proxy-ingress.yaml \
+      --set 'global.enabled=true' \
+      --set 'proxy.ingress.enabled=true' \
+      . || echo "---") | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+}
+
+@test "proxy/Ingress: name is <release>-proxy" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/proxy-ingress.yaml \
+      --set 'proxy.enabled=true' \
+      --set 'proxy.ingress.enabled=true' \
+      . | tee /dev/stderr |
+      yq -r '.metadata.name' | tee /dev/stderr)
+  [ "${actual}" = "release-name-vault-proxy" ]
+}
+
+@test "proxy/Ingress: namespace" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/proxy-ingress.yaml \
+      --set 'proxy.enabled=true' \
+      --set 'proxy.ingress.enabled=true' \
+      --namespace foo \
+      . | tee /dev/stderr |
+      yq -r '.metadata.namespace' | tee /dev/stderr)
+  [ "${actual}" = "foo" ]
+
+  local actual=$(helm template \
+      --show-only templates/proxy-ingress.yaml \
+      --set 'proxy.enabled=true' \
+      --set 'proxy.ingress.enabled=true' \
+      --set 'global.namespace=bar' \
+      --namespace foo \
+      . | tee /dev/stderr |
+      yq -r '.metadata.namespace' | tee /dev/stderr)
+  [ "${actual}" = "bar" ]
+}
+
+@test "proxy/Ingress: backend is the proxy Service on proxy.service.port" {
+  cd `chart_dir`
+  local output=$(helm template \
+      --show-only templates/proxy-ingress.yaml \
+      --set 'proxy.enabled=true' \
+      --set 'proxy.ingress.enabled=true' \
+      . | tee /dev/stderr)
+
+  local actual=$(echo "$output" |
+      yq -r '.spec.rules[0].http.paths[0].backend.service.name' | tee /dev/stderr)
+  [ "${actual}" = "release-name-vault-proxy" ]
+
+  local actual=$(echo "$output" |
+      yq -r '.spec.rules[0].http.paths[0].backend.service.port.number' | tee /dev/stderr)
+  [ "${actual}" = "8100" ]
+}
+
+@test "proxy/Ingress: backend port follows proxy.service.port" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/proxy-ingress.yaml \
+      --set 'proxy.enabled=true' \
+      --set 'proxy.ingress.enabled=true' \
+      --set 'proxy.service.port=9100' \
+      . | tee /dev/stderr |
+      yq -r '.spec.rules[0].http.paths[0].backend.service.port.number' | tee /dev/stderr)
+  [ "${actual}" = "9100" ]
+}
+
+@test "proxy/Ingress: host entry gets added and path defaults to /" {
+  cd `chart_dir`
+  local output=$(helm template \
+      --show-only templates/proxy-ingress.yaml \
+      --set 'proxy.enabled=true' \
+      --set 'proxy.ingress.enabled=true' \
+      --set 'proxy.ingress.hosts[0].host=proxy.example.com' \
+      . | tee /dev/stderr)
+
+  local actual=$(echo "$output" |
+      yq -r '.spec.rules[0].host' | tee /dev/stderr)
+  [ "${actual}" = "proxy.example.com" ]
+
+  local actual=$(echo "$output" |
+      yq -r '.spec.rules[0].http.paths[0].path' | tee /dev/stderr)
+  [ "${actual}" = "/" ]
+}
+
+@test "proxy/Ingress: multiple hosts and paths" {
+  cd `chart_dir`
+  local output=$(helm template \
+      --show-only templates/proxy-ingress.yaml \
+      --set 'proxy.enabled=true' \
+      --set 'proxy.ingress.enabled=true' \
+      --set 'proxy.ingress.hosts[0].host=proxy.example.com' \
+      --set 'proxy.ingress.hosts[0].paths[0]=/v1' \
+      --set 'proxy.ingress.hosts[1].host=proxy2.example.com' \
+      --set 'proxy.ingress.hosts[1].paths[0]=/v1/secret' \
+      . | tee /dev/stderr)
+
+  local actual=$(echo "$output" |
+      yq -r '.spec.rules | length' | tee /dev/stderr)
+  [ "${actual}" = "2" ]
+
+  local actual=$(echo "$output" |
+      yq -r '.spec.rules[0].http.paths[0].path' | tee /dev/stderr)
+  [ "${actual}" = "/v1" ]
+
+  local actual=$(echo "$output" |
+      yq -r '.spec.rules[1].host' | tee /dev/stderr)
+  [ "${actual}" = "proxy2.example.com" ]
+
+  local actual=$(echo "$output" |
+      yq -r '.spec.rules[1].http.paths[0].path' | tee /dev/stderr)
+  [ "${actual}" = "/v1/secret" ]
+}
+
+@test "proxy/Ingress: extra paths prepend host configuration" {
+  cd `chart_dir`
+  local output=$(helm template \
+      --show-only templates/proxy-ingress.yaml \
+      --set 'proxy.enabled=true' \
+      --set 'proxy.ingress.enabled=true' \
+      --set 'proxy.ingress.hosts[0].host=proxy.example.com' \
+      --set 'proxy.ingress.hosts[0].paths[0]=/' \
+      --set 'proxy.ingress.extraPaths[0].path=/annotation-service' \
+      --set 'proxy.ingress.extraPaths[0].backend.service.name=ssl-redirect' \
+      . | tee /dev/stderr)
+
+  local actual=$(echo "$output" |
+      yq -r '.spec.rules[0].http.paths[0].backend.service.name' | tee /dev/stderr)
+  [ "${actual}" = "ssl-redirect" ]
+
+  local actual=$(echo "$output" |
+      yq -r '.spec.rules[0].http.paths[0].path' | tee /dev/stderr)
+  [ "${actual}" = "/annotation-service" ]
+
+  local actual=$(echo "$output" |
+      yq -r '.spec.rules[0].http.paths[1].path' | tee /dev/stderr)
+  [ "${actual}" = "/" ]
+}
+
+@test "proxy/Ingress: default pathType is Prefix" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/proxy-ingress.yaml \
+      --set 'proxy.enabled=true' \
+      --set 'proxy.ingress.enabled=true' \
+      . | tee /dev/stderr |
+      yq -r '.spec.rules[0].http.paths[0].pathType' | tee /dev/stderr)
+  [ "${actual}" = "Prefix" ]
+}
+
+@test "proxy/Ingress: custom pathType" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/proxy-ingress.yaml \
+      --set 'proxy.enabled=true' \
+      --set 'proxy.ingress.enabled=true' \
+      --set 'proxy.ingress.pathType=ImplementationSpecific' \
+      . | tee /dev/stderr |
+      yq -r '.spec.rules[0].http.paths[0].pathType' | tee /dev/stderr)
+  [ "${actual}" = "ImplementationSpecific" ]
+}
+
+@test "proxy/Ingress: no ingressClassName by default" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/proxy-ingress.yaml \
+      --set 'proxy.enabled=true' \
+      --set 'proxy.ingress.enabled=true' \
+      . | tee /dev/stderr |
+      yq -r '.spec.ingressClassName' | tee /dev/stderr)
+  [ "${actual}" = "null" ]
+}
+
+@test "proxy/Ingress: ingressClassName added to spec" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/proxy-ingress.yaml \
+      --set 'proxy.enabled=true' \
+      --set 'proxy.ingress.enabled=true' \
+      --set 'proxy.ingress.ingressClassName=nginx' \
+      . | tee /dev/stderr |
+      yq -r '.spec.ingressClassName' | tee /dev/stderr)
+  [ "${actual}" = "nginx" ]
+}
+
+@test "proxy/Ingress: no tls by default" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/proxy-ingress.yaml \
+      --set 'proxy.enabled=true' \
+      --set 'proxy.ingress.enabled=true' \
+      . | tee /dev/stderr |
+      yq -r '.spec.tls' | tee /dev/stderr)
+  [ "${actual}" = "null" ]
+}
+
+@test "proxy/Ingress: tls added to spec" {
+  cd `chart_dir`
+  local output=$(helm template \
+      --show-only templates/proxy-ingress.yaml \
+      --set 'proxy.enabled=true' \
+      --set 'proxy.ingress.enabled=true' \
+      --set 'proxy.ingress.tls[0].secretName=proxy-tls' \
+      --set 'proxy.ingress.tls[0].hosts[0]=proxy.example.com' \
+      . | tee /dev/stderr)
+
+  local actual=$(echo "$output" |
+      yq -r '.spec.tls[0].secretName' | tee /dev/stderr)
+  [ "${actual}" = "proxy-tls" ]
+
+  local actual=$(echo "$output" |
+      yq -r '.spec.tls[0].hosts[0]' | tee /dev/stderr)
+  [ "${actual}" = "proxy.example.com" ]
+}
+
+@test "proxy/Ingress: default labels" {
+  cd `chart_dir`
+  local output=$(helm template \
+      --show-only templates/proxy-ingress.yaml \
+      --set 'proxy.enabled=true' \
+      --set 'proxy.ingress.enabled=true' \
+      . | tee /dev/stderr)
+
+  local actual=$(echo "$output" |
+      yq -r '.metadata.labels["app.kubernetes.io/name"]' | tee /dev/stderr)
+  [ "${actual}" = "vault-proxy" ]
+
+  local actual=$(echo "$output" |
+      yq -r '.metadata.labels["app.kubernetes.io/instance"]' | tee /dev/stderr)
+  [ "${actual}" = "release-name" ]
+}
+
+@test "proxy/Ingress: extra labels get added" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/proxy-ingress.yaml \
+      --set 'proxy.enabled=true' \
+      --set 'proxy.ingress.enabled=true' \
+      --set 'proxy.ingress.labels.traffic=external' \
+      . | tee /dev/stderr |
+      yq -r '.metadata.labels.traffic' | tee /dev/stderr)
+  [ "${actual}" = "external" ]
+}
+
+@test "proxy/Ingress: no annotations by default" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/proxy-ingress.yaml \
+      --set 'proxy.enabled=true' \
+      --set 'proxy.ingress.enabled=true' \
+      . | tee /dev/stderr |
+      yq -r '.metadata.annotations' | tee /dev/stderr)
+  [ "${actual}" = "null" ]
+}
+
+@test "proxy/Ingress: specify annotations yaml" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/proxy-ingress.yaml \
+      --set 'proxy.enabled=true' \
+      --set 'proxy.ingress.enabled=true' \
+      --set 'proxy.ingress.annotations.foo=bar' \
+      . | tee /dev/stderr |
+      yq -r '.metadata.annotations.foo' | tee /dev/stderr)
+  [ "${actual}" = "bar" ]
+}
+
+@test "proxy/Ingress: specify annotations string" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/proxy-ingress.yaml \
+      --set 'proxy.enabled=true' \
+      --set 'proxy.ingress.enabled=true' \
+      --set 'proxy.ingress.annotations=foo: bar' \
+      . | tee /dev/stderr |
+      yq -r '.metadata.annotations.foo' | tee /dev/stderr)
+  [ "${actual}" = "bar" ]
+}

--- a/test/unit/proxy-service.bats
+++ b/test/unit/proxy-service.bats
@@ -1,0 +1,147 @@
+#!/usr/bin/env bats
+
+load _helpers
+
+@test "proxy/Service: disabled by default" {
+  cd `chart_dir`
+  local actual=$( (helm template \
+      --show-only templates/proxy-service.yaml \
+      . || echo "---") | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+}
+
+@test "proxy/Service: enabled with proxy.enabled=true" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/proxy-service.yaml \
+      --set 'proxy.enabled=true' \
+      . | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}
+
+@test "proxy/Service: disable with proxy.service.enabled false" {
+  cd `chart_dir`
+  local actual=$( (helm template \
+      --show-only templates/proxy-service.yaml \
+      --set 'proxy.enabled=true' \
+      --set 'proxy.service.enabled=false' \
+      . || echo "---") | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+}
+
+@test "proxy/Service: default type and ports" {
+  cd `chart_dir`
+  local output=$(helm template \
+      --show-only templates/proxy-service.yaml \
+      --set 'proxy.enabled=true' \
+      . | tee /dev/stderr)
+  [ "$(echo "$output" | yq -r '.spec.type')" = "ClusterIP" ]
+  [ "$(echo "$output" | yq -r '.spec.ports[0].port')" = "8100" ]
+  [ "$(echo "$output" | yq -r '.spec.ports[0].targetPort')" = "8100" ]
+  [ "$(echo "$output" | yq -r '.spec.ports[0].name')" = "proxy" ]
+}
+
+@test "proxy/Service: custom type and ports" {
+  cd `chart_dir`
+  local output=$(helm template \
+      --show-only templates/proxy-service.yaml \
+      --set 'proxy.enabled=true' \
+      --set 'proxy.service.type=NodePort' \
+      --set 'proxy.service.port=8300' \
+      --set 'proxy.service.targetPort=8300' \
+      . | tee /dev/stderr)
+  [ "$(echo "$output" | yq -r '.spec.type')" = "NodePort" ]
+  [ "$(echo "$output" | yq -r '.spec.ports[0].port')" = "8300" ]
+  [ "$(echo "$output" | yq -r '.spec.ports[0].targetPort')" = "8300" ]
+}
+
+@test "proxy/Service: no externalTrafficPolicy for ClusterIP" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/proxy-service.yaml \
+      --set 'proxy.enabled=true' \
+      --set 'proxy.service.externalTrafficPolicy=Local' \
+      . | tee /dev/stderr |
+      yq -r '.spec.externalTrafficPolicy' | tee /dev/stderr)
+  [ "${actual}" = "null" ]
+}
+
+@test "proxy/Service: specify externalTrafficPolicy with LoadBalancer" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/proxy-service.yaml \
+      --set 'proxy.enabled=true' \
+      --set 'proxy.service.type=LoadBalancer' \
+      --set 'proxy.service.externalTrafficPolicy=Local' \
+      . | tee /dev/stderr |
+      yq -r '.spec.externalTrafficPolicy' | tee /dev/stderr)
+  [ "${actual}" = "Local" ]
+}
+
+@test "proxy/Service: specify nodePort with NodePort type" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/proxy-service.yaml \
+      --set 'proxy.enabled=true' \
+      --set 'proxy.service.type=NodePort' \
+      --set 'proxy.service.nodePort=30100' \
+      . | tee /dev/stderr |
+      yq -r '.spec.ports[0].nodePort' | tee /dev/stderr)
+  [ "${actual}" = "30100" ]
+}
+
+@test "proxy/Service: nodePort ignored for ClusterIP" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/proxy-service.yaml \
+      --set 'proxy.enabled=true' \
+      --set 'proxy.service.nodePort=30100' \
+      . | tee /dev/stderr |
+      yq -r '.spec.ports[0].nodePort' | tee /dev/stderr)
+  [ "${actual}" = "null" ]
+}
+
+@test "proxy/Service: selector targets the proxy pods" {
+  cd `chart_dir`
+  local output=$(helm template \
+      --show-only templates/proxy-service.yaml \
+      --set 'proxy.enabled=true' \
+      . | tee /dev/stderr)
+  [ "$(echo "$output" | yq -r '.spec.selector["app.kubernetes.io/name"]')" = "vault-proxy" ]
+  [ "$(echo "$output" | yq -r '.spec.selector.component')" = "proxy" ]
+}
+
+@test "proxy/Service: no annotations by default" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/proxy-service.yaml \
+      --set 'proxy.enabled=true' \
+      . | tee /dev/stderr |
+      yq -r '.metadata.annotations' | tee /dev/stderr)
+  [ "${actual}" = "null" ]
+}
+
+@test "proxy/Service: specify annotations yaml" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/proxy-service.yaml \
+      --set 'proxy.enabled=true' \
+      --set 'proxy.service.annotations.foo=bar' \
+      . | tee /dev/stderr |
+      yq -r '.metadata.annotations.foo' | tee /dev/stderr)
+  [ "${actual}" = "bar" ]
+}
+
+@test "proxy/Service: specify annotations string" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/proxy-service.yaml \
+      --set 'proxy.enabled=true' \
+      --set 'proxy.service.annotations=foo: bar' \
+      . | tee /dev/stderr |
+      yq -r '.metadata.annotations.foo' | tee /dev/stderr)
+  [ "${actual}" = "bar" ]
+}

--- a/test/unit/proxy-serviceaccount.bats
+++ b/test/unit/proxy-serviceaccount.bats
@@ -1,0 +1,87 @@
+#!/usr/bin/env bats
+
+load _helpers
+
+@test "proxy/ServiceAccount: disabled by default" {
+  cd `chart_dir`
+  local actual=$( (helm template \
+      --show-only templates/proxy-serviceaccount.yaml \
+      . || echo "---") | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+}
+
+@test "proxy/ServiceAccount: enabled with proxy.enabled=true" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/proxy-serviceaccount.yaml \
+      --set 'proxy.enabled=true' \
+      . | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}
+
+@test "proxy/ServiceAccount: disable with serviceAccount.create false" {
+  cd `chart_dir`
+  local actual=$( (helm template \
+      --show-only templates/proxy-serviceaccount.yaml \
+      --set 'proxy.enabled=true' \
+      --set 'proxy.serviceAccount.create=false' \
+      . || echo "---") | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+}
+
+@test "proxy/ServiceAccount: default name" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/proxy-serviceaccount.yaml \
+      --set 'proxy.enabled=true' \
+      . | tee /dev/stderr |
+      yq -r '.metadata.name' | tee /dev/stderr)
+  [ "${actual}" = "release-name-vault-proxy" ]
+}
+
+@test "proxy/ServiceAccount: specify name" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/proxy-serviceaccount.yaml \
+      --set 'proxy.enabled=true' \
+      --set 'proxy.serviceAccount.name=custom-proxy-sa' \
+      . | tee /dev/stderr |
+      yq -r '.metadata.name' | tee /dev/stderr)
+  [ "${actual}" = "custom-proxy-sa" ]
+}
+
+@test "proxy/ServiceAccount: specify annotations yaml" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/proxy-serviceaccount.yaml \
+      --set 'proxy.enabled=true' \
+      --set 'proxy.serviceAccount.annotations.foo=bar' \
+      . | tee /dev/stderr |
+      yq -r '.metadata.annotations.foo' | tee /dev/stderr)
+  [ "${actual}" = "bar" ]
+}
+
+@test "proxy/ServiceAccount: specify annotations string" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/proxy-serviceaccount.yaml \
+      --set 'proxy.enabled=true' \
+      --set 'proxy.serviceAccount.annotations=foo: bar' \
+      . | tee /dev/stderr |
+      yq -r '.metadata.annotations.foo' | tee /dev/stderr)
+  [ "${actual}" = "bar" ]
+}
+
+@test "proxy/ServiceAccount: specify extraLabels" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/proxy-serviceaccount.yaml \
+      --set 'proxy.enabled=true' \
+      --set 'proxy.serviceAccount.extraLabels.foo=bar' \
+      . | tee /dev/stderr |
+      yq -r '.metadata.labels.foo' | tee /dev/stderr)
+  [ "${actual}" = "bar" ]
+}

--- a/values.openshift.yaml
+++ b/values.openshift.yaml
@@ -23,6 +23,11 @@ server:
   readinessProbe:
     path: "/v1/sys/health?uninitcode=204"
 
+proxy:
+  image:
+    repository: "registry.connect.redhat.com/hashicorp/vault"
+    tag: "2.0.4-ubi"
+
 csi:
   image:
     repository: "registry.connect.redhat.com/hashicorp/vault-csi-provider"

--- a/values.schema.json
+++ b/values.schema.json
@@ -620,6 +620,268 @@
                 }
             }
         },
+        "proxy": {
+            "type": "object",
+            "properties": {
+                "affinity": {
+                    "type": [
+                        "object",
+                        "string"
+                    ]
+                },
+                "annotations": {
+                    "type": [
+                        "object",
+                        "string"
+                    ]
+                },
+                "config": {
+                    "type": "string"
+                },
+                "enabled": {
+                    "type": [
+                        "boolean",
+                        "string"
+                    ]
+                },
+                "extraArgs": {
+                    "type": "array"
+                },
+                "extraEnvironmentVars": {
+                    "type": "object"
+                },
+                "extraLabels": {
+                    "type": "object"
+                },
+                "extraSecretEnvironmentVars": {
+                    "type": "array"
+                },
+                "image": {
+                    "type": "object",
+                    "properties": {
+                        "pullPolicy": {
+                            "type": "string"
+                        },
+                        "repository": {
+                            "type": "string"
+                        },
+                        "tag": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "livenessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "failureThreshold": {
+                            "type": "integer"
+                        },
+                        "initialDelaySeconds": {
+                            "type": "integer"
+                        },
+                        "path": {
+                            "type": "string"
+                        },
+                        "periodSeconds": {
+                            "type": "integer"
+                        },
+                        "port": {
+                            "type": "integer"
+                        },
+                        "successThreshold": {
+                            "type": "integer"
+                        },
+                        "timeoutSeconds": {
+                            "type": "integer"
+                        }
+                    }
+                },
+                "logFormat": {
+                    "type": "string"
+                },
+                "logLevel": {
+                    "type": "string"
+                },
+                "nodeSelector": {
+                    "type": [
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                },
+                "podDisruptionBudget": {
+                    "type": "object"
+                },
+                "port": {
+                    "type": "integer"
+                },
+                "priorityClassName": {
+                    "type": "string"
+                },
+                "readinessProbe": {
+                    "type": "object",
+                    "properties": {
+                        "failureThreshold": {
+                            "type": "integer"
+                        },
+                        "initialDelaySeconds": {
+                            "type": "integer"
+                        },
+                        "path": {
+                            "type": "string"
+                        },
+                        "periodSeconds": {
+                            "type": "integer"
+                        },
+                        "port": {
+                            "type": "integer"
+                        },
+                        "successThreshold": {
+                            "type": "integer"
+                        },
+                        "timeoutSeconds": {
+                            "type": "integer"
+                        }
+                    }
+                },
+                "replicas": {
+                    "type": "integer"
+                },
+                "resources": {
+                    "type": "object"
+                },
+                "securityContext": {
+                    "type": "object",
+                    "properties": {
+                        "container": {
+                            "type": [
+                                "object",
+                                "string"
+                            ]
+                        },
+                        "pod": {
+                            "type": [
+                                "object",
+                                "string"
+                            ]
+                        }
+                    }
+                },
+                "service": {
+                    "type": "object",
+                    "properties": {
+                        "annotations": {
+                            "type": [
+                                "object",
+                                "string"
+                            ]
+                        },
+                        "enabled": {
+                            "type": "boolean"
+                        },
+                        "externalTrafficPolicy": {
+                            "type": "string"
+                        },
+                        "nodePort": {
+                            "type": "integer"
+                        },
+                        "port": {
+                            "type": "integer"
+                        },
+                        "targetPort": {
+                            "type": "integer"
+                        },
+                        "type": {
+                            "type": "string"
+                        },
+                        "externalService": {
+                            "type": "object",
+                            "properties": {
+                                "annotations": {
+                                    "type": [
+                                        "object",
+                                        "string"
+                                    ]
+                                },
+                                "enabled": {
+                                    "type": "boolean"
+                                },
+                                "externalTrafficPolicy": {
+                                    "type": "string"
+                                },
+                                "loadBalancerSourceRanges": {
+                                    "type": "array"
+                                },
+                                "port": {
+                                    "type": "integer"
+                                },
+                                "targetPort": {
+                                    "type": "integer"
+                                },
+                                "type": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
+                },
+                "serviceAccount": {
+                    "type": "object",
+                    "properties": {
+                        "annotations": {
+                            "type": [
+                                "object",
+                                "string"
+                            ]
+                        },
+                        "create": {
+                            "type": "boolean"
+                        },
+                        "extraLabels": {
+                            "type": "object"
+                        },
+                        "name": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "strategy": {
+                    "type": [
+                        "object",
+                        "string"
+                    ]
+                },
+                "tlsDisable": {
+                    "type": "boolean"
+                },
+                "tolerations": {
+                    "type": [
+                        "null",
+                        "array",
+                        "string"
+                    ]
+                },
+                "topologySpreadConstraints": {
+                    "type": [
+                        "null",
+                        "array",
+                        "string"
+                    ]
+                },
+                "volumeMounts": {
+                    "type": [
+                        "null",
+                        "array"
+                    ]
+                },
+                "volumes": {
+                    "type": [
+                        "null",
+                        "array"
+                    ]
+                }
+            }
+        },
         "server": {
             "type": "object",
             "properties": {

--- a/values.schema.json
+++ b/values.schema.json
@@ -670,6 +670,49 @@
                         }
                     }
                 },
+                "ingress": {
+                    "type": "object",
+                    "properties": {
+                        "annotations": {
+                            "type": [
+                                "object",
+                                "string"
+                            ]
+                        },
+                        "enabled": {
+                            "type": "boolean"
+                        },
+                        "extraPaths": {
+                            "type": "array"
+                        },
+                        "hosts": {
+                            "type": "array",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "host": {
+                                        "type": "string"
+                                    },
+                                    "paths": {
+                                        "type": "array"
+                                    }
+                                }
+                            }
+                        },
+                        "ingressClassName": {
+                            "type": "string"
+                        },
+                        "labels": {
+                            "type": "object"
+                        },
+                        "pathType": {
+                            "type": "string"
+                        },
+                        "tls": {
+                            "type": "array"
+                        }
+                    }
+                },
                 "livenessProbe": {
                     "type": "object",
                     "properties": {

--- a/values.yaml
+++ b/values.yaml
@@ -1656,6 +1656,56 @@ proxy:
       # specific load balancer annotations for AWS, GKE, Azure, or OpenStack.
       annotations: {}
 
+  # Ingress for the proxy. This is the HTTP-layer alternative to
+  # service.externalService for reaching the proxy from outside the cluster,
+  # and routes to the proxy Service above, so service.enabled must stay true.
+  #
+  # The proxy speaks the Vault API, so anything that can reach this Ingress
+  # can reach Vault through it. Terminate TLS at the ingress controller and
+  # restrict who can reach it. If the proxy configuration uses auto_auth
+  # together with api_proxy.use_auto_auth_token, every client that reaches
+  # the Ingress inherits the access of the proxy's own Vault role.
+  ingress:
+    enabled: false
+
+    # Extra labels to attach to the Ingress.
+    # This should be a YAML map of the labels to apply to the Ingress.
+    labels: {}
+      # traffic: external
+
+    # Extra annotations for the Ingress. This can either be YAML or a
+    # YAML-formatted multi-line templated string map of the annotations to
+    # apply to the Ingress.
+    annotations: {}
+      # |
+      # kubernetes.io/tls-acme: "true"
+      #   or
+      # nginx.ingress.kubernetes.io/backend-protocol: HTTP
+
+    # Optionally use ingressClassName instead of deprecated annotation.
+    # See: https://kubernetes.io/docs/concepts/services-networking/ingress/#deprecated-annotation
+    ingressClassName: ""
+
+    # As of Kubernetes 1.19, all Ingress Paths must have a pathType configured. The default value below should be sufficient in most cases.
+    # See: https://kubernetes.io/docs/concepts/services-networking/ingress/#path-types for other possible values.
+    pathType: Prefix
+
+    hosts:
+      - host: chart-example.local
+        paths: []
+    ## Extra paths to prepend to the host configuration. This is useful when working with annotation based services.
+    extraPaths: []
+    # - path: /*
+    #   backend:
+    #     service:
+    #       name: ssl-redirect
+    #       port:
+    #         number: use-annotation
+    tls: []
+    #  - secretName: chart-example-tls
+    #    hosts:
+    #      - chart-example.local
+
   serviceAccount:
     # Specifies whether a service account should be created.
     # The service account is what the proxy authenticates with when the

--- a/values.yaml
+++ b/values.yaml
@@ -1356,6 +1356,334 @@ csi:
   # for the available command line flags.
   extraArgs: []
 
+# Vault Proxy runs as a standalone Deployment that acts as a cluster-local
+# API proxy in front of a Vault server (in-cluster or external), providing
+# response caching and optional automatic authentication for its clients.
+# See https://developer.hashicorp.com/vault/docs/agent-and-proxy/proxy
+proxy:
+  # True if you want to deploy Vault Proxy. Unlike the other components, the
+  # proxy is not enabled by default via global.enabled and must be enabled
+  # explicitly.
+  enabled: false
+
+  # Number of proxy pods to run. The proxy is stateless (its cache is
+  # per-pod and in-memory), so it can be scaled horizontally; for a highly
+  # available deployment run 3 or more replicas spread across availability
+  # zones (see topologySpreadConstraints below) with a podDisruptionBudget.
+  replicas: 1
+
+  # image sets the repo and tag of the Vault image to use for the proxy.
+  # Vault Proxy is a subcommand of Vault itself, so this uses the official
+  # Vault image. Vault 1.14+ is required.
+  image:
+    repository: "hashicorp/vault"
+    tag: "2.0.4"
+    pullPolicy: IfNotPresent
+
+  # Port the proxy listens on. This must match the address of the
+  # listener "tcp" stanza in the proxy configuration below; it is used for
+  # the container port and as the default port for the liveness/readiness
+  # probes (overridable via livenessProbe.port / readinessProbe.port). The
+  # default of 8100 follows the Vault Proxy documentation convention and
+  # avoids confusion with the Vault server's 8200.
+  port: 8100
+
+  # TLS for the proxy listener. This must match the tls_disable setting of
+  # the listener "tcp" stanza in the proxy configuration below; it is used
+  # to derive the scheme for path-based health probes.
+  tlsDisable: true
+
+  # Configures the log level of the proxy. Supported log levels include:
+  # trace, debug, info, warn, and error.
+  logLevel: "info"
+
+  # Configures the log format of the proxy. Supported log formats:
+  # "standard", "json".
+  logFormat: "standard"
+
+  # Pass arbitrary additional arguments to vault proxy.
+  # See https://developer.hashicorp.com/vault/docs/agent-and-proxy/proxy#command-line-options
+  extraArgs: []
+
+  # The proxy configuration in Vault's HCL format. This is rendered as a
+  # template, so other values can be referenced from it; by default the
+  # vault address resolves to global.externalVaultAddr when set, otherwise
+  # to the chart's internal Vault service. A listener stanza is required
+  # and its address must match proxy.port above. An empty cache stanza
+  # enables caching of tokens and leased secrets that flow through the
+  # proxy. Requests that carry a client token keep that token: Vault
+  # enforces the client's own identity and policies, and responses are
+  # cached per client token. (The exception is setting use_auto_auth_token
+  # to "force" in the api_proxy stanza, which replaces even client-supplied
+  # tokens with the proxy's own.)
+  #
+  # To have the proxy authenticate on behalf of clients that send no
+  # token, add auto_auth and api_proxy stanzas as shown in the commented
+  # example; the Vault server must have the Kubernetes auth method
+  # configured with a role bound to the proxy's service account. WARNING:
+  # with use_auto_auth_token, tokenless requests — or all requests, when
+  # set to "force" — are performed with the proxy's own identity, so
+  # every client that can reach the proxy inherits the access of the
+  # proxy's Vault role. Only use this pattern
+  # when the proxy is dedicated to a single application or trust domain
+  # (for example, replicas of one workload that share the same access);
+  # keep the role's policies minimal and restrict access to the proxy
+  # Service, for example with a NetworkPolicy.
+  config: |
+    vault {
+      address = "{{ include "proxy.vaultAddress" . }}"
+    }
+
+    listener "tcp" {
+      address = "[::]:8100"
+      tls_disable = true
+    }
+
+    cache {
+    }
+  # config: |
+  #   vault {
+  #     address = "{{ include "proxy.vaultAddress" . }}"
+  #     retry {
+  #       num_retries = 5
+  #     }
+  #   }
+  #
+  #   listener "tcp" {
+  #     address = "[::]:8100"
+  #     tls_disable = true
+  #   }
+  #
+  #   auto_auth {
+  #     method "kubernetes" {
+  #       mount_path = "auth/kubernetes"
+  #       config = {
+  #         role = "vault-proxy"
+  #       }
+  #     }
+  #   }
+  #
+  #   api_proxy {
+  #     use_auto_auth_token = true
+  #   }
+  #
+  #   cache {
+  #   }
+
+  resources: {}
+  # resources:
+  #   requests:
+  #     memory: 128Mi
+  #     cpu: 100m
+  #   limits:
+  #     memory: 256Mi
+  #     cpu: 500m
+
+  # extraEnvironmentVars is a list of extra environment variables to set in
+  # the proxy deployment, for example VAULT_CACERT for a private CA or
+  # VAULT_SKIP_VERIFY for a self-signed Vault server certificate.
+  extraEnvironmentVars: {}
+    # VAULT_CACERT: /vault/tls/ca.crt
+
+  # extraSecretEnvironmentVars is a list of extra environment variables to
+  # set with the deployment. These variables take value from existing Secret
+  # objects.
+  extraSecretEnvironmentVars: []
+    # - envName: AWS_SECRET_ACCESS_KEY
+    #   secretName: vault
+    #   secretKey: AWS_SECRET_ACCESS_KEY
+
+  # volumes is a list of volumes made available to the proxy pods, for
+  # example to provide TLS certificates for the listener or the connection
+  # to the Vault server.
+  volumes: null
+  # volumes:
+  #   - name: listener-tls
+  #     secret:
+  #       secretName: vault-proxy-tls
+
+  # volumeMounts is a list of volumeMounts for the proxy container.
+  volumeMounts: null
+  # volumeMounts:
+  #   - mountPath: /vault/tls
+  #     name: listener-tls
+  #     readOnly: true
+
+  # Extra annotations to attach to the proxy pods.
+  # This can either be YAML or a YAML-formatted multi-line templated string
+  # map of the annotations to apply to the proxy pods.
+  annotations: {}
+
+  # Extra labels to attach to the proxy pods.
+  # This should be a YAML map of the labels to apply to the proxy pods.
+  extraLabels: {}
+
+  # Affinity Settings for proxy pods.
+  # This can either be a multi-line string or YAML matching the PodSpec's
+  # affinity field.
+  affinity: {}
+
+  # Topology settings for proxy pods.
+  # This can either be YAML or a YAML-formatted multi-line templated string
+  # map of the topologySpreadConstraints to apply to the proxy pods, for
+  # example to spread replicas across availability zones.
+  topologySpreadConstraints: []
+
+  # Toleration Settings for proxy pods.
+  # This should be either a multi-line string or YAML matching the
+  # Toleration array.
+  tolerations: []
+
+  # nodeSelector labels for proxy pod assignment.
+  # This should be either a multi-line string or YAML matching the
+  # nodeSelector type.
+  nodeSelector: {}
+
+  # Priority class for proxy pods.
+  priorityClassName: ""
+
+  # A disruption budget limits the number of pods of a replicated
+  # application that are down simultaneously from voluntary disruptions.
+  podDisruptionBudget: {}
+  # podDisruptionBudget:
+  #   minAvailable: 2
+
+  # strategy for updating the deployment. This can be a multi-line string
+  # or a YAML map.
+  strategy: {}
+  # strategy: |
+  #   rollingUpdate:
+  #     maxSurge: 25%
+  #     maxUnavailable: 25%
+  #   type: RollingUpdate
+
+  # Used to define custom livenessProbe settings. By default the probe is a
+  # TCP check on the listener at proxy.port: health requests through the
+  # proxy are forwarded to the Vault server, so an HTTP liveness probe would
+  # couple pod restarts to Vault availability — and restarting a proxy while
+  # Vault is unreachable also discards the cached secrets it can still
+  # serve. Set path to switch to an HTTP GET probe against the listener.
+  livenessProbe:
+    # When set, use an HTTP GET probe on this path (forwarded to the Vault
+    # server) instead of a TCP check on the listener.
+    path: ""
+    # Port to probe. Defaults to proxy.port; set this to probe a different
+    # listener defined in the proxy configuration.
+    # port: 8100
+    # When a probe fails, Kubernetes will try failureThreshold times before giving up
+    failureThreshold: 2
+    # Number of seconds after the container has started before probe initiates
+    initialDelaySeconds: 5
+    # How often (in seconds) to perform the probe
+    periodSeconds: 5
+    # Minimum consecutive successes for the probe to be considered successful after having failed
+    successThreshold: 1
+    # Number of seconds after which the probe times out.
+    timeoutSeconds: 3
+  # Used to define custom readinessProbe settings. Defaults to a TCP check
+  # on the listener at proxy.port, which keeps proxies serving cached
+  # secrets while the Vault server is unreachable. Set path to instead
+  # forward the probe to the Vault server, marking proxy pods unready when
+  # Vault is unhealthy; include standbyok=true and perfstandbyok=true so
+  # standby nodes (HTTP 429/473) are not treated as failures.
+  readinessProbe:
+    # When set, use an HTTP GET probe on this path (forwarded to the Vault
+    # server) instead of a TCP check on the listener.
+    path: ""
+    # path: "/v1/sys/health?standbyok=true&perfstandbyok=true"
+    # Port to probe. Defaults to proxy.port; set this to probe a different
+    # listener defined in the proxy configuration.
+    # port: 8100
+    # When a probe fails, Kubernetes will try failureThreshold times before giving up
+    failureThreshold: 2
+    # Number of seconds after the container has started before probe initiates
+    initialDelaySeconds: 5
+    # How often (in seconds) to perform the probe
+    periodSeconds: 5
+    # Minimum consecutive successes for the probe to be considered successful after having failed
+    successThreshold: 1
+    # Number of seconds after which the probe times out.
+    timeoutSeconds: 3
+
+  # Definition of the proxy Service.
+  service:
+    # Enables the proxy Service.
+    enabled: true
+    # Type of the Service. ClusterIP serves in-cluster clients; use
+    # LoadBalancer together with cloud-specific annotations below to expose
+    # the proxy outside the cluster.
+    type: ClusterIP
+    # Port on which the proxy Service is listening.
+    port: 8100
+    # Target port to which the Service should be mapped to. This should
+    # match proxy.port.
+    targetPort: 8100
+    # If type is set to "NodePort", a specific nodePort value can be
+    # configured, will be random if left blank.
+    # nodePort: 30100
+    # Denotes if this Service wants to route external traffic to node-local
+    # or cluster-wide endpoints. Applies to LoadBalancer and NodePort
+    # service types.
+    externalTrafficPolicy: Cluster
+    # Extra annotations for the Service definition. This can either be YAML
+    # or a YAML-formatted multi-line templated string map of the
+    # annotations to apply to the Service, for example the cloud provider
+    # specific load balancer annotations for AWS, GKE, Azure, or OpenStack.
+    annotations: {}
+
+    # Optional second Service that exposes Vault Proxy outside the cluster.
+    # Rendered as a separate resource (<fullname>-proxy-external, where fullname
+    # defaults to <release>-vault) so it can be managed independently of the
+    # cluster-internal Service above.
+    externalService:
+      # Set to true to render the external Service.
+      enabled: false
+      # Kubernetes Service type. Typically LoadBalancer for cloud NLB/ALB.
+      type: LoadBalancer
+      # Port the external Service listens on.
+      port: 8100
+      # Pod port the external Service forwards to. Should match proxy.port.
+      targetPort: 8100
+      # Restrict which source CIDRs can reach the load balancer.
+      # Applies only when type is LoadBalancer.
+      # loadBalancerSourceRanges: []
+      # Denotes if this Service wants to route external traffic to node-local
+      # or cluster-wide endpoints. Applies to LoadBalancer and NodePort types.
+      externalTrafficPolicy: Local
+      # Extra annotations for the external Service. This can either be YAML
+      # or a YAML-formatted multi-line templated string map of the
+      # annotations to apply to the Service, for example cloud provider
+      # specific load balancer annotations for AWS, GKE, Azure, or OpenStack.
+      annotations: {}
+
+  serviceAccount:
+    # Specifies whether a service account should be created.
+    # The service account is what the proxy authenticates with when the
+    # Kubernetes auto-auth method is configured, so the Vault role used in
+    # auto_auth must be bound to this service account.
+    create: true
+    # The name of the service account to use.
+    # If not set and create is true, a name is generated using the fullname
+    # template.
+    name: ""
+    # Extra annotations for the serviceAccount definition. This can either
+    # be YAML or a YAML-formatted multi-line templated string map of the
+    # annotations to apply to the serviceAccount.
+    annotations: {}
+    # Extra labels to attach to the serviceAccount.
+    # This should be a YAML map of the labels to apply to the serviceAccount.
+    extraLabels: {}
+
+  securityContext:
+    # Extra securityContext settings for the proxy pods.
+    # This can either be YAML or a YAML-formatted multi-line templated
+    # string map of the securityContext to apply to the proxy pods.
+    pod: {}
+    # Extra securityContext settings for the proxy container.
+    # This can either be YAML or a YAML-formatted multi-line templated
+    # string map of the securityContext to apply to the proxy container.
+    container: {}
+
 # Vault is able to collect and publish various runtime metrics.
 # Enabling this feature requires setting adding `telemetry{}` stanza to
 # the Vault configuration. There are a few examples included in the `config` sections above.


### PR DESCRIPTION
## Summary

Adds Vault Proxy as an optional, opt-in component of the chart: a standalone Deployment that provides a cluster-local, caching Vault API endpoint in front of an in-cluster or external Vault server.

Closes #756. Also answers #929, which was closed in 2023 as "nothing to implement (yet)" while the Vault Proxy roadmap was still forming.

## Problem

Today the chart offers two ways to put an Agent/Proxy in the request path, and both are per-pod: the Agent Injector's sidecar, and the Agent sidecar inside the CSI provider added in #749. Neither gives operators a shared, independently scalable proxy.

Running the proxy as its own Deployment instead of a sidecar means:

- **Centralised caching and renewal.** Token and lease caching and background renewal happen in one place rather than once per pod.
- **Independent scaling and lifecycle.** Scale, restart or roll the proxy without touching workloads, with topology-aware scheduling for zonal resilience.
- **One place to monitor.** Aggregate Vault traffic is visible at a single point instead of spread across every injected sidecar.
- **Outage buffering.** Clients keep reading cached responses while the Vault server is unreachable.

Vault 1.14 moved this functionality into the dedicated [`vault proxy`](https://developer.hashicorp.com/vault/docs/agent-and-proxy/proxy) subcommand and deprecated the Agent's API-proxy mode, so the component runs `vault proxy` rather than an agent in proxy mode.

## What this adds

A new `proxy.*` values section rendering a Deployment, a ConfigMap holding the `tpl`-rendered HCL config, a Service, a ServiceAccount, and an optional PodDisruptionBudget. It follows the injector's conventions throughout: `replicas`, `image`, `resources`, `affinity`, `topologySpreadConstraints`, `tolerations`, `nodeSelector`, `priorityClassName`, `strategy`, `annotations`, `extraLabels`, `extraArgs`, `extraEnvironmentVars`, `extraSecretEnvironmentVars`, `volumes`, `volumeMounts`, `securityContext.pod`/`.container`, and `serviceAccount.create`/`.name`.

A checksum of the rendered config is set as a pod annotation, so a config change rolls the pods. The Vault address resolves to `global.externalVaultAddr` when set and to the chart's own Service otherwise, and `values.openshift.yaml` gains the matching UBI image.

### Opt-in, and inert when disabled

`proxy.enabled` defaults to `false` and is deliberately **not** governed by `global.enabled`, so enabling the chart's other components never silently starts a proxy. With the proxy disabled, `helm template` output is byte-identical to current `main` (verified: 615 lines, zero diff).

### Health probes default to TCP, not HTTP

Probes default to TCP socket checks on the listener, with HTTP paths available via `proxy.livenessProbe.path` / `readinessProbe.path`.

This is deliberate. An HTTP health check forwards through to Vault, so during a Vault outage the kubelet would restart the proxy and destroy the cache that is still serving requests, turning a degraded state into a total one. We have verified cache-served responses through a full Vault outage with zero pod restarts, and that a fresh pod cold-starts cleanly while Vault is unreachable: listener up, TCP-ready, auth handler retrying with backoff, self-recovering when Vault returns.

### Optional external Service

`proxy.service.externalService.enabled` renders a second Service (`<fullname>-proxy-external`) for exposing the proxy outside the cluster. It is its own template and is independent of `proxy.service.enabled`, with its own `type`, `port`, `targetPort`, `annotations` (YAML-map or templated-string form), `externalTrafficPolicy`, `loadBalancerIP` and `loadBalancerSourceRanges`.

This required one fix to an existing helper: `service.loadBalancer` only resolved `serviceType`, so `loadBalancerIP` and `loadBalancerSourceRanges` were silently dropped for any service configured with a `type` key. It now falls back to `type`. The only other caller, `ui-service.yaml`, renders identically to before (verified).

## On the caching caveat raised in #756

@tomhjp's point on #756 is correct and we reproduced it: the lease-cache index includes the client token, so with per-pod projected service account tokens, pass-through requests essentially never get cross-pod cache hits.

This PR does not attempt to relax cache-hit matching, which would need an Agent/Proxy-side feature. It makes the two patterns that exist today deployable and documents their trade-offs:

1. **Pass-through (the shipped default).** Clients authenticate as themselves and send their own tokens, so Vault enforces each client's identity and policies exactly as it would without the proxy. Caching and renewal are per client token, so there is no cross-pod dedup. The value is per-client caching, centralised renewal and outage buffering.

2. **Shared identity** (`auto_auth` plus `api_proxy { use_auto_auth_token = true }`, shipped as a commented example in `values.yaml`). Tokenless clients ride on the proxy's own Kubernetes service account, so cross-pod cache hits work and dynamic credentials become service-account-scoped, which is the model this issue originally asked for.

   The caveat is spelled out in the values documentation: authorization collapses to the proxy's role, so this is only sound where the proxy serves a single trust domain (replicas of one workload, or one proxy per app/namespace with a minimal bound role and network-restricted access to the Service). It is not a fit for one central proxy in front of heterogeneous workloads.

For clarity on semantics: with `use_auto_auth_token = true` the proxy's token is applied only to requests that carry no token; client-supplied tokens pass through unchanged. `"force"` is the variant that overrides them.

## Backwards compatibility

Additive. `proxy.enabled` defaults to `false`, and the default rendered output is byte-identical to `main`. The single change to existing behaviour is the `service.loadBalancer` helper fix described above, which only adds fields that were previously dropped.

## Testing

Unit tests follow the repo's existing conventions and cover the ConfigMap, Deployment, Service, external Service, ServiceAccount and PodDisruptionBudget:

```
bats test/unit/proxy-configmap.bats
bats test/unit/proxy-deployment.bats
bats test/unit/proxy-disruptionbudget.bats
bats test/unit/proxy-external-service.bats
bats test/unit/proxy-service.bats
bats test/unit/proxy-serviceaccount.bats
```

`test/acceptance/proxy.bats` adds a kind-based acceptance test covering pass-through requests, cache hits, tokenless auto-auth, and config-checksum rollout. Both suites are picked up automatically, since CI runs `bats ./test/unit` and `bats ./test/acceptance` over the whole directory.

`helm lint` passes.

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [x] I have documented a clear reason for, and description of, the change I am making.

- [x] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

  The component is opt-in and disabled by default, and the default rendered output is unchanged. Reverting the pull request is sufficient.

- [x] If applicable, I've documented the impact of any changes to security controls.

  In the shipped default configuration the proxy is pass-through: clients present their own tokens and Vault enforces their identity and policies unchanged, so no authorization decision moves into the chart. The optional `auto_auth` pattern is shipped commented out and does move authorization to the proxy's own role; the values documentation states the trust-domain constraints that make it sound, and the accompanying `loadBalancerSourceRanges` support on the external Service exists so operators can restrict reachability. The proxy runs under its own ServiceAccount with a configurable `securityContext`, and the external Service is opt-in and disabled by default.
