### PR TITLE
server: allow setting unhealthyPodEvictionPolicy on the disruption budget

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Unreleased
+
+Improvements:
+
+* server: Allow setting `unhealthyPodEvictionPolicy` on the disruption budget
+
 ## 0.34.1 (August 13, 2026)
 
 Changes:

--- a/templates/server-disruptionbudget.yaml
+++ b/templates/server-disruptionbudget.yaml
@@ -21,6 +21,9 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
 spec:
   maxUnavailable: {{ template "vault.pdb.maxUnavailable" . }}
+  {{- with .Values.server.ha.disruptionBudget.unhealthyPodEvictionPolicy }}
+  unhealthyPodEvictionPolicy: {{ . }}
+  {{- end }}
   selector:
     matchLabels:
       app.kubernetes.io/name: {{ include "vault.name" . }}

--- a/test/unit/server-ha-disruptionbudget.bats
+++ b/test/unit/server-ha-disruptionbudget.bats
@@ -171,3 +171,24 @@ load _helpers
       yq '.spec.maxUnavailable' | tee /dev/stderr)
   [ "${actual}" = "2" ]
 }
+
+@test "server/DisruptionBudget: unhealthyPodEvictionPolicy is not set by default" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/server-disruptionbudget.yaml  \
+      --set 'server.ha.enabled=true' \
+      . | tee /dev/stderr |
+      yq '.spec.unhealthyPodEvictionPolicy' | tee /dev/stderr)
+  [ "${actual}" = "null" ]
+}
+
+@test "server/DisruptionBudget: unhealthyPodEvictionPolicy can be set" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/server-disruptionbudget.yaml  \
+      --set 'server.ha.enabled=true' \
+      --set 'server.ha.disruptionBudget.unhealthyPodEvictionPolicy=AlwaysAllow' \
+      . | tee /dev/stderr |
+      yq '.spec.unhealthyPodEvictionPolicy' | tee /dev/stderr)
+  [ "${actual}" = "\"AlwaysAllow\"" ]
+}

--- a/values.yaml
+++ b/values.yaml
@@ -1070,6 +1070,11 @@ server:
     # an override here.
       maxUnavailable: null
 
+    # unhealthyPodEvictionPolicy allows unhealthy pods to be evicted even when
+    # the disruption budget would otherwise be exceeded. Defaults to the
+    # Kubernetes default (IfHealthyBudget) when unset.
+      unhealthyPodEvictionPolicy: null
+
   # Definition of the serviceAccount used to run Vault.
   # These options are also used when using an external Vault server to validate
   # Kubernetes tokens.


### PR DESCRIPTION
## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [x] I have documented a clear reason for, and description of, the change I am making.

  Adds `server.ha.disruptionBudget.unhealthyPodEvictionPolicy`, rendered on the server PodDisruptionBudget via `with` so it's only emitted when set. Existing releases keep the Kubernetes default of `IfHealthyBudget`. Setting it to `AlwaysAllow` lets a not-Ready replica be evicted during a node drain instead of blocking it, per the [Kubernetes drain recommendation](https://kubernetes.io/docs/tasks/run-application/configure-pdb/#pdb-unhealthy-pod-eviction-policy). Added two bats unit tests covering the default (unset) and explicit-`AlwaysAllow` cases, and a CHANGELOG entry under Unreleased.

- [x] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

  Not applicable — reverting the pull request is sufficient, this is an additive, opt-in values field.

- [x] If applicable, I've documented the impact of any changes to security controls.

  Not applicable — no changes to access control, logging, or other security controls.
